### PR TITLE
DNM / Discussion: Fix for Bone Scaling

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/animation/node/animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/animation/node/animation_bone.py
@@ -63,7 +63,7 @@ class AnimationBone():
 
                                 mat = (parent_mat.to_quaternion() * delta.inverted() * transform.to_quaternion() * delta).to_matrix().to_4x4()
                                 mat = Matrix.Translation(parent_mat.to_translation() + ( parent_mat.to_quaternion() * delta.inverted() * transform.to_translation() )) * mat
-                                #TODO scaling of bones
+                                # Blender has no bone "scale" instead the visual scale is defined by the head and tail point
 
                         bone.location = self.animation.node.blender_bone_matrix.to_translation() - mat.to_translation()
                         bone.keyframe_insert(blender_path, frame = key[0] * fps, group='location')
@@ -89,7 +89,7 @@ class AnimationBone():
 
                                 mat = (parent_mat.to_quaternion() * delta.inverted() * transform.to_quaternion() * delta).to_matrix().to_4x4()
                                 mat = Matrix.Translation(parent_mat.to_translation() + ( parent_mat.to_quaternion() * delta.inverted() * transform.to_translation() )) * mat
-                                #TODO scaling of bones
+                                 # Blender has no bone "scale" instead the scale is defined by the start and end point
 
                         bone.rotation_quaternion = self.animation.node.blender_bone_matrix.to_quaternion().inverted() * mat.to_quaternion()
                         bone.keyframe_insert(blender_path, frame = key[0] * fps, group='rotation')
@@ -122,10 +122,9 @@ class AnimationBone():
 
                                 mat = (parent_mat.to_quaternion() * delta.inverted() * transform.to_quaternion() * delta).to_matrix().to_4x4()
                                 mat = Matrix.Translation(parent_mat.to_translation() + ( parent_mat.to_quaternion() * delta.inverted() * transform.to_translation() )) * mat
-                                #TODO scaling of bones
 
 
-                        #bone.scale # TODO
+                        #bone.scale  # Blender has no bone "scale" instead the scale is defined by the start and end point
                         bone.keyframe_insert(blender_path, frame = key[0] * fps, group='scale')
 
                     # Setting interpolation


### PR DESCRIPTION
This is a specific fix for the issue of bones being too tiny and not scaled correctly. 

DNM is for clarification and discussion on the subject and to double check conventions, and due to still incomplete fix: tested with Binary version of Celsius Man and Monster (which seems to be offset, separate issue). Will post an issue related to the Monster, later.. 

Not Perfect, as joint ends are most likely not upto spec (will look into just using the previous bone length in the future).

Bones in Blender inherently have no scale: instead they have a start point (head, or joint position) and an endpoint (tail, child point.). This is something to keep in mind when designing the nodes.

From what I understood, the idea is to put most of the correction logic into the Nodes. However we cannot rely on the information in them while the scene is building, as information comes in out of order.