### PR TITLE
Feature/import updates

### DIFF
--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
@@ -33,3 +33,10 @@ class Conversion():
     @staticmethod
     def quaternion_gltf_to_blender(q):
         return Quaternion([q[3], q[0], q[1], q[2]])
+
+    def scale_to_matrix(scale):
+        mat = Matrix()
+        for i in range(3):
+            mat[i][i] = scale[i]
+
+        return mat

--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_material_helpers.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_material_helpers.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-def get_pbr_node(node_tree):
-        pass
-
 def get_output_node(node_tree):
     output = [node for node in node_tree.nodes if node.type == 'OUTPUT_MATERIAL'][0]
     return output

--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_material_helpers.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_material_helpers.py
@@ -1,0 +1,54 @@
+# Copyright 2018 The glTF-Blender-IO authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def get_pbr_node(node_tree):
+        pass
+
+def get_output_node(node_tree):
+    output = [node for node in node_tree.nodes if node.type == 'OUTPUT_MATERIAL'][0]
+    return output
+
+def get_output_surface_input(node_tree):
+    output_node = get_output_node(node_tree)
+    return output_node.inputs['Surface']
+
+def get_diffuse_texture(node_tree):
+    for node in node_tree.nodes:
+        print(node.name)
+        if node.label == 'BASE COLOR':
+            return node
+
+    return None
+
+def get_preoutput_node_output(node_tree):
+    output_node = get_output_node(node_tree)
+    preoutput_node = output_node.inputs['Surface'].links[0].from_node
+
+    # Pre output node is Principled BSDF or any BSDF => BSDF
+    if 'BSDF' in preoutput_node.type:
+        return preoutput_node.outputs['BSDF']
+    elif 'SHADER' in preoutput_node.type:
+        return preoutput_node.outputs['Shader']
+    else:
+        print(preoutput_node.type)
+
+
+def get_base_color_node(node_tree):
+    """ returns the last node of the diffuse block """
+    for node in node_tree.nodes:
+        if node.label == 'BASE COLOR':
+            return node
+
+    return None

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -79,7 +79,7 @@ class BlenderBoneAnim():
         for idx, key in enumerate(keys):
             quat_keyframe = Conversion.quaternion_gltf_to_blender(values[idx])
             if not node.parent:
-                bone.scale =  bind_scale.inverted() * scale_mat
+                bone.rotation_quaternion =  bind_rotation.inverted() * quat_keyframe.to_matrix().to_4x4()
             else:
                 if not gltf.data.nodes[node.parent].is_joint: # TODO if Node in another scene
                     parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -49,7 +49,7 @@ class BlenderBoneAnim():
                 parent_mat = Matrix()
             else:
                 if not gltf.data.nodes[node.parent].is_joint: # TODO if Node in another scene
-                    parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
+                    parent_mat = Matrix()
                 else:
                     parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
 
@@ -79,10 +79,10 @@ class BlenderBoneAnim():
         for idx, key in enumerate(keys):
             quat_keyframe = Conversion.quaternion_gltf_to_blender(values[idx])
             if not node.parent:
-                bone.rotation_quaternion =  bind_rotation.inverted() * quat_keyframe.to_matrix().to_4x4()
+                bone.rotation_quaternion = bind_rotation.inverted() * quat_keyframe.to_matrix().to_4x4()
             else:
                 if not gltf.data.nodes[node.parent].is_joint: # TODO if Node in another scene
-                    parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
+                    parent_mat = Matrix()
                 else:
                     parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
 
@@ -113,7 +113,7 @@ class BlenderBoneAnim():
                 bone.scale =  bind_scale.inverted() * scale_mat
             else:
                 if not gltf.data.nodes[node.parent].is_joint: # TODO if Node in another scene
-                    parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
+                    parent_mat = Matrix()
                 else:
                     parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -34,6 +34,99 @@ class BlenderBoneAnim():
             kf.interpolation = 'BEZIER'
 
     @staticmethod
+    def parse_translation_channel(gltf, node, obj, bone, channel, animation):
+        fps = bpy.context.scene.render.fps
+        blender_path = "location"
+
+        keys   = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].input)
+        values = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].output)
+        inv_bind_matrix = node.blender_bone_matrix.to_quaternion().to_matrix().to_4x4().inverted() \
+                          * Matrix.Translation(node.blender_bone_matrix.to_translation()).inverted()
+
+        for idx, key in enumerate(keys):
+            translation_keyframe = Conversion.loc_gltf_to_blender(values[idx])
+            if not node.parent:
+                parent_mat = Matrix()
+            else:
+                if not gltf.data.nodes[node.parent].is_joint: # TODO if Node in another scene
+                    parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
+                else:
+                    parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
+
+            # Pose is in object (armature) space and it's value if the offset from the bind pose (which is also in object space)
+            # Scale is not taken into account
+            final_trans = (parent_mat * Matrix.Translation(translation_keyframe)).to_translation()
+            bone.location = inv_bind_matrix * final_trans
+            bone.keyframe_insert(blender_path, frame = key[0] * fps, group="location")
+
+        for fcurve in [curve for curve in obj.animation_data.action.fcurves if curve.group.name == "location"]:
+            for kf in fcurve.keyframe_points:
+                BlenderBoneAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
+
+    @staticmethod
+    def parse_rotation_channel(gltf, node, obj, bone, channel, animation):
+        # Note: some operations lead to issue with quaternions. Converting to matrix and then back to quaternions breaks quaternion continuity
+        # (see antipodal quaternions). Blender interpolates between two antipodal quaternions, which causes glitches in animation.
+        # Converting to euler and then back to quaternion is a dirty fix preventing this issue in animation, until a better solution is found
+        # This fix is skipped when parent matrix is identity
+        fps = bpy.context.scene.render.fps
+        blender_path = "rotation_quaternion"
+
+        keys   = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].input)
+        values = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].output)
+        bind_rotation = node.blender_bone_matrix.to_quaternion()
+
+        for idx, key in enumerate(keys):
+            quat_keyframe = Conversion.quaternion_gltf_to_blender(values[idx])
+            if not node.parent:
+                bone.scale =  bind_scale.inverted() * scale_mat
+            else:
+                if not gltf.data.nodes[node.parent].is_joint: # TODO if Node in another scene
+                    parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
+                else:
+                    parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
+
+                if parent_mat != parent_mat.inverted():
+                    final_rot = (parent_mat * quat_keyframe.to_matrix().to_4x4()).to_quaternion()
+                    bone.rotation_quaternion = bind_rotation.rotation_difference(final_rot).to_euler().to_quaternion()
+                else:
+                    bone.rotation_quaternion = bind_rotation.rotation_difference(quat_keyframe)
+
+            bone.keyframe_insert(blender_path, frame = key[0] * fps, group='rotation')
+
+        for fcurve in [curve for curve in obj.animation_data.action.fcurves if curve.group.name == "rotation"]:
+            for kf in fcurve.keyframe_points:
+                BlenderBoneAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
+
+    @staticmethod
+    def parse_scale_channel(gltf, node, obj, bone, channel, animation):
+        fps = bpy.context.scene.render.fps
+        blender_path = "scale"
+
+        keys   = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].input)
+        values = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].output)
+        bind_scale = Conversion.scale_to_matrix(node.blender_bone_matrix.to_scale())
+
+        for idx, key in enumerate(keys):
+            scale_mat = Conversion.scale_to_matrix(Conversion.loc_gltf_to_blender(values[idx]))
+            if not node.parent:
+                bone.scale =  bind_scale.inverted() * scale_mat
+            else:
+                if not gltf.data.nodes[node.parent].is_joint: # TODO if Node in another scene
+                    parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
+                else:
+                    parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
+
+                bone.scale = (bind_scale.inverted() * Conversion.scale_to_matrix(parent_mat.to_scale()) * scale_mat).to_scale()
+
+            bone.keyframe_insert(blender_path, frame = key[0] * fps, group='scale')
+
+        for fcurve in [curve for curve in obj.animation_data.action.fcurves if curve.group.name == "scale"]:
+            for kf in fcurve.keyframe_points:
+                BlenderBoneAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
+
+
+    @staticmethod
     def anim(gltf, anim_idx, node_idx):
         node  = gltf.data.nodes[node_idx]
         obj   = bpy.data.objects[gltf.data.skins[node.skin_id].blender_armature_name]
@@ -60,88 +153,11 @@ class BlenderBoneAnim():
         for channel_idx in node.animations[anim_idx]:
             channel = animation.channels[channel_idx]
 
-            keys   = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].input)
-            values = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].output)
-
             if channel.target.path == "translation":
-                blender_path = "location"
-                for idx, key in enumerate(keys):
-                    transform = Matrix.Translation(Conversion.loc_gltf_to_blender(list(values[idx])))
-                    if not node.parent:
-                        mat = transform
-                    else:
-                        if not gltf.data.nodes[node.parent].is_joint:
-                            parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
-                            mat = transform
-                        else:
-                            parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
-
-                            mat = (parent_mat.to_quaternion() * transform.to_quaternion()).to_matrix().to_4x4()
-                            mat = Matrix.Translation(parent_mat.to_translation() + ( parent_mat.to_quaternion() * transform.to_translation() )) * mat
-                            #TODO scaling of bones ?
-
-                    bone.location = node.blender_bone_matrix.inverted() * mat.to_translation()
-                    bone.keyframe_insert(blender_path, frame = key[0] * fps, group='location')
-
-
-                # Setting interpolation
-                for fcurve in [curve for curve in obj.animation_data.action.fcurves if curve.group.name == "location"]:
-                    for kf in fcurve.keyframe_points:
-                        BlenderBoneAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
-
+                BlenderBoneAnim.parse_translation_channel(gltf, node, obj, bone, channel, animation)
 
             elif channel.target.path == "rotation":
-                blender_path = "rotation_quaternion"
-                for idx, key in enumerate(keys):
-                    transform = Conversion.quaternion_gltf_to_blender(values[idx]).to_matrix().to_4x4()
-                    if not node.parent:
-                        mat = transform
-                    else:
-                        if not gltf.data.nodes[node.parent].is_joint:
-                            parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
-                            mat = transform
-                        else:
-                            parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
-
-                            mat = (parent_mat.to_quaternion() * transform.to_quaternion()).to_matrix().to_4x4()
-                            mat = Matrix.Translation(parent_mat.to_translation() + ( parent_mat.to_quaternion() * transform.to_translation() )) * mat
-                            #TODO scaling of bones ?
-
-                    bone.rotation_quaternion = node.blender_bone_matrix.to_quaternion().inverted() * mat.to_quaternion()
-                    bone.keyframe_insert(blender_path, frame = key[0] * fps, group='rotation')
-
-                # Setting interpolation
-                for fcurve in [curve for curve in obj.animation_data.action.fcurves if curve.group.name == "rotation"]:
-                    for kf in fcurve.keyframe_points:
-                        BlenderBoneAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
+                BlenderBoneAnim.parse_rotation_channel(gltf, node, obj, bone, channel, animation)
 
             elif channel.target.path == "scale":
-                blender_path = "scale"
-                for idx, key in enumerate(keys):
-                    s = Conversion.scale_gltf_to_blender(list(values[idx]))
-                    transform = Matrix([
-                        [s[0], 0, 0, 0],
-                        [0, s[1], 0, 0],
-                        [0, 0, s[2], 0],
-                        [0, 0, 0, 1]
-                    ])
-
-                    if not node.parent:
-                        mat = transform
-                    else:
-                        if not gltf.data.nodes[node.parent].is_joint:
-                            parent_mat = bpy.data.objects[gltf.data.nodes[node.parent].blender_object].matrix_world
-                            mat = transform
-                        else:
-                            parent_mat = gltf.data.nodes[node.parent].blender_bone_matrix
-                            mat = parent_mat.inverted() * transform
-
-
-                    #bone.scale # TODO
-                    bone.scale = mat.to_scale()
-                    bone.keyframe_insert(blender_path, frame = key[0] * fps, group='scale')
-
-                # Setting interpolation
-                for fcurve in [curve for curve in obj.animation_data.action.fcurves if curve.group.name == "scale"]:
-                    for kf in fcurve.keyframe_points:
-                        BlenderBoneAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
+                BlenderBoneAnim.parse_scale_channel(gltf, node, obj, bone, channel, animation)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
@@ -64,6 +64,8 @@ class BlenderGlTF():
                     if (parent.tail - parent.head).normalized().dot(save_parent_direction) < 0.9:
                         parent.tail = save_parent_tail
 
+        bpy.ops.object.mode_set(mode="OBJECT")
+
 
     @staticmethod
     def pre_compute(gltf):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
@@ -139,7 +139,10 @@ class BlenderGlTF():
 
             # skin management
             if node.skin is not None and node.mesh is not None:
-                gltf.data.skins[node.skin].node_id = node_idx
+                if not hasattr(gltf.data.skins[node.skin], "node_ids"):
+                    gltf.data.skins[node.skin].node_ids = []
+
+                gltf.data.skins[node.skin].node_ids.append(node_idx)
 
             # transform management
             if node.matrix:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
@@ -64,7 +64,7 @@ class BlenderGlTF():
                     if (parent.tail - parent.head).normalized().dot(save_parent_direction) < 0.9:
                         parent.tail = save_parent_tail
 
-        bpy.ops.object.mode_set(mode="OBJECT")
+            bpy.ops.object.mode_set(mode="OBJECT")
 
 
     @staticmethod

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
@@ -94,13 +94,13 @@ class BlenderGlTF():
                     else:
                         material.pbr_metallic_roughness.base_color_factor = [1.0,1.0,1.0,1.0]
 
-                    if material.pbr_metallic_roughness.metallic_factor:
+                    if material.pbr_metallic_roughness.metallic_factor is not None:
                         if material.pbr_metallic_roughness.metallic_type == gltf.TEXTURE and material.pbr_metallic_roughness.metallic_factor != 1.0:
                             material.pbr_metallic_roughness.metallic_type = gltf.TEXTURE_FACTOR
                     else:
                         material.pbr_metallic_roughness.metallic_factor = 1.0
 
-                    if material.pbr_metallic_roughness.roughness_factor:
+                    if material.pbr_metallic_roughness.roughness_factor is not None:
                         if material.pbr_metallic_roughness.metallic_type == gltf.TEXTURE and material.pbr_metallic_roughness.roughness_factor != 1.0:
                             material.pbr_metallic_roughness.metallic_type = gltf.TEXTURE_FACTOR
                     else:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_map_emissive.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_map_emissive.py
@@ -14,6 +14,7 @@
 
 import bpy
 from .gltf2_blender_texture import *
+from ..com.gltf2_blender_material_helpers import *
 
 class BlenderEmissiveMap():
 
@@ -35,12 +36,7 @@ class BlenderEmissiveMap():
         BlenderTextureInfo.create(gltf, pymaterial.emissive_texture.index)
 
         # retrieve principled node and output node
-        if len([node for node in node_tree.nodes if node.type == "BSDF_PRINCIPLED"]) != 0:
-            fix = [node for node in node_tree.nodes if node.type == "BSDF_PRINCIPLED"][0]
-        else:
-            # No principled, we are coming from an extenstion, probably
-            fix = [node for node in node_tree.nodes if node.type == "MIX_SHADER"][0]
-
+        principled = get_preoutput_node_output(node_tree)
         output = [node for node in node_tree.nodes if node.type == 'OUTPUT_MATERIAL'][0]
 
         # add nodes
@@ -62,6 +58,7 @@ class BlenderEmissiveMap():
 
         text  = node_tree.nodes.new('ShaderNodeTexImage')
         text.image = bpy.data.images[gltf.data.images[gltf.data.textures[pymaterial.emissive_texture.index].source].blender_image_name]
+        text.label = 'EMISSIVE'
         text.location = -1000,1000
         add = node_tree.nodes.new('ShaderNodeAddShader')
         add.location = 500,500
@@ -99,5 +96,5 @@ class BlenderEmissiveMap():
 
         # following  links will modify PBR node tree
         node_tree.links.new(add.inputs[0], emit.outputs[0])
-        node_tree.links.new(add.inputs[1], fix.outputs[0])
+        node_tree.links.new(add.inputs[1], principled)
         node_tree.links.new(output.inputs[0], add.outputs[0])

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_map_normal.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_map_normal.py
@@ -57,6 +57,7 @@ class BlenderNormalMap():
 
         text  = node_tree.nodes.new('ShaderNodeTexImage')
         text.image = bpy.data.images[gltf.data.images[gltf.data.textures[pymaterial.normal_texture.index].source].blender_image_name]
+        text.label = 'NORMALMAP'
         text.color_space = 'NONE'
         text.location = -500, -500
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
@@ -18,6 +18,7 @@ from .gltf2_blender_KHR_materials_pbrSpecularGlossiness import *
 from .gltf2_blender_map_emissive import *
 from .gltf2_blender_map_normal import *
 from .gltf2_blender_map_occlusion import *
+from ..com.gltf2_blender_material_helpers import *
 
 class BlenderMaterial():
 
@@ -53,6 +54,9 @@ class BlenderMaterial():
         if pymaterial.occlusion_texture is not None:
             BlenderOcclusionMap.create(gltf, material_idx)
 
+        if pymaterial.alpha_mode != None and pymaterial.alpha_mode != 'OPAQUE':
+            BlenderMaterial.blender_alpha(gltf, material_idx)
+
     @staticmethod
     def set_uvmap(gltf, material_idx, prim, obj):
         pymaterial = gltf.data.materials[material_idx]
@@ -62,3 +66,63 @@ class BlenderMaterial():
         for uvmap_node in uvmap_nodes:
             if uvmap_node["gltf2_texcoord"] in prim.blender_texcoord.keys():
                 uvmap_node.uv_map = prim.blender_texcoord[uvmap_node["gltf2_texcoord"]]
+
+    @staticmethod
+    def blender_alpha(gltf, material_idx):
+        pymaterial = gltf.data.materials[material_idx]
+        material = bpy.data.materials[pymaterial.blender_material]
+
+        node_tree = material.node_tree
+         # Add nodes for basic transparency
+        # Add mix shader between output and Principled BSDF
+        trans = node_tree.nodes.new('ShaderNodeBsdfTransparent')
+        trans.location = 750, -500
+        mix = node_tree.nodes.new('ShaderNodeMixShader')
+        mix.location = 1000, 0
+
+        output_surface_input = get_output_surface_input(node_tree)
+        preoutput_node_output = get_preoutput_node_output(node_tree)
+        pre_output_node = output_surface_input.links[0].from_node
+
+        link = output_surface_input.links[0]
+        node_tree.links.remove(link)
+
+         # PBR => Mix input 1
+        node_tree.links.new(preoutput_node_output, mix.inputs[1])
+
+         # Trans => Mix input 2
+        node_tree.links.new(trans.outputs['BSDF'], mix.inputs[2])
+
+         # Mix => Output
+        node_tree.links.new(mix.outputs['Shader'], output_surface_input)
+
+         # alpha blend factor
+        add = node_tree.nodes.new('ShaderNodeMath')
+        add.operation = 'ADD'
+        add.location = 750, -250
+
+        diffuse_factor = 1.0
+        if pymaterial.extensions is not None and 'KHR_materials_pbrSpecularGlossiness' in pymaterial.extensions:
+            diffuse_factor = pymaterial.extensions['KHR_materials_pbrSpecularGlossiness']['diffuseFactor'][3]
+        elif pymaterial.pbr_metallic_roughness:
+            diffuse_factor = pymaterial.pbr_metallic_roughness.base_color_factor[3]
+
+        add.inputs[0].default_value = abs(1.0 - diffuse_factor)
+        add.inputs[1].default_value = 0.0
+        node_tree.links.new(add.outputs['Value'], mix.inputs[0])
+
+         # Take diffuse texture alpha into account if any
+        diffuse_texture = get_base_color_node(node_tree)
+        if diffuse_texture:
+            inverter = node_tree.nodes.new('ShaderNodeInvert')
+            inverter.location = 250, -250
+            inverter.inputs[1].default_value = (1.0, 1.0, 1.0, 1.0)
+            node_tree.links.new(diffuse_texture.outputs['Alpha'], inverter.inputs[0])
+
+            mult = node_tree.nodes.new('ShaderNodeMath')
+            mult.operation = 'MULTIPLY' if pymaterial.alpha_mode == 'BLEND' else 'GREATER_THAN'
+            mult.location = 500, -250
+            alpha_cutoff = 1.0 if pymaterial.alpha_mode == 'BLEND' else 1.0 - pymaterial.alpha_cutoff if pymaterial.alpha_cutoff is not None else 0.5
+            mult.inputs[1].default_value = alpha_cutoff
+            node_tree.links.new(inverter.outputs['Color'], mult.inputs[0])
+            node_tree.links.new(mult.outputs['Value'], add.inputs[0])

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -139,7 +139,18 @@ class BlenderNode():
                     obj.select = True
                     bpy.data.objects[node.blender_armature_name].select = True
                     bpy.context.scene.objects.active = bpy.data.objects[node.blender_armature_name]
-                    bpy.ops.object.parent_set(type='BONE', keep_transform=True)
+                    bpy.context.scene.update()
+                    bpy.ops.object.parent_set(type='BONE_RELATIVE', keep_transform=True)
+                    # From world transform to local (-armature transform -bone transform)
+                    bone_trans = bpy.data.objects[node.blender_armature_name].pose.bones[node.blender_bone_name].matrix.to_translation().copy()
+                    bone_rot = bpy.data.objects[node.blender_armature_name].pose.bones[node.blender_bone_name].matrix.to_quaternion().copy()
+                    bone_scale_mat = Conversion.scale_to_matrix(node.blender_bone_matrix.to_scale())
+                    obj.location = bone_scale_mat * obj.location
+                    obj.location = bone_rot * obj.location
+                    obj.location += bone_trans
+                    obj.location = bpy.data.objects[node.blender_armature_name].matrix_world.to_quaternion() * obj.location
+                    obj.rotation_quaternion = obj.rotation_quaternion * bpy.data.objects[node.blender_armature_name].matrix_world.to_quaternion()
+                    obj.scale = bone_scale_mat * obj.scale
 
                     return
                 if node.blender_object:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -40,7 +40,7 @@ class BlenderPbr():
                 node_tree.nodes.remove(node)
 
         output_node = node_tree.nodes[0]
-        output_node.location = 1000,0
+        output_node.location = 1250,0
 
         # create PBR node
         principled = node_tree.nodes.new('ShaderNodeBsdfPrincipled')
@@ -91,6 +91,7 @@ class BlenderPbr():
             # create UV Map / Mapping / Texture nodes / separate & math and combine
             text_node = node_tree.nodes.new('ShaderNodeTexImage')
             text_node.image = bpy.data.images[gltf.data.images[gltf.data.textures[pypbr.base_color_texture.index].source].blender_image_name]
+            text_node.label = 'BASE COLOR'
             text_node.location = -1000,500
 
             combine = node_tree.nodes.new('ShaderNodeCombineRGB')
@@ -191,6 +192,7 @@ class BlenderPbr():
             # create UV Map / Mapping / Texture nodes / separate & math and combine
             text_node = node_tree.nodes.new('ShaderNodeTexImage')
             text_node.image = bpy.data.images[gltf.data.images[gltf.data.textures[pypbr.base_color_texture.index].source].blender_image_name]
+            text_node.label = 'BASE COLOR'
             if vertex_color:
                 text_node.location = -2000,500
             else:
@@ -252,6 +254,7 @@ class BlenderPbr():
             metallic_text = node_tree.nodes.new('ShaderNodeTexImage')
             metallic_text.image = bpy.data.images[gltf.data.images[gltf.data.textures[pypbr.metallic_roughness_texture.index].source].blender_image_name]
             metallic_text.color_space = 'NONE'
+            metallic_text.label = 'METALLIC ROUGHNESS'
             metallic_text.location = -500,0
 
             metallic_separate = node_tree.nodes.new('ShaderNodeSeparateRGB')
@@ -278,10 +281,10 @@ class BlenderPbr():
         elif pypbr.metallic_type == gltf.TEXTURE_FACTOR:
 
             BlenderTextureInfo.create(gltf, pypbr.metallic_roughness_texture.index)
-
             metallic_text = node_tree.nodes.new('ShaderNodeTexImage')
             metallic_text.image = bpy.data.images[gltf.data.images[gltf.data.textures[pypbr.metallic_roughness_texture.index].source].blender_image_name]
             metallic_text.color_space = 'NONE'
+            metallic_text.label = 'METALLIC ROUGHNESS'
             metallic_text.location = -1000,0
 
             metallic_separate = node_tree.nodes.new('ShaderNodeSeparateRGB')

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -65,7 +65,12 @@ class BlenderPbr():
                 principled.inputs[7].default_value = pypbr.roughness_factor
 
                 # links
-                node_tree.links.new(principled.inputs[0], attribute_node.outputs[1])
+                rgb_node = node_tree.nodes.new('ShaderNodeMixRGB')
+                rgb_node.blend_type = 'MULTIPLY'
+                rgb_node.inputs['Fac'].default_value = 1.0
+                rgb_node.inputs['Color1'].default_value = pypbr.base_color_factor
+                node_tree.links.new(rgb_node.inputs['Color2'], attribute_node.outputs[0])
+                node_tree.links.new(principled.inputs[0], rgb_node.outputs[0])
 
         elif pypbr.color_type == gltf.TEXTURE_FACTOR:
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -277,7 +277,7 @@ class BlenderPbr():
 
         elif pypbr.metallic_type == gltf.TEXTURE_FACTOR:
 
-            BlenderTextureInfo.create(pypbr.metallic_roughness_texture.index)
+            BlenderTextureInfo.create(gltf, pypbr.metallic_roughness_texture.index)
 
             metallic_text = node_tree.nodes.new('ShaderNodeTexImage')
             metallic_text.image = bpy.data.images[gltf.data.images[gltf.data.textures[pypbr.metallic_roughness_texture.index].source].blender_image_name]

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -52,13 +52,16 @@ class BlenderScene():
         # Now that all mesh / bones are created, create vertex groups on mesh
         if gltf.data.skins:
             for skin_id, skin in enumerate(gltf.data.skins):
-                BlenderSkin.create_vertex_groups(gltf, skin_id)
+                if hasattr(skin, "node_ids"):
+                    BlenderSkin.create_vertex_groups(gltf, skin_id)
 
             for skin_id, skin in enumerate(gltf.data.skins):
-                BlenderSkin.assign_vertex_groups(gltf, skin_id)
+                if hasattr(skin, "node_ids"):
+                    BlenderSkin.assign_vertex_groups(gltf, skin_id)
 
             for skin_id, skin in enumerate(gltf.data.skins):
-                BlenderSkin.create_armature_modifiers(gltf, skin_id)
+                if hasattr(skin, "node_ids"):
+                    BlenderSkin.create_armature_modifiers(gltf, skin_id)
 
         if gltf.data.animations:
             for anim_idx, anim in enumerate(gltf.data.animations):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_skin.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_skin.py
@@ -163,7 +163,7 @@ class BlenderSkin():
                     gltf.log.error("No Skinning ?????") #TODO
 
 
-            offset = offset + prim.vertices_length
+                offset = offset + prim.vertices_length
 
     @staticmethod
     def create_armature_modifiers(gltf, skin_id):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_skin.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_skin.py
@@ -186,6 +186,8 @@ class BlenderSkin():
             bpy.context.scene.objects.active = obj
 
             #bpy.ops.object.parent_clear(type='CLEAR_KEEP_TRANSFORM')
-            #obj.parent = bpy.data.objects[pyskin.blender_armature_name]
+            # Reparent skinned mesh to it's armature to avoid breaking
+            # skinning with interleaved transforms
+            obj.parent = bpy.data.objects[pyskin.blender_armature_name]
             arma = obj.modifiers.new(name="Armature", type="ARMATURE")
             arma.object = bpy.data.objects[pyskin.blender_armature_name]


### PR DESCRIPTION
Hi, 

This PR contains a bunch of fixes and improvements of glTF import code for skinning animation and materials.
The code has been tested with various animated models downloaded from [Sketchfab](https://sketchfab.com/models?features=downloadable+staffpicked&sort_by=-likeCount) and is now used in our [plugin](https://github.com/sketchfab/glTF-Blender-IO/releases/latest)

**Materials**
 - import transparency
 - a few minor fixes

**Skinning animation should now work when** (sould cover most "edge cases")
- rest and pose transforms that are different
- scales in animation, inverse bind matrices etc
- skin shared by several meshes
- nodes attached to animated bones (with scales/ non trivial transforms) 

It also includes a "ducktape" fix for quaternion interpolation discontinuities. If you have a better fix in mind, please let me know.

**Note**
Skins with bones spread across distinct node trees is still not supported (as technical constraints avoid uss to have such structure in Sketchfab exported assets).

**Some samples used to test**
[Junkrat by Claudia Luehl](https://sketchfab.com/models/7deb2dd552df4bf4bb65005018176647)
[Zophrac by branx](https://sketchfab.com/models/9fea6ffd67b840cb970f5b4570794709) (skin + morph)
[Cuphead - Hilda Berg Boss Fight by Morganicism](https://sketchfab.com/models/2891149bbd734b05a20457ef609aa9e3)
[Hanu by Nathan Wondrak](https://sketchfab.com/models/11202d39304d4fdca47750c5870d6dd7)
[Fnake Drunk Walking](https://sketchfab.com/models/9fe240e9894145449ec548c2c468f61b) (this one had a LOT of quaternion interpolation issues)

Also, if it can help, we also have a [branch with a working version for Blender 2.8](https://github.com/sketchfab/glTF-Blender-IO/pull/3) (in case you're interested by the required updates)

