### PR TITLE
Fixes quaternion discontinuity in bone animation

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -104,7 +104,7 @@ class BlenderBoneAnim():
                         final_rot = (parent_mat @ quat_keyframe.to_matrix().to_4x4()).to_quaternion()
                     bone.rotation_quaternion = bind_rotation.rotation_difference(final_rot).to_euler().to_quaternion()
                 else:
-                    bone.rotation_quaternion = bind_rotation.rotation_difference(quat_keyframe)
+                    bone.rotation_quaternion = bind_rotation.rotation_difference(quat_keyframe).to_euler().to_quaternion()
 
             bone.keyframe_insert(blender_path, frame = key[0] * fps, group='rotation')
 


### PR DESCRIPTION
Operations applied to bone quaternion keyframes (to change the space or compute pose/bind) introduce quaternion discontinuities which breaks the interpolations and introduces glitches in animation.

The fix is quite dirty and consists of converting final quaternion to euler and then back to quaternion. It was applied when matrix computations were involved, but it seems that it happens with quaternion operations as well.

This PR extends the fix for quaternion operations.

Sample to reproduce the issue: https://sketchfab.com/models/7b00f231aa82442fbd27ab8c0c234d01
and take a look at the two small rocks at the beginning of the animation.