### PR TITLE
Rename extension options.

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -258,19 +258,19 @@ class ExportGLTF2_Base:
     )
 
     export_lights = BoolProperty(
-        name='Export KHR_lights_punctual',
+        name='Export punctual lights',
         description='',
         default=False
     )
 
     export_texture_transform = BoolProperty(
-        name='Export KHR_texture_transform',
+        name='Export texture transforms',
         description='',
         default=False
     )
 
     export_displacement = BoolProperty(
-        name='Export KHR_materials_displacement',
+        name='Export displacement',
         description='',
         default=False
     )


### PR DESCRIPTION
I think it may be better to name these options for what they do, rather than the extension name.

/cc @emackey 