### PR TITLE
Bugfix: #114 directional light wrong direction

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_light_spots.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_light_spots.py
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bpy
-from typing import Optional, List, Any
-
-from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
-
+from typing import Optional
 from io_scene_gltf2.io.com import gltf2_io_lights_punctual
-from io_scene_gltf2.io.com import gltf2_io_debug
 
 
 def gather_light_spot(blender_lamp, export_settings) -> Optional[gltf2_io_lights_punctual.LightSpot]:

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
@@ -24,6 +24,7 @@ from io_scene_gltf2.io.com import gltf2_io_debug
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_light_spots
 from io_scene_gltf2.blender.exp import gltf2_blender_search_node_tree
 
+
 @cached
 def gather_lights_punctual(blender_lamp, export_settings) -> Optional[Dict[str, Any]]:
     if not __filter_lights_punctual(blender_lamp, export_settings):


### PR DESCRIPTION
resolves the invalid light and camera direction mentioned in #114 by adding an orientation correction node [(that was also in place in the original exporter)](https://github.com/KhronosGroup/glTF-Blender-Exporter/blob/master/scripts/addons/io_scene_gltf2/gltf2_generate.py#L1670)