### PR TITLE
Remove "until this project is ready..." in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Version
 
 Beta
 
-Until this project is ready, please use the separate [export](https://github.com/KhronosGroup/glTF-Blender-Exporter) and [import](https://github.com/julienduroure/gltf2-blender-importer) addons.
-
 Credits
 -------
 


### PR DESCRIPTION
Besides the fact that we're shipping in 2.8, both of the projects linked to are now pointing back to this project.