### PR TITLE
Catch wrong Property type when loading settings.

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -272,7 +272,7 @@ class ExportGLTF2_Base:
                     setattr(self, k, v)
                 self.will_save_settings = True
 
-            except AttributeError:
+            except (AttributeError, TypeError):
                 self.report({"ERROR"}, "Loading export settings failed. Removed corrupted settings")
                 del context.scene[self.scene_key]
 


### PR DESCRIPTION
I'm not sure how it happened but I think a setting saved in my blender file was of the incorrect type for it's associated Property. I had to make this change to be able to export again.

It seems fairly inconspicuous to me, but I would understand if you'd refuse the patch without a test case or example blend file (as mine no longer has the culprit setting saved).