### PR TITLE
Ignore non-deforming vertex weights when exporting from Blender

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -667,7 +667,7 @@ def extract_primitives(glTF, blender_mesh, blender_vertex_groups, modifiers, exp
 
                     #
 
-                    joint_index = 0
+                    joint_index = None
 
                     if modifiers is not None:
                         modifiers_dict = {m.type: m for m in modifiers}
@@ -681,8 +681,9 @@ def extract_primitives(glTF, blender_mesh, blender_vertex_groups, modifiers, exp
                     joint_weight = group_element.weight
 
                     #
-                    joint.append(joint_index)
-                    weight.append(joint_weight)
+                    if joint_weight > 0.0 and joint_index is not None:
+                        joint.append(joint_index)
+                        weight.append(joint_weight)
 
                 if len(joint) > 0:
                     bone_count += 1

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -662,10 +662,14 @@ def extract_primitives(glTF, blender_mesh, blender_vertex_groups, modifiers, exp
 
                     #
 
-                    vertex_group_index = group_element.group
-                    vertex_group_name = blender_vertex_groups[vertex_group_index].name
+                    joint_weight = group_element.weight
+                    if joint_weight <= 0.0:
+                        continue
 
                     #
+
+                    vertex_group_index = group_element.group
+                    vertex_group_name = blender_vertex_groups[vertex_group_index].name
 
                     joint_index = None
 
@@ -677,11 +681,10 @@ def extract_primitives(glTF, blender_mesh, blender_vertex_groups, modifiers, exp
                             for index, j in enumerate(skin.joints):
                                 if j.name == vertex_group_name:
                                     joint_index = index
-
-                    joint_weight = group_element.weight
+                                    break
 
                     #
-                    if joint_weight > 0.0 and joint_index is not None:
+                    if joint_index is not None:
                         joint.append(joint_index)
                         weight.append(joint_weight)
 


### PR DESCRIPTION
* Fixed an issue where weight was added to joint 0 when the bone doesn't exist in armature (the case for non-deforming vertex groups)
* Don't add joint weight to vertex if weight is zero

Was trying a Blender 2.80->gltf2->Godot workflow, but some vertices behaved funny in Godot. This fixed the look in Godot