### PR TITLE
faster export

### DIFF
--- a/addons/io_scene_gltf2/io/exp/gltf2_io_image_data.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_image_data.py
@@ -132,5 +132,5 @@ class ImageData:
         return b"".join([
             b'\x89PNG\r\n\x1a\n',
             png_pack(b'IHDR', struct.pack("!2I5B", self.width, self.height, 8, 6, 0, 0, 0)),
-            png_pack(b'IDAT', zlib.compress(raw_data, 9)),
+            png_pack(b'IDAT', zlib.compress(raw_data)),
             png_pack(b'IEND', b'')])


### PR DESCRIPTION
This seems to resolve the biggest chunk of #203

WaterBottle export comparison (same machine of course):

Branch | Export Time | Exported Bytes
--- | --- | ---
master | 93 s | 6,682,716
faster-export | 15 s | 7,061,076
**Diff** | -83.87 % | 5.35 %