### PR TITLE
Implement KHR_materials_unlit export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -16,6 +16,7 @@ import bpy
 
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from io_scene_gltf2.io.com import gltf2_io
+from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture_info
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_material_normal_texture_info_class
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_material_occlusion_texture_info_class
@@ -121,7 +122,10 @@ def __gather_extensions(blender_material, export_settings):
 
     if bpy.app.version < (2, 80, 0):
         if blender_material.use_shadeless:
-            extensions["KHR_materials_unlit"] = {}
+            extensions["KHR_materials_unlit"] = Extension("KHR_materials_unlit", {}, False)
+    else:
+        if gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Background") is not None:
+            extensions["KHR_materials_unlit"] = Extension("KHR_materials_unlit", {}, False)
 
     # TODO specular glossiness extension
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
@@ -48,6 +48,8 @@ def __gather_base_color_factor(blender_material, export_settings):
         base_color_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "BaseColor")
     if base_color_socket is None:
         base_color_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "BaseColorFactor")
+    if base_color_socket is None:
+        base_color_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Background")
     if isinstance(base_color_socket, bpy.types.NodeSocket) and not base_color_socket.is_linked:
         return list(base_color_socket.default_value)
     return None
@@ -58,6 +60,8 @@ def __gather_base_color_texture(blender_material, export_settings):
         base_color_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "BaseColor")
     if base_color_socket is None:
         base_color_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "BaseColor")
+    if base_color_socket is None:
+        base_color_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Background")
     return gltf2_blender_gather_texture_info.gather_texture_info((base_color_socket,), export_settings)
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -48,6 +48,9 @@ def get_socket_or_texture_slot(blender_material: bpy.types.Material, name: str):
         if name == "Emissive":
             type = bpy.types.ShaderNodeEmission
             name = "Color"
+        elif name == "Background":
+            type = bpy.types.ShaderNodeBackground
+            name = "Color"
         else:
             type = bpy.types.ShaderNodeBsdfPrincipled
         nodes = [n for n in blender_material.node_tree.nodes if isinstance(n, type)]

--- a/docs/io_gltf2.rst
+++ b/docs/io_gltf2.rst
@@ -57,7 +57,7 @@ Supports Metal/Rough PBR (Principled BSDF) and Spec/Gloss PBR.
 Export
 ^^^^^^
 
-Supports Metal/Rough PBR (Principled BSDF) materials.
+Supports Metal/Rough PBR (Principled BSDF) and Shadeless (Unlit) materials.
 
 .. note::
 
@@ -72,7 +72,7 @@ Supports Metal/Rough PBR (Principled BSDF) materials.
 
 .. note::
 
-  Support for Shadeless (Unlit) materials is in progress.
+  To create Shadeless (Unlit) materials, use the Background material type.
 
 Complex nodes cannot be exported. For best results when using nodes, prefer
 the following structure:


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/glTF-Blender-IO/issues/83.

I ended up using the *Background* material type, rather than *Emissive*, for a couple reasons:

- By default emissive materials emit light in the scene, which is very much not the intent of `KHR_materials_unlit`.
- The way to disable that emission, via *Light Path* nodes, is functional but not especially obvious.
- Having the Emissive node sometimes become an actual emissive, and other times base color, may complicate both code and documentation.
- The *Background* node type seems to fill the right role without any expectation of emission. https://blender.stackexchange.com/questions/8923/how-do-you-use-an-image-as-the-world-background

