### PR TITLE
Importer: Manage KHR_materials_unlit

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_unlit.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_unlit.py
@@ -1,0 +1,50 @@
+# Copyright 2018 The glTF-Blender-IO authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import bpy
+from .gltf2_blender_texture import BlenderTextureInfo
+from ...io.com.gltf2_io import MaterialPBRMetallicRoughness
+from .gltf2_blender_pbrMetallicRoughness import BlenderPbr
+
+class BlenderKHR_materials_unlit():
+    """Blender KHR_materials_unlit extension."""
+    def __new__(cls, *args, **kwargs):
+        raise RuntimeError("%s should not be instantiated" % cls)
+
+    @staticmethod
+    def create(gltf, material_index, unlit, mat_name, vertex_color):
+        """KHR_materials_unlit creation."""
+        engine = bpy.context.scene.render.engine
+        if engine in ['CYCLES', 'BLENDER_EEVEE']:
+            BlenderKHR_materials_unlit.create_nodetree(gltf, material_index, unlit, mat_name, vertex_color)
+
+    @staticmethod
+    def create_nodetree(gltf, material_index, unlit, mat_name, vertex_color):
+        """Node tree creation."""
+        material = bpy.data.materials[mat_name]
+        material.use_nodes = True
+        node_tree = material.node_tree
+
+        pymaterial = gltf.data.materials[material_index]
+        if pymaterial.pbr_metallic_roughness is None:
+            # If no pbr material is set, we need to apply all default of pbr
+            pbr = {}
+            pbr["baseColorFactor"] = [1.0, 1.0, 1.0, 1.0]
+            pbr["metallicFactor"] = 1.0
+            pbr["roughnessFactor"] = 1.0
+            pymaterial.pbr_metallic_roughness = MaterialPBRMetallicRoughness.from_dict(pbr)
+            pymaterial.pbr_metallic_roughness.color_type = gltf.SIMPLE
+            pymaterial.pbr_metallic_roughness.metallic_type = gltf.SIMPLE
+
+        BlenderPbr.create_nodetree(gltf, pymaterial.pbr_metallic_roughness, mat_name, vertex_color, nodetype='unlit')

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
@@ -15,6 +15,7 @@
 import bpy
 from .gltf2_blender_pbrMetallicRoughness import BlenderPbr
 from .gltf2_blender_KHR_materials_pbrSpecularGlossiness import BlenderKHR_materials_pbrSpecularGlossiness
+from .gltf2_blender_KHR_materials_unlit import BlenderKHR_materials_unlit
 from .gltf2_blender_map_emissive import BlenderEmissiveMap
 from .gltf2_blender_map_normal import BlenderNormalMap
 from .gltf2_blender_map_occlusion import BlenderOcclusionMap
@@ -48,10 +49,21 @@ class BlenderMaterial():
         mat = bpy.data.materials.new(name)
         pymaterial.blender_material[vertex_color] = mat.name
 
-        if pymaterial.extensions is not None and 'KHR_materials_pbrSpecularGlossiness' in pymaterial.extensions.keys():
-            BlenderKHR_materials_pbrSpecularGlossiness.create(
-                gltf, pymaterial.extensions['KHR_materials_pbrSpecularGlossiness'], mat.name, vertex_color
-            )
+        ignore_map = False
+
+        if pymaterial.extensions is not None :
+            if 'KHR_materials_unlit' in pymaterial.extensions.keys():
+                ignore_map = True
+                BlenderKHR_materials_unlit.create(
+                    gltf, material_idx,
+                    pymaterial.extensions['KHR_materials_unlit'],
+                    mat.name,
+                    vertex_color
+                )
+            elif 'KHR_materials_pbrSpecularGlossiness' in pymaterial.extensions.keys():
+                BlenderKHR_materials_pbrSpecularGlossiness.create(
+                    gltf, pymaterial.extensions['KHR_materials_pbrSpecularGlossiness'], mat.name, vertex_color
+                )
         else:
             # create pbr material
             if pymaterial.pbr_metallic_roughness is None:
@@ -66,21 +78,22 @@ class BlenderMaterial():
 
             BlenderPbr.create(gltf, pymaterial.pbr_metallic_roughness, mat.name, vertex_color)
 
-        # add emission map if needed
-        if pymaterial.emissive_texture is not None:
-            BlenderEmissiveMap.create(gltf, material_idx, vertex_color)
+        if ignore_map == False:
+            # add emission map if needed
+            if pymaterial.emissive_texture is not None:
+                BlenderEmissiveMap.create(gltf, material_idx, vertex_color)
 
-        # add normal map if needed
-        if pymaterial.normal_texture is not None:
-            BlenderNormalMap.create(gltf, material_idx, vertex_color)
+            # add normal map if needed
+            if pymaterial.normal_texture is not None:
+                BlenderNormalMap.create(gltf, material_idx, vertex_color)
 
-        # add occlusion map if needed
-        # will be pack, but not used
-        if pymaterial.occlusion_texture is not None:
-            BlenderOcclusionMap.create(gltf, material_idx, vertex_color)
+            # add occlusion map if needed
+            # will be pack, but not used
+            if pymaterial.occlusion_texture is not None:
+                BlenderOcclusionMap.create(gltf, material_idx, vertex_color)
 
-        if pymaterial.alpha_mode is not None and pymaterial.alpha_mode != 'OPAQUE':
-            BlenderMaterial.blender_alpha(gltf, material_idx, vertex_color)
+            if pymaterial.alpha_mode is not None and pymaterial.alpha_mode != 'OPAQUE':
+                BlenderMaterial.blender_alpha(gltf, material_idx, vertex_color)
 
     @staticmethod
     def set_uvmap(gltf, material_idx, prim, obj, vertex_color):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
@@ -92,8 +92,8 @@ class BlenderMaterial():
             if pymaterial.occlusion_texture is not None:
                 BlenderOcclusionMap.create(gltf, material_idx, vertex_color)
 
-        if pymaterial.alpha_mode is not None and pymaterial.alpha_mode != 'OPAQUE':
-            BlenderMaterial.blender_alpha(gltf, material_idx, vertex_color, pymaterial.alpha_mode)
+            if pymaterial.alpha_mode is not None and pymaterial.alpha_mode != 'OPAQUE':
+                BlenderMaterial.blender_alpha(gltf, material_idx, vertex_color, pymaterial.alpha_mode)
 
     @staticmethod
     def set_uvmap(gltf, material_idx, prim, obj, vertex_color):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -209,7 +209,6 @@ class BlenderPbr():
             node_tree.links.new(mapping.inputs[0], uvmap.outputs[0])
             node_tree.links.new(text_node.inputs[0], mapping.outputs[0])
 
-<<<<<<< HEAD
         if nodetype == 'principled':
             # Says metallic, but it means metallic & Roughness values
             if pypbr.metallic_type == gltf.SIMPLE:
@@ -282,85 +281,6 @@ class BlenderPbr():
                     metallic_uvmap["gltf2_texcoord"] = pypbr.metallic_roughness_texture.tex_coord
                 else:
                     metallic_uvmap["gltf2_texcoord"] = 0  # TODO set in pre_compute instead of here
-=======
-        # Says metallic, but it means metallic & Roughness values
-        if pypbr.metallic_type == gltf.SIMPLE:
-            principled.inputs[4].default_value = pypbr.metallic_factor
-            principled.inputs[7].default_value = pypbr.roughness_factor
-
-        elif pypbr.metallic_type == gltf.TEXTURE:
-            BlenderTextureInfo.create(gltf, pypbr.metallic_roughness_texture.index)
-            metallic_text = node_tree.nodes.new('ShaderNodeTexImage')
-            if gltf.data.images[
-                gltf.data.textures[pypbr.metallic_roughness_texture.index].source
-            ].blender_image_name is not None:
-                metallic_text.image = bpy.data.images[gltf.data.images[
-                    gltf.data.textures[pypbr.metallic_roughness_texture.index].source
-                ].blender_image_name]
-            metallic_text.color_space = 'NONE'
-            metallic_text.label = 'METALLIC ROUGHNESS'
-            metallic_text.location = -500, 0
-
-            metallic_separate = node_tree.nodes.new('ShaderNodeSeparateRGB')
-            metallic_separate.location = -250, 0
-
-            metallic_mapping = node_tree.nodes.new('ShaderNodeMapping')
-            metallic_mapping.location = -1000, 0
-
-            metallic_uvmap = node_tree.nodes.new('ShaderNodeUVMap')
-            metallic_uvmap.location = -1500, 0
-            if pypbr.metallic_roughness_texture.tex_coord is not None:
-                # Set custom flag to retrieve TexCoord
-                metallic_uvmap["gltf2_texcoord"] = pypbr.metallic_roughness_texture.tex_coord
-            else:
-                metallic_uvmap["gltf2_texcoord"] = 0  # TODO set in pre_compute instead of here
-
-            # links
-            node_tree.links.new(metallic_separate.inputs[0], metallic_text.outputs[0])
-            node_tree.links.new(principled.inputs[4], metallic_separate.outputs[2])  # metallic
-            node_tree.links.new(principled.inputs[7], metallic_separate.outputs[1])  # Roughness
-
-            node_tree.links.new(metallic_mapping.inputs[0], metallic_uvmap.outputs[0])
-            node_tree.links.new(metallic_text.inputs[0], metallic_mapping.outputs[0])
-
-        elif pypbr.metallic_type == gltf.TEXTURE_FACTOR:
-
-            BlenderTextureInfo.create(gltf, pypbr.metallic_roughness_texture.index)
-            metallic_text = node_tree.nodes.new('ShaderNodeTexImage')
-            if gltf.data.images[
-                gltf.data.textures[pypbr.metallic_roughness_texture.index].source
-            ].blender_image_name is not None:
-                metallic_text.image = bpy.data.images[gltf.data.images[
-                    gltf.data.textures[pypbr.metallic_roughness_texture.index].source
-                ].blender_image_name]
-            metallic_text.color_space = 'NONE'
-            metallic_text.label = 'METALLIC ROUGHNESS'
-            metallic_text.location = -1000, 0
-
-            metallic_separate = node_tree.nodes.new('ShaderNodeSeparateRGB')
-            metallic_separate.location = -500, 0
-
-            metallic_math = node_tree.nodes.new('ShaderNodeMath')
-            metallic_math.operation = 'MULTIPLY'
-            metallic_math.inputs[1].default_value = pypbr.metallic_factor
-            metallic_math.location = -250, 100
-
-            roughness_math = node_tree.nodes.new('ShaderNodeMath')
-            roughness_math.operation = 'MULTIPLY'
-            roughness_math.inputs[1].default_value = pypbr.roughness_factor
-            roughness_math.location = -250, -100
-
-            metallic_mapping = node_tree.nodes.new('ShaderNodeMapping')
-            metallic_mapping.location = -1000, 0
-
-            metallic_uvmap = node_tree.nodes.new('ShaderNodeUVMap')
-            metallic_uvmap.location = -1500, 0
-            if pypbr.metallic_roughness_texture.tex_coord is not None:
-                # Set custom flag to retrieve TexCoord
-                metallic_uvmap["gltf2_texcoord"] = pypbr.metallic_roughness_texture.tex_coord
-            else:
-                metallic_uvmap["gltf2_texcoord"] = 0  # TODO set in pre_compute instead of here
->>>>>>> master
 
                 # links
                 node_tree.links.new(metallic_separate.inputs[0], metallic_text.outputs[0])

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -53,9 +53,10 @@ class BlenderPbr():
         elif nodetype == "unlit":
             if bpy.app.version < (2, 80, 0):
                 main_node = node_tree.nodes.new('ShaderNodeEmission')
+                main_node.location = 750, -300
             else:
                 main_node = node_tree.nodes.new('ShaderNodeBackground')
-            main_node.location = 0, 0
+                main_node.location = 0, 0
 
         if pypbr.color_type == gltf.SIMPLE:
 
@@ -290,4 +291,17 @@ class BlenderPbr():
                 node_tree.links.new(metallic_text.inputs[0], metallic_mapping.outputs[0])
 
         # link node to output
-        node_tree.links.new(output_node.inputs[0], main_node.outputs[0])
+        if bpy.app.version < (2, 80, 0):
+            if nodetype == 'principled':
+                node_tree.links.new(output_node.inputs[0], main_node.outputs[0])
+            elif nodetype == 'unlit':
+                mix = node_tree.nodes.new('ShaderNodeMixShader')
+                mix.location = 1000, 0
+                path = node_tree.nodes.new('ShaderNodeLightPath')
+                path.location = 750, 300
+
+                node_tree.links.new(output_node.inputs[0], mix.outputs[0])
+                node_tree.links.new(mix.inputs[2], main_node.outputs[0])
+                node_tree.links.new(mix.inputs[0], path.outputs[0])
+        else:
+            node_tree.links.new(output_node.inputs[0], main_node.outputs[0])

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
@@ -44,7 +44,8 @@ class glTFImporter():
         # TODO: move to a com place?
         self.extensions_managed = [
             'KHR_materials_pbrSpecularGlossiness',
-            'KHR_lights_punctual'
+            'KHR_lights_punctual',
+            'KHR_materials_unlit'
         ]
 
         # TODO : merge with io_constants


### PR DESCRIPTION
Note that Background Node is not working for objects on 2.79.
So for now, I replaced Background node by emission node, even if this is wrong.

One solution for 2.79 is to create a tree with Light Path 'Is camera ray'.
Other solution is to keep it wrong in 2.79, with a warning