### PR TITLE
Much faster animation import

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -17,6 +17,7 @@
 #
 
 import os
+import time
 import bpy
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 from bpy.types import Operator, AddonPreferences
@@ -482,8 +483,10 @@ class ImportGLTF2(Operator, ImportHelper):
             self.report({'ERROR'}, txt)
             return {'CANCELLED'}
         self.gltf_importer.log.critical("Data are loaded, start creating Blender stuff")
+        start_time = time.time()
         BlenderGlTF.create(self.gltf_importer)
-        self.gltf_importer.log.critical("glTF import is now finished")
+        elapsed_s = "{:.2f}s".format(time.time() - start_time)
+        self.gltf_importer.log.critical("glTF import finished in " + elapsed_s)
         self.gltf_importer.log.removeHandler(self.gltf_importer.log_handler)
 
         return {'FINISHED'}


### PR DESCRIPTION
[Persuant to #76](https://github.com/KhronosGroup/glTF-Blender-IO/issues/76#issuecomment-456704838), I changed the importer for node TRS and bone TRS curves to fill in Blender's FCurves in batches. This gives enormous speedups for models with lots of animation data. To measure this I added the import time to the "glTF import finished" log statement and tried the slowest sample models, plus the model I've been testing with.

|Model|Before|After|% Improvement|
|---|---|---|---|
|Brainstem | 63s | 26s | 142%|
|VC | 23s | 4s | 475%|
|[b00A](https://github.com/KhronosGroup/glTF-Blender-IO/files/2794270/animation_test.zip) | 7.2s | 0.5s | 1340%|

I didn't change the importer for morph weight curves, but you can do something similar to that one too.