### PR TITLE
Reconnect the double-sided flag from the old custom node system.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -94,6 +94,9 @@ def __gather_alpha_mode(blender_material, export_settings):
 
 
 def __gather_double_sided(blender_material, export_settings):
+    old_double_sided_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "DoubleSided")
+    if not old_double_sided_socket.is_linked and old_double_sided_socket.default_value > 0.5:
+        return True
     return None
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -95,7 +95,9 @@ def __gather_alpha_mode(blender_material, export_settings):
 
 def __gather_double_sided(blender_material, export_settings):
     old_double_sided_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "DoubleSided")
-    if not old_double_sided_socket.is_linked and old_double_sided_socket.default_value > 0.5:
+    if old_double_sided_socket is not None and\
+            not old_double_sided_socket.is_linked and\
+            old_double_sided_socket.default_value > 0.5:
         return True
     return None
 


### PR DESCRIPTION
Most exporter inputs still have fallback behavior to look for the old custom node system, but DoubleSided was missing this hookup.  Talked offline with @donmccurdy and there still isn't a great way to get this flag from within Blender, but, it's worth maintaining compatibility with the old system here.
