### PR TITLE
Fix exceptions on exporting lights.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -409,7 +409,7 @@ def extract_primitives(glTF, blender_mesh, blender_vertex_groups, modifiers, exp
     Furthermore, primitives are split up, if the indices range is exceeded.
     Finally, triangles are also split up/duplicated, if face normals are used instead of vertex normals.
     """
-    print_console('INFO', 'Extracting primitive')
+    print_console('INFO', 'Extracting primitive: ' + blender_mesh.name)
 
     use_tangents = False
     if blender_mesh.uv_layers.active and len(blender_mesh.uv_layers) > 0:

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
@@ -55,7 +55,7 @@ def __filter_lights_punctual(blender_lamp, export_settings) -> bool:
 def __gather_color(blender_lamp, export_settings) -> Optional[List[float]]:
     emission_node = __get_cycles_emission_node(blender_lamp)
     if emission_node is not None:
-        return emission_node.inputs["Color"].default_value
+        return list(emission_node.inputs["Color"].default_value)[:3]
 
     return list(blender_lamp.color)
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_search_node_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_search_node_tree.py
@@ -73,7 +73,7 @@ def from_socket(start_socket: bpy.types.NodeSocket,
     :param shader_node_filter: should be a function(x: shader_node) -> bool
     :return: a list of shader nodes for which filter is true
     """
-    # hide implementation (especially the search path
+    # hide implementation (especially the search path)
     def __search_from_socket(start_socket: bpy.types.NodeSocket,
                              shader_node_filter: typing.Union[Filter, typing.Callable],
                              search_path: typing.List[bpy.types.NodeLink]) -> typing.List[NodeTreeSearchResult]:
@@ -95,5 +95,7 @@ def from_socket(start_socket: bpy.types.NodeSocket,
 
         return results
 
-    return __search_from_socket(start_socket, shader_node_filter, [])
+    if start_socket is None:
+        return []
 
+    return __search_from_socket(start_socket, shader_node_filter, [])

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_map_emissive.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_map_emissive.py
@@ -101,7 +101,7 @@ class BlenderEmissiveMap():
         add = node_tree.nodes.new('ShaderNodeAddShader')
         add.location = 500, 500
 
-        # following  links will modify PBR node tree
+        # following links will modify PBR node tree
         node_tree.links.new(add.inputs[0], emit.outputs[0])
         node_tree.links.new(add.inputs[1], principled)
         node_tree.links.new(output.inputs[0], add.outputs[0])


### PR DESCRIPTION
An exception was thrown instead of printing 'No quadratic light falloff node attached to emission strength property', and reading the `default_colour` of an emission node triggered an exception later in `from_list`.

This partly overlaps the patch in #171, which I saw later.