### PR TITLE
Make FCurve group names consistent with Blender

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -41,7 +41,7 @@ class BlenderBoneAnim():
     def parse_translation_channel(gltf, node, obj, bone, channel, animation):
         """Manage Location animation."""
         blender_path = "pose.bones[" + json.dumps(bone.name) + "].location"
-        group_name = "location"
+        group_name = bone.name
 
         keys = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].input)
         values = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].output)
@@ -102,7 +102,7 @@ class BlenderBoneAnim():
         # better solution is found
         # This fix is skipped when parent matrix is identity
         blender_path = "pose.bones[" + json.dumps(bone.name) + "].rotation_quaternion"
-        group_name = "rotation"
+        group_name = bone.name
 
         keys = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].input)
         values = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].output)
@@ -175,7 +175,7 @@ class BlenderBoneAnim():
     def parse_scale_channel(gltf, node, obj, bone, channel, animation):
         """Manage scaling animation."""
         blender_path = "pose.bones[" + json.dumps(bone.name) + "].scale"
-        group_name = "scale"
+        group_name = bone.name
 
         keys = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].input)
         values = BinaryData.get_data_from_accessor(gltf, animation.samplers[channel.sampler].output)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -82,13 +82,13 @@ class BlenderNodeAnim():
 
                 if channel.target.path == "translation":
                     blender_path = "location"
-                    group_name = "location"
+                    group_name = "Location"
                     num_components = 3
                     values = [loc_gltf_to_blender(vals) for vals in values]
 
                 elif channel.target.path == "rotation":
                     blender_path = "rotation_quaternion"
-                    group_name = "rotation"
+                    group_name = "Rotation"
                     num_components = 4
                     if node.correction_needed is True:
                         if bpy.app.version < (2, 80, 0):
@@ -112,7 +112,7 @@ class BlenderNodeAnim():
 
                 elif channel.target.path == "scale":
                     blender_path = "scale"
-                    group_name = "scale"
+                    group_name = "Scale"
                     num_components = 3
                     values = [scale_gltf_to_blender(vals) for vals in values]
 


### PR DESCRIPTION
When you insert keyframes for a pose bone manually in Blender (ie. with `I`), it groups the FCurves by bone name, rather than TRS property like the importer does. For objects (ie. not pose bones), it groups it by TRS property, but with capitalized names.

This PR makes the importer consistent with this practice.

Before (pose bones):
![before](https://user-images.githubusercontent.com/11024420/52238356-66b4ba80-2891-11e9-9225-6f3ad9d4ad45.png)

After (pose bones):
![after](https://user-images.githubusercontent.com/11024420/52238370-6a484180-2891-11e9-8dd2-617a402c41ea.png)
