### PR TITLE
Use mesh object's xfrom for inv bind matrix

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -676,8 +676,9 @@ def extract_primitives(glTF, blender_mesh, blender_vertex_groups, modifiers, exp
                     if modifiers is not None:
                         modifiers_dict = {m.type: m for m in modifiers}
                         if "ARMATURE" in modifiers_dict:
-                            armature = modifiers_dict["ARMATURE"].object
-                            skin = gltf2_blender_gather_skins.gather_skin(armature, export_settings)
+                            modifier = modifiers_dict["ARMATURE"]
+                            armature = modifier.object
+                            skin = gltf2_blender_gather_skins.gather_skin(armature, modifier.id_data, export_settings)
                             for index, j in enumerate(skin.joints):
                                 if j.name == vertex_group_name:
                                     joint_index = index

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -678,11 +678,12 @@ def extract_primitives(glTF, blender_mesh, blender_vertex_groups, modifiers, exp
                         if "ARMATURE" in modifiers_dict:
                             modifier = modifiers_dict["ARMATURE"]
                             armature = modifier.object
-                            skin = gltf2_blender_gather_skins.gather_skin(armature, modifier.id_data, export_settings)
-                            for index, j in enumerate(skin.joints):
-                                if j.name == vertex_group_name:
-                                    joint_index = index
-                                    break
+                            if armature:
+                                skin = gltf2_blender_gather_skins.gather_skin(armature, modifier.id_data, export_settings)
+                                for index, j in enumerate(skin.joints):
+                                    if j.name == vertex_group_name:
+                                        joint_index = index
+                                        break
 
                     #
                     if joint_index is not None:

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -252,7 +252,7 @@ def __gather_skin(blender_object, export_settings):
         return None
 
     # Skins and meshes must be in the same glTF node, which is different from how blender handles armatures
-    return gltf2_blender_gather_skins.gather_skin(modifiers["ARMATURE"].object, export_settings)
+    return gltf2_blender_gather_skins.gather_skin(modifiers["ARMATURE"].object, blender_object, export_settings)
 
 
 def __gather_weights(blender_object, export_settings):

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -235,7 +235,7 @@ def __gather_trans_rot_scale(blender_object, export_settings):
 
 def __gather_skin(blender_object, export_settings):
     modifiers = {m.type: m for m in blender_object.modifiers}
-    if "ARMATURE" not in modifiers:
+    if "ARMATURE" not in modifiers or modifiers["ARMATURE"].object is None:
         return None
 
     # no skin needed when the modifier is linked without having a vertex group

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_skins.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_skins.py
@@ -23,11 +23,12 @@ from io_scene_gltf2.blender.com import gltf2_blender_math
 
 
 @cached
-def gather_skin(blender_object, export_settings):
+def gather_skin(blender_object, mesh_object, export_settings):
     """
     Gather armatures, bones etc into a glTF2 skin object.
 
     :param blender_object: the object which may contain a skin
+    :param mesh_object: the mesh object to be deformed
     :param export_settings:
     :return: a glTF2 skin object
     """
@@ -37,7 +38,7 @@ def gather_skin(blender_object, export_settings):
     return gltf2_io.Skin(
         extensions=__gather_extensions(blender_object, export_settings),
         extras=__gather_extras(blender_object, export_settings),
-        inverse_bind_matrices=__gather_inverse_bind_matrices(blender_object, export_settings),
+        inverse_bind_matrices=__gather_inverse_bind_matrices(blender_object, mesh_object, export_settings),
         joints=__gather_joints(blender_object, export_settings),
         name=__gather_name(blender_object, export_settings),
         skeleton=__gather_skeleton(blender_object, export_settings)
@@ -60,8 +61,7 @@ def __gather_extensions(blender_object, export_settings):
 def __gather_extras(blender_object, export_settings):
     return None
 
-
-def __gather_inverse_bind_matrices(blender_object, export_settings):
+def __gather_inverse_bind_matrices(blender_object, mesh_object, export_settings):
     inverse_matrices = []
 
     axis_basis_change = mathutils.Matrix.Identity(4)
@@ -77,11 +77,15 @@ def __gather_inverse_bind_matrices(blender_object, export_settings):
 
     #
     for blender_bone in blender_object.pose.bones:
-        inverse_bind_matrix = gltf2_blender_math.multiply(axis_basis_change, blender_bone.bone.matrix_local)
-        bind_shape_matrix = gltf2_blender_math.multiply(gltf2_blender_math.multiply(
-            axis_basis_change, blender_object.matrix_world.inverted()), axis_basis_change.inverted())
+        matrix_world = gltf2_blender_math.multiply(blender_object.matrix_world, mesh_object.matrix_world.inverted())
+        inverse_bind_matrix = gltf2_blender_math.multiply(
+            axis_basis_change,
+            gltf2_blender_math.multiply(
+                matrix_world,
+                blender_bone.bone.matrix_local
+            )
+        ).inverted()
 
-        inverse_bind_matrix = gltf2_blender_math.multiply(inverse_bind_matrix.inverted(), bind_shape_matrix)
         for column in range(0, 4):
             for row in range(0, 4):
                 inverse_matrices.append(inverse_bind_matrix[row][column])


### PR DESCRIPTION
Fixes skinning where the mesh object being skinned has a matrix_world != identity

Was in old exporter here: https://github.com/KhronosGroup/glTF-Blender-Exporter/blob/master/scripts/addons/io_scene_gltf2/gltf2_generate.py#L1865

Full CI tests here: https://circleci.com/workflow-run/87659138-f912-4753-af8d-c1a51403c4fe