### PR TITLE
Disable armature modifier when applying modifiers and exporting skins

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -177,11 +177,24 @@ def __gather_mesh(blender_object, export_settings):
             edge_split.split_angle = blender_object.data.auto_smooth_angle
             edge_split.use_edge_angle = not blender_object.data.has_custom_normals
 
+        armature_modifiers = {}
+        if export_settings[gltf2_blender_export_keys.SKINS]:
+            # temprorary disable Armature modifiers if exporting skins
+            for idx, modifier in enumerate(blender_object.modifiers):
+                if modifier.type == 'ARMATURE':
+                    armature_modifiers[idx] = modifier.show_viewport
+                    modifier.show_viewport = False
+
         if bpy.app.version < (2, 80, 0):
             blender_mesh = blender_object.to_mesh(bpy.context.scene, True, 'PREVIEW')
         else:
             blender_mesh = blender_object.to_mesh(bpy.context.depsgraph, True)
         skip_filter = True
+
+        if export_settings[gltf2_blender_export_keys.SKINS]:
+            # restore Armature modifiers
+            for key, val in armature_modifiers.items():
+                blender_object.modifiers[key].show_viewport = val
 
         if auto_smooth:
             bpy.data.objects.remove(blender_object)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -193,8 +193,8 @@ def __gather_mesh(blender_object, export_settings):
 
         if export_settings[gltf2_blender_export_keys.SKINS]:
             # restore Armature modifiers
-            for key, val in armature_modifiers.items():
-                blender_object.modifiers[key].show_viewport = val
+            for idx, show_viewport in armature_modifiers.items():
+                blender_object.modifiers[idx].show_viewport = show_viewport
 
         if auto_smooth:
             bpy.data.objects.remove(blender_object)


### PR DESCRIPTION
Makes things work when you want to non-destructively apply other modifiers (e.g decimate) and still be able to export skinning and animation