### PR TITLE
Exporter: correctly convert UV texture transforms

### DIFF
--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from mathutils import Matrix, Quaternion
-from math import sqrt
+from math import sqrt, sin, cos
 
 def matrix_gltf_to_blender(mat_input):
     """Matrix from glTF format to Blender format."""
@@ -46,3 +46,22 @@ def correction_rotation():
     # Correction is needed for lamps, because Yup2Zup is not written in vertices
     # and lamps has no vertices :)
     return Quaternion((sqrt(2)/2, -sqrt(2)/2, 0.0, 0.0)).to_matrix().to_4x4()
+
+def convert_texture_transform(texture_transform):
+    """
+    Converts a KHR_texture_transform object in one UV space (glTF or Blender)
+    into the equivalent in the other UV space. The returned transform is the
+    same as switching UV spaces (with u,v -> u,1-v), applying texture_transform,
+    then switching back.
+    """
+    offset = texture_transform.get('offset', [0, 0])
+    rotation = texture_transform.get('rotation', 0)
+    scale = texture_transform.get('scale', [1, 1])
+    return {
+        'offset': [
+            offset[0] - scale[1] * sin(rotation),
+            1 - offset[1] - scale[1] * cos(rotation),
+        ],
+        'rotation': -rotation,
+        'scale': [scale[0], scale[1]],
+    }

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -20,6 +20,7 @@ import bpy
 
 from . import gltf2_blender_export_keys
 from ...io.exp import gltf2_io_get
+from ...blender.com.gltf2_blender_conversion import convert_texture_transform
 from io_scene_gltf2.io.com import gltf2_io_debug
 #
 # Globals
@@ -381,6 +382,8 @@ def get_texture_transform_from_texture_node(texture_node):
         texture_transform["offset"] = [mapping_node.translation[0], mapping_node.translation[1]]
         texture_transform["rotation"] = mapping_node.rotation[2]
         texture_transform["scale"] = [mapping_node.scale[0], mapping_node.scale[1]]
+
+    texture_transform = convert_texture_transform(texture_transform)
 
     if all([component == 0 for component in texture_transform["offset"]]):
         del(texture_transform["offset"])


### PR DESCRIPTION
Previous to this change, the values in the Mapping node in Blender were copied straight into the KHR_texture_transform object. This is incorrect because the Mapping node is applied in Blender's UV space, which is related to glTF's with the u,v->u,1-v conversion. That meant that a Mapping node that eg. translates up would be exported as a KHR_texture_transform that translates down because of the
differing directions of the V axis.

The correct thing to do is to calculate the equivalent transform in the other UV space.

This was added to the common module because the importer would need to apply the same conversion to get the right Mapping node from a KHR_texture_transform.