### PR TITLE
Importer: add documentation for tool-tip popup

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -436,6 +436,7 @@ def menu_func_export(self, context):
 
 
 class ImportGLTF2(Operator, ImportHelper):
+    """Load a glTF 2.0 file"""
     bl_idname = 'import_scene.gltf'
     bl_label = 'Import glTF 2.0'
 


### PR DESCRIPTION
The class documentation is used as a pop-up tooltip for the importer menu option. Previously it said "(undocumented operator)". The phrasing matches the phrasing for the other standard importers.

Before:

![before](https://user-images.githubusercontent.com/11024420/52534598-39409480-2d09-11e9-8adb-4adda0a2c61f.png)

 After:

![after](https://user-images.githubusercontent.com/11024420/52534600-3e9ddf00-2d09-11e9-88d8-15dd95c6f7b4.png)
