### PR TITLE
Export option cleanup

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -156,7 +156,7 @@ class ExportGLTF2_Base:
     export_apply = BoolProperty(
         name='Apply Modifiers',
         description='Apply modifiers (excluding Armatures) to mesh objects',
-        default=True
+        default=False
     )
 
     export_animations = BoolProperty(

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -82,7 +82,6 @@ class ExportGLTF2_Base:
         items=(('GENERAL', "General", "General settings"),
                ('MESHES', "Meshes", "Mesh settings"),
                ('OBJECTS', "Objects", "Object settings"),
-               ('MATERIALS', "Materials", "Material settings"),
                ('ANIMATION', "Animation", "Animation settings")),
         name="ui_tab",
         description="Export setting categories",
@@ -157,7 +156,7 @@ class ExportGLTF2_Base:
     export_apply = BoolProperty(
         name='Apply Modifiers',
         description='Apply modifiers (excluding Armatures) to mesh objects',
-        default=False
+        default=True
     )
 
     export_animations = BoolProperty(
@@ -238,13 +237,6 @@ class ExportGLTF2_Base:
         name='Punctual Lights',
         description='Export directional, point, and spot lights. '
                     'Uses "KHR_lights_punctual" glTF extension',
-        default=False
-    )
-
-    export_texture_transform = BoolProperty(
-        name='Texture Transforms',
-        description='Export texture or UV position, rotation, and scale. '
-                    'Uses "KHR_texture_transform" glTF extension',
         default=False
     )
 
@@ -351,7 +343,6 @@ class ExportGLTF2_Base:
             export_settings['gltf_morph_tangent'] = False
 
         export_settings['gltf_lights'] = self.export_lights
-        export_settings['gltf_texture_transform'] = self.export_texture_transform
         export_settings['gltf_displacement'] = self.export_displacement
 
         export_settings['gltf_binary'] = bytearray()
@@ -389,16 +380,12 @@ class ExportGLTF2_Base:
         if self.export_normals:
             col.prop(self, 'export_tangents')
         col.prop(self, 'export_colors')
+        col.prop(self, 'export_materials')
 
     def draw_object_settings(self):
         col = self.layout.box().column()
         col.prop(self, 'export_cameras')
         col.prop(self, 'export_lights')
-
-    def draw_material_settings(self):
-        col = self.layout.box().column()
-        col.prop(self, 'export_materials')
-        col.prop(self, 'export_texture_transform')
 
     def draw_animation_settings(self):
         col = self.layout.box().column()

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_export_keys.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_export_keys.py
@@ -55,7 +55,6 @@ ANIMATIONS = 'gltf_animations'
 EMBED_IMAGES = 'gltf_embed_images'
 BINARY = 'gltf_binary'
 EMBED_BUFFERS = 'gltf_embed_buffers'
-TEXTURE_TRANSFORM = 'gltf_texture_transform'
 USE_NO_COLOR = 'gltf_use_no_color'
 
 METALLIC_ROUGHNESS_IMAGE = "metallic_roughness_image"

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_material_normal_texture_info_class.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_material_normal_texture_info_class.py
@@ -54,9 +54,6 @@ def __filter_texture_info(blender_shader_sockets_or_texture_slots, export_settin
 
 
 def __gather_extensions(blender_shader_sockets_or_texture_slots, export_settings):
-    if not export_settings[gltf2_blender_export_keys.TEXTURE_TRANSFORM]:
-        return None
-
     normal_map_node = blender_shader_sockets_or_texture_slots[0].links[0].from_node
     if not isinstance(normal_map_node, bpy.types.ShaderNodeNormalMap):
         return None

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -53,6 +53,9 @@ def __filter_texture_info(blender_shader_sockets_or_texture_slots, export_settin
 
 
 def __gather_extensions(blender_shader_sockets_or_texture_slots, export_settings):
+    if blender_shader_sockets_or_texture_slots[0] is None:
+        return None
+
     texture_node = blender_shader_sockets_or_texture_slots[0].links[0].from_node
     texture_transform = gltf2_blender_get.get_texture_transform_from_texture_node(texture_node)
     if texture_transform is None:

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -53,7 +53,7 @@ def __filter_texture_info(blender_shader_sockets_or_texture_slots, export_settin
 
 
 def __gather_extensions(blender_shader_sockets_or_texture_slots, export_settings):
-    if blender_shader_sockets_or_texture_slots[0] is None:
+    if not hasattr(blender_shader_sockets_or_texture_slots[0], 'links'):
         return None
 
     texture_node = blender_shader_sockets_or_texture_slots[0].links[0].from_node

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -53,9 +53,6 @@ def __filter_texture_info(blender_shader_sockets_or_texture_slots, export_settin
 
 
 def __gather_extensions(blender_shader_sockets_or_texture_slots, export_settings):
-    if not export_settings[gltf2_blender_export_keys.TEXTURE_TRANSFORM]:
-        return None
-
     texture_node = blender_shader_sockets_or_texture_slots[0].links[0].from_node
     texture_transform = gltf2_blender_get.get_texture_transform_from_texture_node(texture_node)
     if texture_transform is None:

--- a/docs/blender_docs/io_gltf2.rst
+++ b/docs/blender_docs/io_gltf2.rst
@@ -181,6 +181,8 @@ Tangents
    Export vertex tangents with meshes.
 Vertex Colors
    Export vertex colors with meshes.
+Materials
+   Export materials.
 
 
 Objects
@@ -190,15 +192,6 @@ Cameras
    Export cameras.
 Punctual Lights
    Export directional, point, and spot lights. Uses the ``KHR_lights_punctual`` glTF extension.
-
-
-Materials
-^^^^^^^^^
-
-Materials
-   Export materials.
-Texture Transforms
-   Export texture or UV position, rotation, and scale. Uses the ``KHR_texture_transform`` glTF extension.
 
 
 Animation


### PR DESCRIPTION
- ~~**Apply Modifiers** set to `true` per https://github.com/KhronosGroup/glTF-Blender-IO/issues/109#issuecomment-463713414~~ Edit: Reverted this, it caused test failures.

- **Texture Transforms** removed from the UI, always on now.  If you don't want it, don't use the mapping nodes, or leave the mapping nodes set to the default (identity transform).

- **Materials** was alone on a tab by itself, it has been moved over to the Mesh tab.

Fixes #109.