### PR TITLE
Export blender double-sided mesh flag to gltf materials.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -27,7 +27,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_get
 
 
 @cached
-def gather_material(blender_material, export_settings):
+def gather_material(blender_material, mesh_double_sided, export_settings):
     """
     Gather the material used by the blender primitive.
 
@@ -41,7 +41,7 @@ def gather_material(blender_material, export_settings):
     material = gltf2_io.Material(
         alpha_cutoff=__gather_alpha_cutoff(blender_material, export_settings),
         alpha_mode=__gather_alpha_mode(blender_material, export_settings),
-        double_sided=__gather_double_sided(blender_material, export_settings),
+        double_sided=__gather_double_sided(blender_material, mesh_double_sided, export_settings),
         emissive_factor=__gather_emissive_factor(blender_material, export_settings),
         emissive_texture=__gather_emissive_texture(blender_material, export_settings),
         extensions=__gather_extensions(blender_material, export_settings),
@@ -93,7 +93,10 @@ def __gather_alpha_mode(blender_material, export_settings):
     return None
 
 
-def __gather_double_sided(blender_material, export_settings):
+def __gather_double_sided(blender_material, mesh_double_sided, export_settings):
+    if mesh_double_sided:
+        return True
+
     old_double_sided_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "DoubleSided")
     if old_double_sided_socket is not None and\
             not old_double_sided_socket.is_linked and\

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
@@ -63,10 +63,11 @@ def gather_primitives(
 
 def __gather_materials(blender_primitive, blender_mesh, modifiers, export_settings):
     if not blender_primitive['material']:
-        # TODO: fix 'extract_promitives' so that the value of 'material' is None and not empty string
+        # TODO: fix 'extract_primitives' so that the value of 'material' is None and not empty string
         return None
+    mesh_double_sided = blender_mesh.show_double_sided
     material = bpy.data.materials[blender_primitive['material']]
-    return gltf2_blender_gather_materials.gather_material(material, export_settings)
+    return gltf2_blender_gather_materials.gather_material(material, mesh_double_sided, export_settings)
 
 
 def __gather_indices(blender_primitive, blender_mesh, modifiers, export_settings):


### PR DESCRIPTION
Just as making this pull request, it showed another new https://github.com/KhronosGroup/glTF-Blender-IO/commit/cb1f27b6106f77538004b5b331ebc44a7c69969d commit which does the same thing. So I suppose only either that one or this one will be useful, but not both.

Edit: Looking at that version, I think it wouldn't duplicate materials if needed, but this version should.