### PR TITLE
Deduplicate accessors.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_accessors.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_accessors.py
@@ -1,0 +1,47 @@
+# Copyright 2018 The glTF-Blender-IO authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import typing
+
+import bpy
+from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
+from io_scene_gltf2.io.com import gltf2_io
+from io_scene_gltf2.io.com import gltf2_io_constants
+from io_scene_gltf2.io.exp import gltf2_io_binary_data
+from . import gltf2_blender_export_keys
+
+
+@cached
+def gather_accessor(buffer_view: gltf2_io_binary_data.BinaryData,
+                    component_type: gltf2_io_constants.ComponentType,
+                    count,
+                    max,
+                    min,
+                    type: gltf2_io_constants.DataType,
+                    export_settings) -> gltf2_io.Accessor:
+    return gltf2_io.Accessor(
+        buffer_view=buffer_view,
+        byte_offset=None,
+        component_type=component_type,
+        count=count,
+        extensions=None,
+        extras=None,
+        max=list(max) if max is not None else None,
+        min=list(min) if min is not None else None,
+        name=None,
+        normalized=None,
+        sparse=None,
+        type=type
+    )

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -20,6 +20,7 @@ from io_scene_gltf2.blender.com import gltf2_blender_math
 from io_scene_gltf2.blender.com.gltf2_blender_data_path import get_target_property_name, get_target_object_path
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_animation_sampler_keyframes
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_accessors
 from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.io.com import gltf2_io_constants
 from io_scene_gltf2.io.exp import gltf2_io_binary_data
@@ -64,19 +65,14 @@ def __gather_input(channels: typing.Tuple[bpy.types.FCurve],
     keyframes = gltf2_blender_gather_animation_sampler_keyframes.gather_keyframes(channels, export_settings)
     times = [k.seconds for k in keyframes]
 
-    return gltf2_io.Accessor(
-        buffer_view=gltf2_io_binary_data.BinaryData.from_list(times, gltf2_io_constants.ComponentType.Float),
-        byte_offset=None,
-        component_type=gltf2_io_constants.ComponentType.Float,
-        count=len(times),
-        extensions=None,
-        extras=None,
-        max=[max(times)],
-        min=[min(times)],
-        name=None,
-        normalized=None,
-        sparse=None,
-        type=gltf2_io_constants.DataType.Scalar
+    return gltf2_blender_gather_accessors.gather_accessor(
+        gltf2_io_binary_data.BinaryData.from_list(times, gltf2_io_constants.ComponentType.Float),
+        gltf2_io_constants.ComponentType.Float,
+        len(times),
+        tuple([max(times)]),
+        tuple([min(times)]),
+        gltf2_io_constants.DataType.Scalar,
+        export_settings
     )
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
@@ -19,6 +19,7 @@ from .gltf2_blender_export_keys import NORMALS, MORPH_NORMAL, TANGENTS, MORPH_TA
 
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from io_scene_gltf2.blender.exp import gltf2_blender_extract
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_accessors
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_primitive_attributes
 from io_scene_gltf2.blender.exp import gltf2_blender_utils
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials
@@ -90,19 +91,14 @@ def __gather_indices(blender_primitive, blender_mesh, modifiers, export_settings
 
     element_type = gltf2_io_constants.DataType.Scalar
     binary_data = gltf2_io_binary_data.BinaryData.from_list(indices, component_type)
-    return gltf2_io.Accessor(
-        buffer_view=binary_data,
-        byte_offset=None,
-        component_type=component_type,
-        count=len(indices) // gltf2_io_constants.DataType.num_elements(element_type),
-        extensions=None,
-        extras=None,
-        max=None,
-        min=None,
-        name=None,
-        normalized=None,
-        sparse=None,
-        type=element_type
+    return gltf2_blender_gather_accessors.gather_accessor(
+        binary_data,
+        component_type,
+        len(indices) // gltf2_io_constants.DataType.num_elements(element_type),
+        None,
+        None,
+        element_type,
+        export_settings
     )
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_skins.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_skins.py
@@ -18,6 +18,7 @@ from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.io.exp import gltf2_io_binary_data
 from io_scene_gltf2.io.com import gltf2_io_constants
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_accessors
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_joints
 from io_scene_gltf2.blender.com import gltf2_blender_math
 
@@ -91,19 +92,14 @@ def __gather_inverse_bind_matrices(blender_object, mesh_object, export_settings)
                 inverse_matrices.append(inverse_bind_matrix[row][column])
 
     binary_data = gltf2_io_binary_data.BinaryData.from_list(inverse_matrices, gltf2_io_constants.ComponentType.Float)
-    return gltf2_io.Accessor(
-        buffer_view=binary_data,
-        byte_offset=None,
-        component_type=gltf2_io_constants.ComponentType.Float,
-        count=len(inverse_matrices) // gltf2_io_constants.DataType.num_elements(gltf2_io_constants.DataType.Mat4),
-        extensions=None,
-        extras=None,
-        max=None,
-        min=None,
-        name=None,
-        normalized=None,
-        sparse=None,
-        type=gltf2_io_constants.DataType.Mat4
+    return gltf2_blender_gather_accessors.gather_accessor(
+        binary_data,
+        gltf2_io_constants.ComponentType.Float,
+        len(inverse_matrices) // gltf2_io_constants.DataType.num_elements(gltf2_io_constants.DataType.Mat4),
+        None,
+        None,
+        gltf2_io_constants.DataType.Mat4,
+        export_settings
     )
 
 

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_binary_data.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_binary_data.py
@@ -25,6 +25,12 @@ class BinaryData:
             raise TypeError("Data is not a bytes array")
         self.data = data
 
+    def __eq__(self, other):
+        return self.data == other.data
+
+    def __hash__(self):
+        return hash(self.data)
+
     @classmethod
     def from_list(cls, lst: typing.List[typing.Any], gltf_component_type: gltf2_io_constants.ComponentType):
         format_char = gltf2_io_constants.ComponentType.to_type_code(gltf_component_type)


### PR DESCRIPTION
Meshes with modifiers remain duplicated, but should now at least share accessors.

Fixes #353 and helps a bit with #323 / #55. Doesn't help with performance due to regenerating the same mesh multiple times.