### PR TITLE
Fixed dict access key error when image file extension is not lower case.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -81,6 +81,7 @@ def __gather_mime_type(sockets_or_slots, export_settings):
     if export_settings["gltf_image_format"] == "NAME":
         image_name = __get_texname_from_slot(sockets_or_slots, export_settings)
         _, extension = os.path.splitext(image_name)
+        extension = extension.lower()
         if extension in [".jpeg", ".jpg", ".png"]:
             return {
                 ".jpeg": "image/jpeg",
@@ -99,6 +100,7 @@ def __gather_name(sockets_or_slots, export_settings):
     image_name = __get_texname_from_slot(sockets_or_slots, export_settings)
 
     name, extension = os.path.splitext(image_name)
+    extension = extension.lower()
     if extension in [".jpeg", ".jpg", ".png"]:
         return name
     return image_name


### PR DESCRIPTION
Exporting a separate glTF failed, when a texture had a non-lower-case extension.
The conversion to lower-case string was done in the check only, not in the final dictionary acces.

Example file:
[ext_case.zip](https://github.com/KhronosGroup/glTF-Blender-IO/files/3042470/ext_case.zip)
