### PR TITLE
Keep custom properties when applying modifiers to meshes

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -243,6 +243,8 @@ def __gather_mesh(blender_object, export_settings):
             blender_mesh = blender_object.to_mesh(bpy.context.scene, True, 'PREVIEW')
         else:
             blender_mesh = blender_object.to_mesh(bpy.context.depsgraph, True)
+        for prop in blender_object.data.keys():
+            blender_mesh[prop] = blender_object.data[prop]
         skip_filter = True
 
         if export_settings[gltf2_blender_export_keys.SKINS]:


### PR DESCRIPTION
This should fix #403. I haven't included any new tests since the issue is so obscure, but I can put one together if you think the extra coverage would be valuable.