### PR TITLE
Use LINEAR interpolation when sampling anims

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -89,7 +89,9 @@ def __gather_interpolation(channels: typing.Tuple[bpy.types.FCurve],
     if gltf2_blender_gather_animation_sampler_keyframes.needs_baking(blender_object_if_armature,
                                                                      channels,
                                                                      export_settings):
-        return 'LINEAR'
+        min_keyframes = min([len(ch.keyframe_points) for ch in channels])
+        # If only single keyframe revert to STEP
+        return 'STEP' if min_keyframes < 2 else 'LINEAR'
 
     blender_keyframe = channels[0].keyframe_points[0]
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -89,9 +89,9 @@ def __gather_interpolation(channels: typing.Tuple[bpy.types.FCurve],
     if gltf2_blender_gather_animation_sampler_keyframes.needs_baking(blender_object_if_armature,
                                                                      channels,
                                                                      export_settings):
-        min_keyframes = min([len(ch.keyframe_points) for ch in channels])
+        max_keyframes = max([len(ch.keyframe_points) for ch in channels])
         # If only single keyframe revert to STEP
-        return 'STEP' if min_keyframes < 2 else 'LINEAR'
+        return 'STEP' if max_keyframes < 2 else 'LINEAR'
 
     blender_keyframe = channels[0].keyframe_points[0]
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -89,7 +89,7 @@ def __gather_interpolation(channels: typing.Tuple[bpy.types.FCurve],
     if gltf2_blender_gather_animation_sampler_keyframes.needs_baking(blender_object_if_armature,
                                                                      channels,
                                                                      export_settings):
-        return 'STEP'
+        return 'LINEAR'
 
     blender_keyframe = channels[0].keyframe_points[0]
 


### PR DESCRIPTION
Not sure why this ever used STEP :)

With LINEAR you can get decent result with sampling every few frames (e.g. 3-4 depending on your animation), instead of the chunky result you will get with STEP