### PR TITLE
Bump version to 0.9.0, write version number to output file.

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -15,7 +15,7 @@
 bl_info = {
     'name': 'glTF 2.0 format',
     'author': 'Julien Duroure, Norbert Nopper, Urs Hanselmann, Moritz Becher, Benjamin Schmithüsen, Jim Eckerlein, and many external contributors',
-    "version": (1, 0, 0),
+    "version": (0, 9, 0),
     'blender': (2, 80, 0),
     'location': 'File > Import-Export',
     'description': 'Import-Export as glTF 2.0',

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -14,8 +14,8 @@
 
 bl_info = {
     'name': 'glTF 2.0 format',
-    'author': 'Julien Duroure, Norbert Nopper, Urs Hanselmann, Moritz Becher, Benjamin Schmithüsen, Jim Eckerlein',
-    "version": (0, 0, 1),
+    'author': 'Julien Duroure, Norbert Nopper, Urs Hanselmann, Moritz Becher, Benjamin Schmithüsen, Jim Eckerlein, and many external contributors',
+    "version": (1, 0, 0),
     'blender': (2, 80, 0),
     'location': 'File > Import-Export',
     'description': 'Import-Export as glTF 2.0',
@@ -26,6 +26,8 @@ bl_info = {
     'category': 'Import-Export',
 }
 
+def get_version_string():
+    return str(bl_info['version'][0]) + '.' + str(bl_info['version'][1]) + '.' + str(bl_info['version'][2])
 
 #
 # Script reloading (if the user calls 'Reload Scripts' from Blender)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
@@ -14,6 +14,7 @@
 import re
 from typing import List
 
+from ... import get_version_string
 from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.io.com import gltf2_io_extensions
 from io_scene_gltf2.io.exp import gltf2_io_binary_data
@@ -35,7 +36,7 @@ class GlTF2Exporter:
             copyright=copyright,
             extensions=None,
             extras=None,
-            generator='Khronos Blender glTF 2.0 I/O',
+            generator='Khronos glTF Blender I/O v' + get_version_string(),
             min_version=None,
             version='2.0')
 


### PR DESCRIPTION
This PR bumps the version number to `1.0.0`, and I hope to establish a new process where we increment the `PATCH` version (the third number) in the master branch after any PR or group of PRs gets merged.

This PR also includes new code to write the version into the glTF `generator` string.

@donmccurdy Note that I've completely changed the signature of the string, so you may have to update the list of known generators.  The previous string included the glTF version in the generator string, which was redundant because the glTF version is already required to be listed in the version field of the same asset object.

The new addon panel looks something like this:

![AboutAddon](https://user-images.githubusercontent.com/1235080/55972061-bed0ba00-5c50-11e9-86fc-f59138d52a6c.png)

And the new output looks like this:

```
    "asset" : {
        "generator" : "Khronos glTF Blender I/O v1.0.0",
        "version" : "2.0"
    },
```

Fixes #182.

/cc @julienduroure @UX3D-nopper 