### PR TITLE
✨ Allow Opacity export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -43,7 +43,6 @@ def gather_image(
 
     mime_type = __gather_mime_type(blender_shader_sockets_or_texture_slots, export_settings)
     name = __gather_name(blender_shader_sockets_or_texture_slots, export_settings)
-
     uri = __gather_uri(image_data, mime_type, name, export_settings)
     buffer_view = __gather_buffer_view(image_data, mime_type, name, export_settings)
 
@@ -91,6 +90,11 @@ def __gather_extras(sockets_or_slots, export_settings):
 
 
 def __gather_mime_type(sockets_or_slots, export_settings):
+    # force png if Opacity contained so we can export alpha
+    for socket in sockets_or_slots:
+        if socket.name == "Opacity":
+            return "image/png"
+
     if export_settings["gltf_image_format"] == "NAME":
         extension = __get_extension_from_slot(sockets_or_slots, export_settings)
         extension = extension.lower()
@@ -183,6 +187,8 @@ def __get_image_data(sockets_or_slots, export_settings) -> gltf2_blender_image.E
                 composed_image[1] = image[source_channel]
             elif socket.name == 'Occlusion' and len(sockets_or_slots) > 1 and sockets_or_slots[1] is not None:
                 composed_image[0] = image[source_channel]
+            elif socket.name == 'Opacity' and len(sockets_or_slots) > 1 and sockets_or_slots[1] is not None:
+                composed_image[3] = image[0]
             else:
                 composed_image.update(image)
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
@@ -94,7 +94,14 @@ def __gather_base_color_texture(blender_material, export_settings):
         base_color_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "BaseColor")
     if base_color_socket is None:
         base_color_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Background")
-    return gltf2_blender_gather_texture_info.gather_texture_info((base_color_socket,), export_settings)
+
+    alpha_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "Opacity")
+    if alpha_socket is not None and alpha_socket.is_linked:
+        inputs = (base_color_socket, alpha_socket, )
+    else:
+        inputs = (base_color_socket,)
+ 
+    return gltf2_blender_gather_texture_info.gather_texture_info(inputs, export_settings)
 
 
 def __get_tex_from_socket(blender_shader_socket: bpy.types.NodeSocket):

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -17,7 +17,6 @@ import typing
 import numpy as np
 import tempfile
 
-
 class ExportImage:
     """Custom image class that allows manipulation and encoding of images"""
     # FUTURE_WORK: as a method to allow the node graph to be better supported, we could model some of
@@ -97,7 +96,7 @@ class ExportImage:
         self.append(other)
 
     def encode(self, mime_type: typing.Optional[str]) -> bytes:
-        image = bpy.data.images.new("TmpImage", width=self.width, height=self.height)
+        image = bpy.data.images.new("TmpImage", width=self.width, height=self.height, alpha=True)
         pixels = self._img.flatten().tolist()
         image.pixels = pixels
 


### PR DESCRIPTION
Creating a pull request to start some discussion:

I want to export some objects having an opacity map. So far I reused the the "standard" glTF Metallic Roughness node and added the opacity map there.

When exporting I am merging the info from there into the basecolor alpha channel.

This is working like a charm for me and the babylons.js sandbox (https://sandbox.babylonjs.com/) is displaying the result as expected.

Would this be a wothwhile addition? What is missing to get a feature like this merged? I am especially unsure about the hardcoded alpha=True in the image encode function.