### PR TITLE
Fix emission factor (with MULTIPLY node) on export (and use new Principled BSDF Emission slot)

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -110,7 +110,9 @@ def __gather_double_sided(blender_material, mesh_double_sided, export_settings):
 
 
 def __gather_emissive_factor(blender_material, export_settings):
-    emissive_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Emissive")
+    emissive_socket = gltf2_blender_get.get_socket_or_texture_slot_principled(blender_material, "Emission")
+    if emissive_socket is None:
+        emissive_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Emissive")
     if emissive_socket is None:
         emissive_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "EmissiveFactor")
     if isinstance(emissive_socket, bpy.types.NodeSocket):
@@ -152,7 +154,9 @@ def __gather_emissive_factor(blender_material, export_settings):
 
 
 def __gather_emissive_texture(blender_material, export_settings):
-    emissive = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Emissive")
+    emissive = gltf2_blender_get.get_socket_or_texture_slot_principled(blender_material, "Emission")
+    if emissive is None:
+        emissive = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Emissive")
     if emissive is None:
         emissive = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "Emissive")
     return gltf2_blender_gather_texture_info.gather_texture_info((emissive,), export_settings)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -42,6 +42,25 @@ def get_object_from_datapath(blender_object, data_path: str):
 
     return prop
 
+def get_socket_or_texture_slot_principled(blender_material: bpy.types.Material, name: str):
+    """
+    For a given material input name, retrieve the corresponding node tree socket or blender render texture slot.
+
+    :param blender_material: a blender material for which to get the socket/slot
+    :param name: the name of the socket/slot
+    :return: either a blender NodeSocket, if the material is a node tree or a blender Texture otherwise
+    """
+    if blender_material.node_tree and blender_material.use_nodes:
+        #i = [input for input in blender_material.node_tree.inputs]
+        #o = [output for output in blender_material.node_tree.outputs]
+        type = bpy.types.ShaderNodeBsdfPrincipled
+        
+        nodes = [n for n in blender_material.node_tree.nodes if isinstance(n, type)]
+        inputs = sum([[input for input in node.inputs if input.name == name] for node in nodes], [])
+        if inputs:
+            return inputs[0]
+    else:
+        return None
 
 def get_socket_or_texture_slot(blender_material: bpy.types.Material, name: str):
     """


### PR DESCRIPTION
This is my first pull request, so sorry if I messed up something.

For a project I was working on, I needed support for emission factor.  I managed to get the feature working, however I am not sure if I implemented it correctly. I re-used most of the code that was used for extracting the baseColorFactor, so perhaps a refactor could remove this code duplication. Additionally, I included support for the new Principled BSDF emission slot, but to do so I wrote in a slightly hacky looking implementation (because the old code assumed emission would be using an Emission node).

I'm making this pull request in the hopes that I can speed up development of the plugin. If it's not helpful, I'm sorry!