### PR TITLE
Fix Blender 2.79 compatibility and fix custom normals exporting as (0, 0, 0).

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -392,6 +392,10 @@ def extract_primitives(glTF, blender_mesh, blender_vertex_groups, modifiers, exp
     """
     print_console('INFO', 'Extracting primitive: ' + blender_mesh.name)
 
+    if blender_mesh.has_custom_normals:
+        # Custom normals are all (0, 0, 0) until calling calc_normals_split() or calc_tangents().
+        blender_mesh.calc_normals_split()
+
     use_tangents = False
     if blender_mesh.uv_layers.active and len(blender_mesh.uv_layers) > 0:
         try:

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -231,7 +231,10 @@ def __gather_mesh(blender_object, export_settings):
             edge_split.split_angle = blender_object.data.auto_smooth_angle
             edge_split.use_edge_angle = not blender_object.data.has_custom_normals
             blender_object.data.use_auto_smooth = False
-            bpy.context.view_layer.update()
+            if bpy.app.version < (2, 80, 0):
+                bpy.context.scene.update()
+            else:
+                bpy.context.view_layer.update()
 
         armature_modifiers = {}
         if export_settings[gltf2_blender_export_keys.SKINS]:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -200,11 +200,12 @@ class BlenderNode():
                         obj.select = True
                         bpy.data.objects[node.blender_armature_name].select = True
                         bpy.context.scene.objects.active = bpy.data.objects[node.blender_armature_name]
+                        bpy.context.scene.update()
                     else:
                         obj.select_set(True)
                         bpy.data.objects[node.blender_armature_name].select_set(True)
                         bpy.context.view_layer.objects.active = bpy.data.objects[node.blender_armature_name]
-                    bpy.context.view_layer.update()
+                        bpy.context.view_layer.update()
                     bpy.ops.object.parent_set(type='BONE_RELATIVE', keep_transform=True)
                     # From world transform to local (-armature transform -bone transform)
                     bone_trans = bpy.data.objects[node.blender_armature_name] \


### PR DESCRIPTION
Follows 49f88de58b41de421116c2ff4872f114e5070409.

Importer changes untested.