### PR TITLE
Ignore animation import if target has no node

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
@@ -279,6 +279,9 @@ class BlenderGlTF():
 
             for anim_idx, anim in enumerate(gltf.data.animations):
                 for channel_idx, channel in enumerate(anim.channels):
+                    if channel.target.node is None:
+                        continue
+
                     if anim_idx not in gltf.data.nodes[channel.target.node].animations.keys():
                         gltf.data.nodes[channel.target.node].animations[anim_idx] = []
                     gltf.data.nodes[channel.target.node].animations[anim_idx].append(channel_idx)


### PR DESCRIPTION
I encountered the following error when importing a .gltf file (previously exported with this addon)
```
 File "≤path_to≥/2.80/scripts/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py", line 262, in pre_compute
    if anim_idx not in gltf.data.nodes[channel.target.node].animations.keys():
TypeError: list indices must be integers or slices, not NoneType
```
It turns out that the exporter exports an `animation` block if animation export is checked (and it is by default) but there is no animation data. The resulting file cannot be imported back. This fix will not ignore offending operation if `target` has no `node`.


[book_open.zip](https://github.com/KhronosGroup/glTF-Blender-IO/files/3242686/book_open.zip)
