### PR TITLE
Import: fix viewport alpha for KHR_materials_unlit

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
@@ -101,8 +101,8 @@ class BlenderMaterial():
             if pymaterial.occlusion_texture is not None:
                 BlenderOcclusionMap.create(gltf, material_idx, vertex_color)
 
-            if pymaterial.alpha_mode is not None and pymaterial.alpha_mode != 'OPAQUE':
-                BlenderMaterial.blender_alpha(gltf, material_idx, vertex_color, pymaterial.alpha_mode)
+        if pymaterial.alpha_mode is not None and pymaterial.alpha_mode != 'OPAQUE':
+            BlenderMaterial.blender_alpha(gltf, material_idx, vertex_color, pymaterial.alpha_mode)
 
     @staticmethod
     def set_uvmap(gltf, material_idx, prim, obj, vertex_color):


### PR DESCRIPTION
This regressed in 78e6f74. `blender_alpha` wouldn't ever get called if KHR_materials_unlit was present.