### PR TITLE
Fix transforms of children of bones

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_mesh.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_mesh.py
@@ -75,7 +75,7 @@ def __gather_extras(blender_mesh: bpy.types.Mesh,
     extras = {}
 
     if export_settings['gltf_extras']:
-        extras = gltf2_blender_generate_extras.generate_extras(blender_mesh)
+        extras = gltf2_blender_generate_extras.generate_extras(blender_mesh) or {}
 
     if export_settings[MORPH] and blender_mesh.shape_keys:
         morph_max = len(blender_mesh.shape_keys.key_blocks) - 1


### PR DESCRIPTION
When an object is added as a child of a bone I was getting incorrect orientation in the output. The solution was to use the local matrix instead.

Some unnecessary code was found and removed in the process and another minor bug/crash was also fixed.