### PR TITLE
Export: don't write empty buffer

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
@@ -110,23 +110,24 @@ class GlTF2Exporter:
         if self.__finalized:
             raise RuntimeError("Tried to finalize buffers for finalized glTF file")
 
-        if is_glb:
-            uri = None
-        elif output_path and buffer_name:
-            with open(output_path + buffer_name, 'wb') as f:
-                f.write(self.__buffer.to_bytes())
-            uri = buffer_name
-        else:
-            uri = self.__buffer.to_embed_string()
+        if self.__buffer.byte_length > 0:
+            if is_glb:
+                uri = None
+            elif output_path and buffer_name:
+                with open(output_path + buffer_name, 'wb') as f:
+                    f.write(self.__buffer.to_bytes())
+                uri = buffer_name
+            else:
+                uri = self.__buffer.to_embed_string()
 
-        buffer = gltf2_io.Buffer(
-            byte_length=self.__buffer.byte_length,
-            extensions=None,
-            extras=None,
-            name=None,
-            uri=uri
-        )
-        self.__gltf.buffers.append(buffer)
+            buffer = gltf2_io.Buffer(
+                byte_length=self.__buffer.byte_length,
+                extensions=None,
+                extras=None,
+                name=None,
+                uri=uri
+            )
+            self.__gltf.buffers.append(buffer)
 
         self.__finalized = True
 


### PR DESCRIPTION
When exporting a scene with just a camera, I noticed the resulting file was invalid because the JSON contained a buffer with a byteLength of 0 that referenced a non-existent BIN chunk. When there's no buffer data, GLBs were already skipping writing the BIN chunk, but writing the buffer into the JSON and writing the .bin (for .gltf+.bin mode) also needs to be skipped.