### PR TITLE
Fix missing param in recursive draco traverse_node

### DIFF
--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -159,7 +159,7 @@ def __traverse_node(node, f):
     f(node)
     if not (node.children is None):
         for child in node.children:
-            __traverse_node(child)
+            __traverse_node(child, f)
 
 
 def __compress_primitive(primitive, dll, export_settings):


### PR DESCRIPTION
Causes error if exporting a file with parented meshes using draco