### PR TITLE
Fix Blender 2.81: libextern_draco.so is missing

### DIFF
--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -27,12 +27,15 @@ def dll_path() -> Path:
     :return: DLL path.
     """
     lib_name = 'extern_draco'
-    blender_root = Path(bpy.app.binary_path).parent
-    python_lib = Path('2.80/python/lib')
+    # Workaround: convert_to_strict_*.py deletes all lines containing the string 'bpy.app.version'.
+    bapp = bpy.app
+    blender_root = Path(bapp.binary_path).parent
+    python_lib = "{v[0]}.{v[1]}/python/lib".format(v=bapp.version)
+    python_version = "python{v[0]}.{v[1]}".format(v=sys.version_info)
     paths = {
         'win32': blender_root/python_lib/'site-packages'/'{}.dll'.format(lib_name),
-        'linux': blender_root/python_lib/'python3.7'/'site-packages'/'lib{}.so'.format(lib_name),
-        'darwin': blender_root.parent/'Resources'/python_lib/'python3.7'/'site-packages'/'lib{}.dylib'.format(lib_name)
+        'linux': blender_root/python_lib/python_version/'site-packages'/'lib{}.so'.format(lib_name),
+        'darwin': blender_root.parent/'Resources'/python_lib/python_version/'site-packages'/'lib{}.dylib'.format(lib_name)
     }
 
     path = paths.get(sys.platform)


### PR DESCRIPTION
Fixes #627
Hardcoding the Blender and Python version should be avoided.

It was really strange that the script "convert_to_strict_…" just removed the line
`python_lib = "{v[0]}.{v[1]}/python/lib".format(v=bpy.app.version)`
from my patch …

Only tested on Linux:
 ```
bin/2.81/python/lib/python3.7/site-packages/libextern_draco.so' exists, draco mesh compression is available
23:11:14 | INFO: Starting glTF 2.0 export
23:11:14 | INFO: Extracting primitive: Icosphere
23:11:14 | DEBUG: Adding primitive without splitting. Indices: 240 Vertices: 240
23:11:14 | INFO: Primitives created: 1
23:11:14 | INFO: Compressing mesh Icosphere
DRACO-COMPRESSOR: Compressing primitive:
DRACO-COMPRESSOR: Compression level [0-10]:   6
DRACO-COMPRESSOR: Position quantization bits: 14
DRACO-COMPRESSOR: Normal quantization bits:   10
DRACO-COMPRESSOR: Position quantization bits: 12
23:11:14 | INFO: Finished glTF 2.0 export in 0.0362396240234375 s
```