### PR TITLE
Set CI timeout to 20m to avoid failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - checkout
       - run:
           name: Install Blender
+          no_output_timeout: 20m
           command: |
             FILTERS=($TEST_FILTERS)
             FILTER=${FILTERS[$CIRCLE_NODE_INDEX]}


### PR DESCRIPTION
Workaround for #672 slow blender 2.79 download that times out on CircleCI.

Looks like it takes ~12m to download blender 2.79.

Unfortunately also looks like there are other test failures, see sample build here: https://circleci.com/gh/p3d-in/glTF-Blender-IO/77

