### PR TITLE
Import: fix most of #671

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import bpy
+
 from .gltf2_blender_animation_bone import BlenderBoneAnim
 from .gltf2_blender_animation_node import BlenderNodeAnim
+from .gltf2_blender_animation_utils import restore_animation_on_object
 
 
 class BlenderAnimation():
@@ -46,13 +49,20 @@ class BlenderAnimation():
                 BlenderAnimation.stash_action(gltf, anim_idx, child, action_name)
 
     @staticmethod
-    def restore_last_action(gltf, node_idx):
+    def restore_animation(gltf, node_idx, animation_name):
+        """Restores the actions for an animation by its track name on
+        the subtree starting at node_idx."""
+        node = gltf.data.nodes[node_idx]
 
-        if gltf.data.nodes[node_idx].is_joint:
-            BlenderBoneAnim.restore_last_action(gltf, node_idx)
+        if node.is_joint:
+            obj = bpy.data.objects[gltf.data.skins[node.skin_id].blender_armature_name]
         else:
-            BlenderNodeAnim.restore_last_action(gltf, node_idx)
+            obj = bpy.data.objects[node.blender_object]
+
+        restore_animation_on_object(obj, animation_name)
+        if obj.data and hasattr(obj.data, 'shape_keys'):
+            restore_animation_on_object(obj.data.shape_keys, animation_name)
 
         if gltf.data.nodes[node_idx].children:
             for child in gltf.data.nodes[node_idx].children:
-                BlenderAnimation.restore_last_action(gltf, child)
+                BlenderAnimation.restore_animation(gltf, child, animation_name)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation.py
@@ -16,6 +16,7 @@ import bpy
 
 from .gltf2_blender_animation_bone import BlenderBoneAnim
 from .gltf2_blender_animation_node import BlenderNodeAnim
+from .gltf2_blender_animation_weight import BlenderWeightAnim
 from .gltf2_blender_animation_utils import restore_animation_on_object
 
 
@@ -31,6 +32,7 @@ class BlenderAnimation():
             BlenderBoneAnim.anim(gltf, anim_idx, node_idx)
         else:
             BlenderNodeAnim.anim(gltf, anim_idx, node_idx)
+            BlenderWeightAnim.anim(gltf, anim_idx, node_idx)
 
         if gltf.data.nodes[node_idx].children:
             for child in gltf.data.nodes[node_idx].children:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation.py
@@ -39,18 +39,6 @@ class BlenderAnimation():
                 BlenderAnimation.anim(gltf, anim_idx, child)
 
     @staticmethod
-    def stash_action(gltf, anim_idx, node_idx, action_name):
-
-        if gltf.data.nodes[node_idx].is_joint:
-            BlenderBoneAnim.stash_action(gltf, anim_idx, node_idx, action_name)
-        else:
-            BlenderNodeAnim.stash_action(gltf, anim_idx, node_idx, action_name)
-
-        if gltf.data.nodes[node_idx].children:
-            for child in gltf.data.nodes[node_idx].children:
-                BlenderAnimation.stash_action(gltf, anim_idx, child, action_name)
-
-    @staticmethod
     def restore_animation(gltf, node_idx, animation_name):
         """Restores the actions for an animation by its track name on
         the subtree starting at node_idx."""

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -18,7 +18,7 @@ from mathutils import Matrix
 
 from ..com.gltf2_blender_conversion import loc_gltf_to_blender, quaternion_gltf_to_blender, scale_to_matrix
 from ...io.imp.gltf2_io_binary import BinaryData
-from .gltf2_blender_animation_utils import simulate_stash, restore_last_action
+from .gltf2_blender_animation_utils import simulate_stash
 
 
 class BlenderBoneAnim():
@@ -57,13 +57,6 @@ class BlenderBoneAnim():
         simulate_stash(obj, track_name, bpy.data.actions[action_name], start_frame)
 
         gltf.actions_stashed[(obj.name, action_name)] = True
-
-    @staticmethod
-    def restore_last_action(gltf, node_idx):
-        node = gltf.data.nodes[node_idx]
-        obj = bpy.data.objects[gltf.data.skins[node.skin_id].blender_armature_name]
-
-        restore_last_action(obj)
 
     @staticmethod
     def parse_translation_channel(gltf, node, obj, bone, channel, animation):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -53,8 +53,8 @@ class BlenderBoneAnim():
 
         start_frame = bpy.context.scene.frame_start
 
-        animation_name = gltf.data.animations[anim_idx].name
-        simulate_stash(obj, animation_name, bpy.data.actions[action_name], start_frame)
+        track_name = gltf.data.animations[anim_idx].track_name
+        simulate_stash(obj, track_name, bpy.data.actions[action_name], start_frame)
 
         gltf.actions_stashed[(obj.name, action_name)] = True
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -41,24 +41,6 @@ class BlenderBoneAnim():
             kf.interpolation = 'LINEAR'
 
     @staticmethod
-    def stash_action(gltf, anim_idx, node_idx, action_name):
-        node = gltf.data.nodes[node_idx]
-        obj = bpy.data.objects[gltf.data.skins[node.skin_id].blender_armature_name]
-
-        if anim_idx not in node.animations.keys():
-            return
-
-        if (obj.name, action_name) in gltf.actions_stashed.keys():
-            return
-
-        start_frame = bpy.context.scene.frame_start
-
-        track_name = gltf.data.animations[anim_idx].track_name
-        simulate_stash(obj, track_name, bpy.data.actions[action_name], start_frame)
-
-        gltf.actions_stashed[(obj.name, action_name)] = True
-
-    @staticmethod
     def parse_translation_channel(gltf, node, obj, bone, channel, animation):
         """Manage Location animation."""
         blender_path = "pose.bones[" + json.dumps(bone.name) + "].location"
@@ -281,6 +263,7 @@ class BlenderBoneAnim():
         if not action:
             name = animation.track_name + "_" + obj.name
             action = bpy.data.actions.new(name)
+            gltf.needs_stash.append((obj, animation.track_name, action))
             gltf.arma_cache[blender_armature_name] = action
 
         if not obj.animation_data:
@@ -298,6 +281,3 @@ class BlenderBoneAnim():
 
             elif channel.target.path == "scale":
                 BlenderBoneAnim.parse_scale_channel(gltf, node, obj, bone, channel, animation)
-
-        if action.name not in gltf.current_animation_names.keys():
-            gltf.current_animation_names[name] = action.name

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -18,7 +18,7 @@ from mathutils import Vector
 from ..com.gltf2_blender_conversion import loc_gltf_to_blender, quaternion_gltf_to_blender, scale_gltf_to_blender
 from ..com.gltf2_blender_conversion import correction_rotation
 from ...io.imp.gltf2_io_binary import BinaryData
-from .gltf2_blender_animation_utils import simulate_stash, restore_last_action
+from .gltf2_blender_animation_utils import simulate_stash
 
 
 class BlenderNodeAnim():
@@ -57,13 +57,6 @@ class BlenderNodeAnim():
         simulate_stash(obj, track_name, bpy.data.actions[action_name], start_frame)
 
         gltf.actions_stashed[(obj.name, action_name)] = True
-
-    @staticmethod
-    def restore_last_action(gltf, node_idx):
-        node = gltf.data.nodes[node_idx]
-        obj = bpy.data.objects[node.blender_object]
-
-        restore_last_action(obj)
 
     @staticmethod
     def anim(gltf, anim_idx, node_idx):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -77,27 +77,12 @@ class BlenderNodeAnim():
         else:
             return
 
-
-        if animation.name:
-            name = animation.name + "_" + obj.name
-        else:
-            name = "Animation_" + str(anim_idx) + "_" + obj.name
-        if len(name) >= 63:
-            # Name is too long to be kept, we are going to keep only animation name for now
-            name = animation.name
-            if len(name) >= 63:
-                # Very long name!
-                name = "Animation_" + str(anim_idx)
+        name = animation.track_name + "_" + obj.name
         action = bpy.data.actions.new(name)
-        # Check if this action has some users.
-        # If no user (only 1 indeed), that means that this action must be deleted
-        # (is an action from a deleted object)
-        if action.users == 1:
-            bpy.data.actions.remove(action)
-            action = bpy.data.actions.new(name)
+
         if not obj.animation_data:
             obj.animation_data_create()
-        obj.animation_data.action = bpy.data.actions[action.name]
+        obj.animation_data.action = action
 
         for channel_idx in node.animations[anim_idx]:
             channel = animation.channels[channel_idx]

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -53,8 +53,8 @@ class BlenderNodeAnim():
 
         start_frame = bpy.context.scene.frame_start
 
-        animation_name = gltf.data.animations[anim_idx].name
-        simulate_stash(obj, animation_name, bpy.data.actions[action_name], start_frame)
+        track_name = gltf.data.animations[anim_idx].track_name
+        simulate_stash(obj, track_name, bpy.data.actions[action_name], start_frame)
 
         gltf.actions_stashed[(obj.name, action_name)] = True
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -41,24 +41,6 @@ class BlenderNodeAnim():
             kf.interpolation = 'LINEAR'
 
     @staticmethod
-    def stash_action(gltf, anim_idx, node_idx, action_name):
-        node = gltf.data.nodes[node_idx]
-        obj = bpy.data.objects[node.blender_object]
-
-        if anim_idx not in node.animations.keys():
-            return
-
-        if (obj.name, action_name) in gltf.actions_stashed.keys():
-            return
-
-        start_frame = bpy.context.scene.frame_start
-
-        track_name = gltf.data.animations[anim_idx].track_name
-        simulate_stash(obj, track_name, bpy.data.actions[action_name], start_frame)
-
-        gltf.actions_stashed[(obj.name, action_name)] = True
-
-    @staticmethod
     def anim(gltf, anim_idx, node_idx):
         """Manage animation."""
         node = gltf.data.nodes[node_idx]
@@ -79,6 +61,7 @@ class BlenderNodeAnim():
 
         name = animation.track_name + "_" + obj.name
         action = bpy.data.actions.new(name)
+        gltf.needs_stash.append((obj, animation.track_name, action))
 
         if not obj.animation_data:
             obj.animation_data_create()
@@ -156,6 +139,3 @@ class BlenderNodeAnim():
                 for kf in fcurve.keyframe_points:
                     BlenderNodeAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
                 fcurve.update() # force updating tangents (this may change when tangent will be managed)
-
-        if action.name not in gltf.current_animation_names.keys():
-            gltf.current_animation_names[name] = action.name

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def simulate_stash(obj, gltf_animation_name, action, start_frame):
+def simulate_stash(obj, track_name, action, start_frame):
     # Simulate stash :
     # * add a track
     # * add an action on track
@@ -20,7 +20,7 @@ def simulate_stash(obj, gltf_animation_name, action, start_frame):
     # * remove active action from object
     tracks = obj.animation_data.nla_tracks
     new_track = tracks.new(prev=None)
-    new_track.name = gltf_animation_name if gltf_animation_name is not None else action.name
+    new_track.name = track_name
     strip = new_track.strips.new(action.name, start_frame, action)
     new_track.lock = True
     new_track.mute = True

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
@@ -26,13 +26,17 @@ def simulate_stash(obj, track_name, action, start_frame):
     new_track.mute = True
     obj.animation_data.action = None
 
-def restore_last_action(obj):
+def restore_animation_on_object(obj, anim_name):
+    if not getattr(obj, 'animation_data', None):
+        return
 
-    if not obj.animation_data:
+    for track in obj.animation_data.nla_tracks:
+        if track.name != anim_name:
+            continue
+        if not track.strips:
+            continue
+
+        obj.animation_data.action = track.strips[0].action
         return
-    tracks = obj.animation_data.nla_tracks
-    if len(tracks) == 0:
-        return
-    if len(tracks[0].strips) == 0:
-        return
-    obj.animation_data.action = tracks[0].strips[0].action
+
+    obj.animation_data.action = None

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def simulate_stash(obj, track_name, action, start_frame):
+import bpy
+
+def simulate_stash(obj, track_name, action, start_frame=None):
     # Simulate stash :
     # * add a track
     # * add an action on track
@@ -21,6 +23,8 @@ def simulate_stash(obj, track_name, action, start_frame):
     tracks = obj.animation_data.nla_tracks
     new_track = tracks.new(prev=None)
     new_track.name = track_name
+    if start_frame is None:
+        start_frame = bpy.context.scene.frame_start
     strip = new_track.strips.new(action.name, start_frame, action)
     new_track.lock = True
     new_track.mute = True

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_weight.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_weight.py
@@ -75,24 +75,10 @@ class BlenderWeightAnim():
         else:
             return
 
-        if animation.name:
-            name = animation.name + "_" + obj.name
-        else:
-            name = "Animation_" + str(anim_idx) + "_" + obj.name
-        if len(name) >= 63:
-            # Name is too long to be kept, we are going to keep only animation name for now
-            name = animation.name
-            if len(name) >= 63:
-                # Very long name!
-                name = "Animation_" + str(anim_idx)
+        name = animation.track_name + "_" + obj.name
         action = bpy.data.actions.new(name)
-        # Check if this action has some users.
-        # If no user (only 1 indeed), that means that this action must be deleted
-        # (is an action from a deleted object)
-        if action.users == 1:
-            bpy.data.actions.remove(action)
-            action = bpy.data.actions.new(name)
         action.id_root = "KEY"
+
         if not obj.data.shape_keys.animation_data:
             obj.data.shape_keys.animation_data_create()
         obj.data.shape_keys.animation_data.action = action

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_weight.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_weight.py
@@ -39,24 +39,6 @@ class BlenderWeightAnim():
             kf.interpolation = 'LINEAR'
 
     @staticmethod
-    def stash_action(gltf, anim_idx, node_idx, action_name):
-        node = gltf.data.nodes[node_idx]
-        obj = bpy.data.objects[node.blender_object]
-
-        if anim_idx not in node.animations.keys():
-            return
-
-        if (obj.name, action_name) in gltf.actions_stashed.keys():
-            return
-
-        start_frame = bpy.context.scene.frame_start
-
-        track_name = gltf.data.animations[anim_idx].track_name
-        simulate_stash(obj.data.shape_keys, track_name, bpy.data.actions[action_name], start_frame)
-
-        gltf.actions_stashed[(obj.name, action_name)] = True
-
-    @staticmethod
     def anim(gltf, anim_idx, node_idx):
         """Manage animation."""
         node = gltf.data.nodes[node_idx]
@@ -78,6 +60,7 @@ class BlenderWeightAnim():
         name = animation.track_name + "_" + obj.name
         action = bpy.data.actions.new(name)
         action.id_root = "KEY"
+        gltf.needs_stash.append((obj.data.shape_keys, animation.track_name, action))
 
         if not obj.data.shape_keys.animation_data:
             obj.data.shape_keys.animation_data_create()
@@ -123,6 +106,3 @@ class BlenderWeightAnim():
                 for kf in fcurve.keyframe_points:
                     BlenderWeightAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
                 fcurve.update() # force updating tangents (this may change when tangent will be managed)
-
-        if action.name not in gltf.current_animation_names.keys():
-            gltf.current_animation_names[name] = action.name

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
@@ -277,7 +277,14 @@ class BlenderGlTF():
             for node_idx, node in enumerate(gltf.data.nodes):
                 node.animations = {}
 
+            track_names = set()
             for anim_idx, anim in enumerate(gltf.data.animations):
+                # Pick pair-wise unique name for each animation to use as a name
+                # for its NLA tracks.
+                desired_name = anim.name or "Anim_%d" % anim_idx
+                anim.track_name = BlenderGlTF.find_unused_name(track_names, desired_name)
+                track_names.add(anim.track_name)
+
                 for channel_idx, channel in enumerate(anim.channels):
                     if channel.target.node is None:
                         continue
@@ -294,3 +301,25 @@ class BlenderGlTF():
             for mesh in gltf.data.meshes:
                 mesh.blender_name = None
                 mesh.is_weight_animated = False
+
+    @staticmethod
+    def find_unused_name(haystack, desired_name):
+        """Finds a name not in haystack and <= 63 UTF-8 bytes.
+        (the limit on the size of a Blender name.)
+        If a is taken, tries a.001, then a.002, etc.
+        """
+        stem = desired_name[:63]
+        suffix = ''
+        cntr = 1
+        while True:
+            name = stem + suffix
+
+            if len(name.encode('utf-8')) > 63:
+                stem = stem[:-1]
+                continue
+
+            if name not in haystack:
+                return name
+
+            suffix = '.%03d' % cntr
+            cntr += 1

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -121,10 +121,10 @@ class BlenderScene():
                 if list_nodes is not None:
                     for node_idx in list_nodes:
                         BlenderAnimation.anim(gltf, anim_idx, node_idx)
-                for an in gltf.current_animation_names.values():
-                    gltf.animation_managed.append(an)
-                    for node_idx in list_nodes:
-                        BlenderAnimation.stash_action(gltf, anim_idx, node_idx, an)
+                #for an in gltf.current_animation_names.values():
+                #    gltf.animation_managed.append(an)
+                #    for node_idx in list_nodes:
+                #        BlenderAnimation.stash_action(gltf, anim_idx, node_idx, an)
             # Restore first animation
             anim_name = gltf.data.animations[0].track_name
             for node_idx in list_nodes:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -114,8 +114,10 @@ class BlenderScene():
                     BlenderSkin.create_armature_modifiers(gltf, skin_id)
 
         if gltf.data.animations:
-            gltf.animation_managed = []
             for anim_idx, anim in enumerate(gltf.data.animations):
+                # Blender armature name -> action all its bones should use
+                gltf.arma_cache = {}
+
                 gltf.current_animation_names = {}
                 gltf.actions_stashed= {}
                 if list_nodes is not None:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -18,6 +18,7 @@ from mathutils import Quaternion
 from .gltf2_blender_node import BlenderNode
 from .gltf2_blender_skin import BlenderSkin
 from .gltf2_blender_animation import BlenderAnimation
+from .gltf2_blender_animation_utils import simulate_stash
 
 
 class BlenderScene():
@@ -117,16 +118,16 @@ class BlenderScene():
             for anim_idx, anim in enumerate(gltf.data.animations):
                 # Blender armature name -> action all its bones should use
                 gltf.arma_cache = {}
+                # Things we need to stash when we're done.
+                gltf.needs_stash = []
 
-                gltf.current_animation_names = {}
-                gltf.actions_stashed= {}
                 if list_nodes is not None:
                     for node_idx in list_nodes:
                         BlenderAnimation.anim(gltf, anim_idx, node_idx)
-                #for an in gltf.current_animation_names.values():
-                #    gltf.animation_managed.append(an)
-                #    for node_idx in list_nodes:
-                #        BlenderAnimation.stash_action(gltf, anim_idx, node_idx, an)
+
+                for (obj, anim_name, action) in gltf.needs_stash:
+                    simulate_stash(obj, anim_name, action)
+
             # Restore first animation
             anim_name = gltf.data.animations[0].track_name
             for node_idx in list_nodes:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -125,8 +125,10 @@ class BlenderScene():
                     gltf.animation_managed.append(an)
                     for node_idx in list_nodes:
                         BlenderAnimation.stash_action(gltf, anim_idx, node_idx, an)
+            # Restore first animation
+            anim_name = gltf.data.animations[0].track_name
             for node_idx in list_nodes:
-                BlenderAnimation.restore_last_action(gltf, node_idx)
+                BlenderAnimation.restore_animation(gltf, node_idx, anim_name)
 
         if bpy.app.debug_value != 100:
             # Parent root node to rotation object


### PR DESCRIPTION
~~This gets started on #671.~~ Okay, I actually wound up doing all of 1-4. Here's how it looks now:

![bars](https://user-images.githubusercontent.com/11024420/64909474-4f189c80-d6d2-11e9-9776-fb3b9c09e0fb.png)

I tested with a [simple script](https://gist.github.com/scurest/ed3d80213fcf422bf4314eb4f9f514c6) and I can now "play" an animation by giving its name. It successfully round-trips with the exporter too.

------

Unique name were picked for each animation and stored in `animation.track_name`. It works just like picking names for other Blender stuff works, by appending .001, then .002, etc. until a name is free. The names are only unique within the current glTF file. There might be tracks already in the .blend that they collide with though.

Morph weights were spun out into their own file (did one object with both morph weight and TRS animations ever work? I think you need two actions...). I also redid it to use `foreach_set` like in #253 since it was actually easier, so there should be a nice performance boost.

Bones don't find their action by its name anymore, they look in a cache at `gltf.arma_cache`. This simplifies things a lot. This should get rid of the problems with grabbing old actions or animations having the same name, and I checked that #518 didn't regress.

Stashing was also simplified. Every time an action gets created, a note is pushed onto a work list at `gltf.needs_stash` and then it's all executed at the end. This got rid of a lot of repeated code too.

And restoring is now done by walking down from the root and and looking for strips with the right name and loading the action from those.

Hopefully you can tell me how it looks and if deleted anything I shouldn't have :)