### PR TITLE
Refactor: factor out code for creating FCurves

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -18,27 +18,13 @@ from mathutils import Vector
 from ..com.gltf2_blender_conversion import loc_gltf_to_blender, quaternion_gltf_to_blender, scale_gltf_to_blender
 from ..com.gltf2_blender_conversion import correction_rotation
 from ...io.imp.gltf2_io_binary import BinaryData
-from .gltf2_blender_animation_utils import simulate_stash
+from .gltf2_blender_animation_utils import simulate_stash, make_fcurve
 
 
 class BlenderNodeAnim():
     """Blender Object Animation."""
     def __new__(cls, *args, **kwargs):
         raise RuntimeError("%s should not be instantiated" % cls)
-
-    @staticmethod
-    def set_interpolation(interpolation, kf):
-        """Manage interpolation."""
-        if interpolation == "LINEAR":
-            kf.interpolation = 'LINEAR'
-        elif interpolation == "STEP":
-            kf.interpolation = 'CONSTANT'
-        elif interpolation == "CUBICSPLINE":
-            kf.interpolation = 'BEZIER'
-            kf.handle_right_type = 'AUTO'
-            kf.handle_left_type = 'AUTO'
-        else:
-            kf.interpolation = 'LINEAR'
 
     @staticmethod
     def anim(gltf, anim_idx, node_idx):
@@ -123,19 +109,13 @@ class BlenderNodeAnim():
             coords = [0] * (2 * len(keys))
             coords[::2] = (key[0] * fps for key in keys)
 
-            if group_name not in action.groups:
-                action.groups.new(group_name)
-            group = action.groups[group_name]
-
             for i in range(0, num_components):
-                fcurve = action.fcurves.new(data_path=blender_path, index=i)
-                fcurve.group = group
-
-                fcurve.keyframe_points.add(len(keys))
                 coords[1::2] = (vals[i] for vals in values)
-                fcurve.keyframe_points.foreach_set('co', coords)
-
-                # Setting interpolation
-                for kf in fcurve.keyframe_points:
-                    BlenderNodeAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
-                fcurve.update() # force updating tangents (this may change when tangent will be managed)
+                make_fcurve(
+                    action,
+                    coords,
+                    data_path=blender_path,
+                    index=i,
+                    group_name=group_name,
+                    interpolation=animation.samplers[channel.sampler].interpolation,
+                )

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
@@ -44,3 +44,35 @@ def restore_animation_on_object(obj, anim_name):
         return
 
     obj.animation_data.action = None
+
+def make_fcurve(action, co, data_path, index=0, group_name=None, interpolation=None):
+    fcurve = action.fcurves.new(data_path=data_path, index=index)
+
+    if group_name:
+        if group_name not in action.groups:
+            action.groups.new(group_name)
+        group = action.groups[group_name]
+        fcurve.group = group
+
+    fcurve.keyframe_points.add(len(co) // 2)
+    fcurve.keyframe_points.foreach_set('co', co)
+
+    # Setting interpolation
+    if interpolation == 'CUBICSPLINE':
+        for kf in fcurve.keyframe_points:
+            kf.interpolation = 'BEZIER'
+            kf.handle_right_type = 'AUTO'
+            kf.handle_left_type = 'AUTO'
+    else:
+        if interpolation == 'LINEAR':
+            blender_interpolation = 'LINEAR'
+        elif interpolation == 'STEP':
+            blender_interpolation = 'CONSTANT'
+        else:
+            blender_interpolation = 'LINEAR'
+        for kf in fcurve.keyframe_points:
+            kf.interpolation = blender_interpolation
+
+    fcurve.update() # force updating tangents (this may change when tangent will be managed)
+
+    return fcurve

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_weight.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_weight.py
@@ -16,27 +16,13 @@ import json
 import bpy
 
 from ...io.imp.gltf2_io_binary import BinaryData
-from .gltf2_blender_animation_utils import simulate_stash
+from .gltf2_blender_animation_utils import simulate_stash, make_fcurve
 
 
 class BlenderWeightAnim():
     """Blender ShapeKey Animation."""
     def __new__(cls, *args, **kwargs):
         raise RuntimeError("%s should not be instantiated" % cls)
-
-    @staticmethod
-    def set_interpolation(interpolation, kf):
-        """Manage interpolation."""
-        if interpolation == "LINEAR":
-            kf.interpolation = 'LINEAR'
-        elif interpolation == "STEP":
-            kf.interpolation = 'CONSTANT'
-        elif interpolation == "CUBICSPLINE":
-            kf.interpolation = 'BEZIER'
-            kf.handle_right_type = 'AUTO'
-            kf.handle_left_type = 'AUTO'
-        else:
-            kf.interpolation = 'LINEAR'
 
     @staticmethod
     def anim(gltf, anim_idx, node_idx):
@@ -86,23 +72,17 @@ class BlenderWeightAnim():
         coords = [0] * (2 * len(keys))
         coords[::2] = (key[0] * fps for key in keys)
 
-        group_name = "ShapeKeys"
-        if group_name not in action.groups:
-            action.groups.new(group_name)
-        group = action.groups[group_name]
-
         for sk in range(nb_targets):
             if gltf.shapekeys[sk] is not None: # Do not animate shapekeys not created
+                coords[1::2] = (values[offset + stride * i + sk][0] for i in range(len(keys)))
+
                 kb_name = obj.data.shape_keys.key_blocks[gltf.shapekeys[sk]].name
                 data_path = "key_blocks[" + json.dumps(kb_name) + "].value"
-                fcurve = action.fcurves.new(data_path=data_path)
-                fcurve.group = group
 
-                fcurve.keyframe_points.add(len(keys))
-                coords[1::2] = (values[offset + stride * i + sk][0] for i in range(len(keys)))
-                fcurve.keyframe_points.foreach_set('co', coords)
-
-                # Setting interpolation
-                for kf in fcurve.keyframe_points:
-                    BlenderWeightAnim.set_interpolation(animation.samplers[channel.sampler].interpolation, kf)
-                fcurve.update() # force updating tangents (this may change when tangent will be managed)
+                make_fcurve(
+                    action,
+                    coords,
+                    data_path=data_path,
+                    group_name="ShapeKeys",
+                    interpolation=animation.samplers[channel.sampler].interpolation,
+                )


### PR DESCRIPTION
Removes code duplicated across the bone/node/weights animation classes.

Setting the keyframe also now branches once and then loops over all the keyframes instead of branching for every keyframe, so it might be a little bit faster too.