### PR TITLE
Importer: performance improvements (accessor decoding, Shading > Use Normal Data)

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -143,26 +143,17 @@ class BlenderMesh():
                 for fi in range(face_idx, face_idx + prim.num_faces):
                     mesh.polygons[fi].use_smooth = True
             elif gltf.import_settings['import_shading'] == "NORMALS":
+                mesh_loops = mesh.loops
                 for fi in range(face_idx, face_idx + prim.num_faces):
                     poly = mesh.polygons[fi]
-                    calc_norm_vertices = []
+                    # "Flat normals" are when all the vertices in poly have the
+                    # poly's normal. Otherwise, smooth the poly.
                     for loop_idx in range(poly.loop_start, poly.loop_start + poly.loop_total):
-                        vert_idx = mesh.loops[loop_idx].vertex_index
-                        calc_norm_vertices.append(vert_idx)
+                        vi = mesh_loops[loop_idx].vertex_index
+                        if poly.normal.dot(bme.verts[vi].normal) <= 0.9999999:
+                            poly.use_smooth = True
+                            break
 
-                        if len(calc_norm_vertices) == 3:
-                            # Calcul normal
-                            vert0 = mesh.vertices[calc_norm_vertices[0]].co
-                            vert1 = mesh.vertices[calc_norm_vertices[1]].co
-                            vert2 = mesh.vertices[calc_norm_vertices[2]].co
-                            calc_normal = (vert1 - vert0).cross(vert2 - vert0).normalized()
-
-                            # Compare normal to vertex normal
-                            for i in calc_norm_vertices:
-                                vec = Vector(bme.verts[i].normal)
-                                if not calc_normal.dot(vec) > 0.9999999:
-                                    poly.use_smooth = True
-                                    break
             else:
                 # shouldn't happen
                 pass

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
@@ -64,12 +64,11 @@ class BinaryData():
         else:
             stride = stride_
 
-        data = []
-        offset = 0
-        while len(data) < accessor.count:
-            element = struct.unpack_from(fmt, buffer_data, offset)
-            data.append(element)
-            offset += stride
+        unpack_from = struct.Struct(fmt).unpack_from
+        data = [
+            unpack_from(buffer_data, offset)
+            for offset in range(0, accessor.count*stride, stride)
+        ]
 
         if accessor.sparse:
             sparse_indices_data = BinaryData.get_data_from_sparse(gltf, accessor.sparse, "indices")
@@ -136,12 +135,11 @@ class BinaryData():
         else:
             stride = stride_
 
-        data = []
-        offset = 0
-        while len(data) < sparse.count:
-            element = struct.unpack_from(fmt, bin_data, offset)
-            data.append(element)
-            offset += stride
+        unpack_from = struct.Struct(fmt).unpack_from
+        data = [
+            unpack_from(bin_data, offset)
+            for offset in range(0, sparse.count*stride, stride)
+        ]
 
         return data
 


### PR DESCRIPTION
Thanks for getting my last PRs in! Here are some more performance improvements:

* The first commit is just a small edit to how accessors are decoded that tries to stay out the Python interpreter as much as possible. It only gives a few tenths of a second on big models, but eh, I'll take it...
* The second tries to reduce the time spent doing the _Shading > Use Normal Data_ calculation. Here's some measurements. The last column is just to give a lower bound.

    |Sample Model|Before (Use Normal Data) |After (Use Normal Data) | — (Smooth Shading)|
    |:---|:---|:---|:---|
    |BrainStem | 1.76s | 1.55s | 1.32s |
    |GearboxAssy | 5.55s | 3.67s | 2.35s |
    |MetalRoughSpheres | 7.03s | 5.01s | 3.43s |
    |Sponza | 4.11s | 3.04s | 2.01 |

    It should have the same intent, but it does change which polys get use_smooth, it isn't exactly the same (see the commit message). The comparison against 0.9999999 is _really_ strict (there's actually only one single-precision float greater than it and still less than 1.0). I guess it's supposed to error on the side of smooth shading though.

    By the way, do you have a really good file for testing whether _Shading > Use Normal Data_ is working correctly? I'm basically just looking for any visual difference after importing a sample model.