### PR TITLE
Export with Always Sample Animations by default

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -247,7 +247,7 @@ class ExportGLTF2_Base:
     export_force_sampling = BoolProperty(
         name='Always Sample Animations',
         description='Apply sampling to all animations',
-        default=False
+        default=True
     )
 
     export_nla_strips = BoolProperty(

--- a/tests/roundtrip/01_morphed_cube/01_morphed_cube_options.txt
+++ b/tests/roundtrip/01_morphed_cube/01_morphed_cube_options.txt
@@ -1,0 +1,1 @@
+--no-sample-anim

--- a/tests/roundtrip_gltf.py
+++ b/tests/roundtrip_gltf.py
@@ -29,18 +29,20 @@ try:
     bpy.ops.import_scene.gltf(filepath=argv[0])
 
     extension = '.gltf'
+    export_format = 'GLTF_SEPARATE'
     if '--glb' in argv:
         extension = '.glb'
+        export_format = 'GLB'
 
     path = os.path.splitext(filepath)[0] + extension
     path_parts = os.path.split(path)
     output_dir = os.path.join(path_parts[0], argv[1])
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    if extension == '.glb':
-        bpy.ops.export_scene.gltf(export_format='GLB', filepath=os.path.join(output_dir, path_parts[1]))
+    if '--no-sample-anim' in argv:
+        bpy.ops.export_scene.gltf(export_format=export_format, filepath=os.path.join(output_dir, path_parts[1]), export_force_sampling=False)
     else:
-        bpy.ops.export_scene.gltf(export_format='GLTF_SEPARATE', filepath=os.path.join(output_dir, path_parts[1]))
+        bpy.ops.export_scene.gltf(export_format=export_format, filepath=os.path.join(output_dir, path_parts[1]))
 except Exception as err:
     print(err, file=sys.stderr)
     sys.exit(1)

--- a/tests/test/test.js
+++ b/tests/test/test.js
@@ -615,6 +615,11 @@ describe('Importer / Exporter (Roundtrip)', function() {
                         let ext = args.indexOf('--glb') === -1 ? '.gltf' : '.glb';
                         let outDirPath = path.resolve(OUT_PREFIX, 'roundtrip', dir, outDirName);
                         let gltfDstPath = path.resolve(outDirPath, `${dir}${ext}`);
+                        let gltfOptionsPath = `roundtrip/${dir}/${dir}_options.txt`;
+                        let options = args;
+                        if (fs.existsSync(gltfOptionsPath)) {
+                            options += ' ' + fs.readFileSync(gltfOptionsPath).toString().replace(/\r?\n|\r/g, '');
+                        }
                         blenderRoundtripGltf(blenderVersion, gltfSrcPath, outDirPath, (error) => {
                             if (error)
                                 return done(error);
@@ -647,7 +652,7 @@ describe('Importer / Exporter (Roundtrip)', function() {
 
                                 done();
                             });
-                        }, args);
+                        }, options);
                     });
                 });
             });


### PR DESCRIPTION
Export more reliably correct animation playback for skinned meshes. #558
Users will vastly prefer that their exported content plays back correctly by default. If "Always Sample Animations" is off, there is often only a marginal difference in filesize, but high chance of animations that are completely invalid and rotating/moving in the wrong directions. The exporter should be robust and work correctly by default