### PR TITLE
User defined extensions

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_channel_target.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_channel_target.py
@@ -20,6 +20,7 @@ from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_nodes
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_joints
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_skins
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 @cached
 def gather_animation_channel_target(channels: typing.Tuple[bpy.types.FCurve],
@@ -29,12 +30,22 @@ def gather_animation_channel_target(channels: typing.Tuple[bpy.types.FCurve],
                                     export_settings
                                     ) -> gltf2_io.AnimationChannelTarget:
 
-        return gltf2_io.AnimationChannelTarget(
+        animation_channel_target = gltf2_io.AnimationChannelTarget(
             extensions=__gather_extensions(channels, blender_object, export_settings, bake_bone),
             extras=__gather_extras(channels, blender_object, export_settings, bake_bone),
             node=__gather_node(channels, blender_object, export_settings, bake_bone),
             path=__gather_path(channels, blender_object, export_settings, bake_bone, bake_channel)
         )
+
+        export_user_extensions('gather_animation_channel_target_hook', 
+                               export_settings, 
+                               animation_channel_target, 
+                               channels, 
+                               blender_object, 
+                               bake_bone, 
+                               bake_channel)
+        
+        return animation_channel_target
 
 def __gather_extensions(channels: typing.Tuple[bpy.types.FCurve],
                         blender_object: bpy.types.Object,

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_channels.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_channels.py
@@ -23,6 +23,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_gather_animation_samplers
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_animation_channel_target
 from io_scene_gltf2.blender.exp import gltf2_blender_get
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_skins
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -149,12 +150,25 @@ def __gather_animation_channel(channels: typing.Tuple[bpy.types.FCurve],
     if not __filter_animation_channel(channels, blender_object, export_settings):
         return None
 
-    return gltf2_io.AnimationChannel(
+    animation_channel = gltf2_io.AnimationChannel(
         extensions=__gather_extensions(channels, blender_object, export_settings, bake_bone),
         extras=__gather_extras(channels, blender_object, export_settings, bake_bone),
         sampler=__gather_sampler(channels, blender_object, export_settings, bake_bone, bake_channel, bake_range_start, bake_range_end, action_name),
         target=__gather_target(channels, blender_object, export_settings, bake_bone, bake_channel)
     )
+
+    export_user_extensions('gather_animation_channel_hook', 
+                           export_settings, 
+                           animation_channel, 
+                           channels, 
+                           blender_object, 
+                           bake_bone, 
+                           bake_channel, 
+                           bake_range_start, 
+                           bake_range_end, 
+                           action_name)
+
+    return animation_channel
 
 
 def __filter_animation_channel(channels: typing.Tuple[bpy.types.FCurve],

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -27,6 +27,7 @@ from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.io.com import gltf2_io_constants
 from io_scene_gltf2.io.exp import gltf2_io_binary_data
 from . import gltf2_blender_export_keys
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -55,7 +56,7 @@ def gather_animation_sampler(channels: typing.Tuple[bpy.types.FCurve],
                                                  export_settings)
 
 
-    return gltf2_io.AnimationSampler(
+    sampler = gltf2_io.AnimationSampler(
         extensions=__gather_extensions(channels, blender_object_if_armature, export_settings, bake_bone, bake_channel),
         extras=__gather_extras(channels, blender_object_if_armature, export_settings, bake_bone, bake_channel),
         input=__gather_input(channels, blender_object_if_armature, non_keyed_values,
@@ -71,6 +72,19 @@ def gather_animation_sampler(channels: typing.Tuple[bpy.types.FCurve],
                                action_name,
                                export_settings)
     )
+
+    export_user_extensions('gather_animation_sampler_hook', 
+                            export_settings, 
+                            sampler, 
+                            channels, 
+                            blender_object, 
+                            bake_bone, 
+                            bake_channel, 
+                            bake_range_start, 
+                            bake_range_end, 
+                            action_name)
+
+    return sampler
 
 def __gather_non_keyed_values(channels: typing.Tuple[bpy.types.FCurve],
                               blender_object: bpy.types.Object,

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animations.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animations.py
@@ -19,6 +19,7 @@ from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_animation_channels
 from io_scene_gltf2.io.com.gltf2_io_debug import print_console
 from ..com.gltf2_blender_extras import generate_extras
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 def gather_animations(blender_object: bpy.types.Object,
@@ -107,6 +108,8 @@ def __gather_animation(blender_action: bpy.types.Action,
 
     if not animation.channels:
         return None
+
+    export_user_extensions('gather_animation_hook', export_settings, animation, blender_action, blender_object)
 
     return animation
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cameras.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cameras.py
@@ -16,6 +16,7 @@ from . import gltf2_blender_export_keys
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from ..com.gltf2_blender_extras import generate_extras
 from io_scene_gltf2.io.com import gltf2_io
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 import bpy
 import math
@@ -26,7 +27,7 @@ def gather_camera(blender_camera, export_settings):
     if not __filter_camera(blender_camera, export_settings):
         return None
 
-    return gltf2_io.Camera(
+    camera = gltf2_io.Camera(
         extensions=__gather_extensions(blender_camera, export_settings),
         extras=__gather_extras(blender_camera, export_settings),
         name=__gather_name(blender_camera, export_settings),
@@ -34,6 +35,10 @@ def gather_camera(blender_camera, export_settings):
         perspective=__gather_perspective(blender_camera, export_settings),
         type=__gather_type(blender_camera, export_settings)
     )
+
+    export_user_extensions('gather_camera_hook', export_settings, camera, blender_camera)
+
+    return camera
 
 
 def __filter_camera(blender_camera, export_settings):

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -26,6 +26,7 @@ from io_scene_gltf2.io.exp import gltf2_io_image_data
 from io_scene_gltf2.io.com import gltf2_io_debug
 from io_scene_gltf2.blender.exp import gltf2_blender_image
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -47,7 +48,7 @@ def gather_image(
     uri = __gather_uri(image_data, mime_type, name, export_settings)
     buffer_view = __gather_buffer_view(image_data, mime_type, name, export_settings)
 
-    return __make_image(
+    image = __make_image(
         buffer_view,
         __gather_extensions(blender_shader_sockets_or_texture_slots, export_settings),
         __gather_extras(blender_shader_sockets_or_texture_slots, export_settings),
@@ -56,6 +57,10 @@ def gather_image(
         uri,
         export_settings
     )
+
+    export_user_extensions('gather_image_hook', export_settings, image, blender_shader_sockets_or_texture_slots)
+
+    return image
 
 @cached
 def __make_image(buffer_view, extensions, extras, mime_type, name, uri, export_settings):

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_material_normal_texture_info_class.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_material_normal_texture_info_class.py
@@ -21,6 +21,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_search_node_tree
 from io_scene_gltf2.blender.exp import gltf2_blender_export_keys
 from io_scene_gltf2.blender.exp import gltf2_blender_get
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -40,6 +41,11 @@ def gather_material_normal_texture_info_class(blender_shader_sockets_or_texture_
 
     if texture_info.index is None:
         return None
+
+    export_user_extensions('gather_material_normal_texture_info_class_hook', 
+                           export_settings, 
+                           texture_info, 
+                           blender_shader_sockets_or_texture_slots)
 
     return texture_info
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_material_occlusion_texture_info_class.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_material_occlusion_texture_info_class.py
@@ -20,6 +20,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture
 from io_scene_gltf2.blender.exp import gltf2_blender_search_node_tree
 from io_scene_gltf2.blender.exp import gltf2_blender_get
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -39,6 +40,11 @@ def gather_material_occlusion_texture_info_class(blender_shader_sockets_or_textu
 
     if texture_info.index is None:
         return None
+
+    export_user_extensions('gather_material_occlusion_texture_info_class_hook', 
+                           export_settings, 
+                           texture_info, 
+                           blender_shader_sockets_or_texture_slots)
 
     return texture_info
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -25,6 +25,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_search_node_tree
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials_pbr_metallic_roughness
 from ..com.gltf2_blender_extras import generate_extras
 from io_scene_gltf2.blender.exp import gltf2_blender_get
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -54,6 +55,8 @@ def gather_material(blender_material, mesh_double_sided, export_settings):
         occlusion_texture=__gather_occlusion_texture(blender_material, orm_texture, export_settings),
         pbr_metallic_roughness=__gather_pbr_metallic_roughness(blender_material, orm_texture, export_settings)
     )
+
+    export_user_extensions('gather_material_hook', export_settings, material, blender_material)
 
     return material
     # material = blender_primitive['material']

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
@@ -20,6 +20,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture_info, gltf2_
 from io_scene_gltf2.blender.exp import gltf2_blender_get
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from io_scene_gltf2.io.com.gltf2_io_debug import print_console
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -36,6 +37,8 @@ def gather_material_pbr_metallic_roughness(blender_material, orm_texture, export
         metallic_roughness_texture=__gather_metallic_roughness_texture(blender_material, orm_texture, export_settings),
         roughness_factor=__gather_roughness_factor(blender_material, export_settings)
     )
+
+    export_user_extensions('gather_material_pbr_metallic_roughness_hook', export_settings, material, blender_material, orm_texture)
 
     return material
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_mesh.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_mesh.py
@@ -20,6 +20,7 @@ from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_primitives
 from ..com.gltf2_blender_extras import generate_extras
 from io_scene_gltf2.io.com.gltf2_io_debug import print_console
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -45,6 +46,17 @@ def gather_mesh(blender_mesh: bpy.types.Mesh,
     if len(mesh.primitives) == 0:
         print_console("WARNING", "Mesh '{}' has no primitives and will be omitted.".format(mesh.name))
         return None
+
+    export_user_extensions('gather_mesh_hook', 
+                           export_settings, 
+                           mesh, 
+                           blender_mesh, 
+                           blender_object, 
+                           vertex_groups, 
+                           modifiers, 
+                           skip_filter, 
+                           material_names)
+
     return mesh
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -28,6 +28,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_gather_lights
 from ..com.gltf2_blender_extras import generate_extras
 from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.io.com import gltf2_io_extensions
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions 
 
 
 def gather_node(blender_object, blender_scene, export_settings):
@@ -85,6 +86,8 @@ def __gather_node(blender_object, blender_scene, export_settings):
             correction_node.camera = node.camera
             node.children.append(correction_node)
         node.camera = None
+
+    export_user_extensions('gather_node_hook', export_settings, node, blender_object)
 
     return node
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
@@ -15,6 +15,7 @@
 import bpy
 from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -22,7 +23,7 @@ def gather_sampler(blender_shader_node: bpy.types.Node, export_settings):
     if not __filter_sampler(blender_shader_node, export_settings):
         return None
 
-    return gltf2_io.Sampler(
+    sampler = gltf2_io.Sampler(
         extensions=__gather_extensions(blender_shader_node, export_settings),
         extras=__gather_extras(blender_shader_node, export_settings),
         mag_filter=__gather_mag_filter(blender_shader_node, export_settings),
@@ -31,6 +32,10 @@ def gather_sampler(blender_shader_node: bpy.types.Node, export_settings):
         wrap_s=__gather_wrap_s(blender_shader_node, export_settings),
         wrap_t=__gather_wrap_t(blender_shader_node, export_settings)
     )
+
+    export_user_extensions('gather_sampler_hook', export_settings, sampler, blender_shader_node)
+
+    return sampler
 
 
 def __filter_sampler(blender_shader_node, export_settings):

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_skins.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_skins.py
@@ -21,6 +21,7 @@ from io_scene_gltf2.io.com import gltf2_io_constants
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_accessors
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_joints
 from io_scene_gltf2.blender.com import gltf2_blender_math
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -35,7 +36,7 @@ def gather_skin(blender_object, export_settings):
     if not __filter_skin(blender_object, export_settings):
         return None
 
-    return gltf2_io.Skin(
+    skin = gltf2_io.Skin(
         extensions=__gather_extensions(blender_object, export_settings),
         extras=__gather_extras(blender_object, export_settings),
         inverse_bind_matrices=__gather_inverse_bind_matrices(blender_object, export_settings),
@@ -43,6 +44,10 @@ def gather_skin(blender_object, export_settings):
         name=__gather_name(blender_object, export_settings),
         skeleton=__gather_skeleton(blender_object, export_settings)
     )
+
+    export_user_extensions('gather_skin_hook', export_settings, skin, blender_object)
+
+    return skin
 
 
 def __filter_skin(blender_object, export_settings):

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture.py
@@ -21,6 +21,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_gather_sampler
 from io_scene_gltf2.blender.exp import gltf2_blender_search_node_tree
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_image
 from io_scene_gltf2.io.com import gltf2_io_debug
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -50,6 +51,8 @@ def gather_texture(
     # although valid, most viewers can't handle missing source properties
     if texture.source is None:
         return None
+
+    export_user_extensions('gather_texture_hook', export_settings, texture, blender_shader_sockets_or_texture_slots)
 
     return texture
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -21,6 +21,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_search_node_tree
 from io_scene_gltf2.blender.exp import gltf2_blender_get
 from io_scene_gltf2.io.com.gltf2_io_debug import print_console
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 @cached
@@ -39,6 +40,8 @@ def gather_texture_info(blender_shader_sockets_or_texture_slots: typing.Union[
 
     if texture_info.index is None:
         return None
+
+    export_user_extensions('gather_texture_info_hook', export_settings, texture_info, blender_shader_sockets_or_texture_slots)
 
     return texture_info
 

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_user_extensions.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_user_extensions.py
@@ -1,0 +1,22 @@
+# Copyright 2019 The glTF-Blender-IO authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def export_user_extensions(hook_name, export_settings, gltf2_object, *args):
+    if gltf2_object.extensions is None:
+        gltf2_object.extensions = {}
+
+    for extension in export_settings['gltf_user_extensions']:
+        hook = getattr(extension, hook_name, None)
+        if hook is not None:
+            hook(gltf2_object, *args, export_settings)

--- a/misc/ExampleExtension.py
+++ b/misc/ExampleExtension.py
@@ -1,0 +1,106 @@
+import bpy
+
+bl_info = {
+    "name": "KDAB_example_extension",
+    "category": "Generic",
+    "blender": (2,80,0),
+    'isDraft': False,
+    'developer': "KDAB",
+    'url': 'https://www.kdab.com',
+}
+
+class ExampleExtensionProperties(bpy.types.PropertyGroup):
+    enabled: bpy.props.BoolProperty(
+        name='ExampleExtension_enabled',
+        description='This is an example of a BoolProperty used by a UserExtension.',
+        default=True
+        )
+    float_property: bpy.props.FloatProperty(
+        name='ExampleExtension_enabled',
+        description='This is an example of a FloatProperty used by a UserExtension.',
+        default=1.0
+        )
+
+def register():
+    bpy.utils.register_class(ExampleExtensionProperties)
+    bpy.types.Scene.ExampleExtensionProperties = bpy.props.PointerProperty(type=ExampleExtensionProperties)
+
+def register_panel():
+    # Register the panel on demand, we need to be sure to only register it once
+    # This is necessary because the panel is a child of the extensions panel, 
+    # which may not be registered when we try to register this extension
+    try:
+        bpy.utils.register_class(GLTF_PT_UserExtensionPanel)
+    except Exception:
+        pass
+
+    # If the glTF exporter is disabled, we need to unregister the extension panel
+    # Just return a function to the exporter so it can unregister the panel
+    return unregister_panel
+
+
+def unregister_panel():
+    # Since panel is registered on demand, it is possible it is not registered
+    try:
+        bpy.utils.unregister_class(GLTF_PT_UserExtensionPanel)
+    except Exception:
+        pass
+        
+
+def unregister():
+    unregister_panel()
+    bpy.utils.unregister_class(ExampleExtensionProperties)
+    del bpy.types.Scene.ExampleExtensionProperties
+
+class GLTF_PT_UserExtensionPanel(bpy.types.Panel):
+
+    bl_space_type = 'FILE_BROWSER'
+    bl_region_type = 'TOOL_PROPS'
+    bl_label = "Example Extension"
+    bl_parent_id = "GLTF_PT_export_user_extensions"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    @classmethod
+    def poll(cls, context):
+        sfile = context.space_data
+        operator = sfile.active_operator
+        return operator.bl_idname == "EXPORT_SCENE_OT_gltf"
+
+    def draw_header(self, context):
+        props = bpy.context.scene.ExampleExtensionProperties
+        self.layout.prop(props, 'enabled')
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation.
+
+
+        box = layout.box()
+        box.label(text="Is draft: " + str(bl_info['isDraft']))
+        box.label(text="Developer: " + str(bl_info['developer']))
+        box.label(text="url: " + str(bl_info['url']))
+
+        props = bpy.context.scene.ExampleExtensionProperties
+        layout.prop(props, 'float_property', text="Some float value")
+
+
+class glTF2ExportUserExtension:
+
+    def __init__(self):
+        # We need to wait until we create the gltf2UserExtension to import the gltf2 modules
+        # Otherwise, it may fail because the gltf2 may not be loaded yet
+        from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
+        self.Extension = Extension 
+        self.properties = bpy.context.scene.ExampleExtensionProperties
+
+    def gather_node_hook(self, gltf2_object, blender_object, export_settings):
+        if self.properties.enabled:
+            if gltf2_object.extensions is None:
+                gltf2_object.extensions = {}
+            gltf2_object.extensions[bl_info['name']] = self.Extension(
+                name= bl_info['name'], 
+                extension={"float": self.properties.float_property},
+                required=False
+            )
+


### PR DESCRIPTION
This patch allows to create user defined extensions. This works by loading dynamically python files in the extensions directory. This way, a user can define his own extensions without the need to fork the exporter