### PR TITLE
Avoid bone.name due to apparent memory corruption effect

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_skin.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_skin.py
@@ -161,8 +161,8 @@ class BlenderSkin():
         BlenderSkin.set_bone_transforms(gltf, skin_id, bone, node_id, parent)
         bpy.ops.object.mode_set(mode="OBJECT")
         # Custom prop on pose bone
-        if bone.name in obj.pose.bones:
-            set_extras(obj.pose.bones[bone.name], pynode.extras)
+        if pynode.blender_bone_name in obj.pose.bones:
+            set_extras(obj.pose.bones[pynode.blender_bone_name], pynode.extras)
 
     @staticmethod
     def create_vertex_groups(gltf, skin_id):


### PR DESCRIPTION
I've seen random test failures (locally and online) that [look like this](https://circleci.com/gh/KhronosGroup/glTF-Blender-IO/1007#tests/containers/2).

These are intermittent and difficult to reproduce reliably, even by following an exact series of steps.  Ultimately what I think I'm seeing is some kind of memory corruption around the value of `bone.name` on [this line](https://github.com/KhronosGroup/glTF-Blender-IO/blob/1f350035f1b219e27038547062ad3f06175f6f9c/addons/io_scene_gltf2/blender/imp/gltf2_blender_skin.py#L164) just after `set_bone_transforms` is called.

This PR just swaps `bone.name` with `pynode.blender_bone_name` which should have the same value.  This is used inside of `set_bone_transforms` which makes me think it's the safer choice.