### PR TITLE
Export: fix #737

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -617,6 +617,11 @@ def extract_primitives(glTF, blender_mesh, blender_object, blender_vertex_groups
             triangles = tessellate_polygon((polyline,))
 
             for triangle in triangles:
+                if bpy.app.version < (2, 81, 15):
+                    # tessellate_polygon winding-order is reversed in old versions of Blender
+                    # See https://developer.blender.org/T70594
+                    triangle = (triangle[0], triangle[2], triangle[1])
+
                 for triangle_index in triangle:
                     loop_index_list.append(blender_polygon.loop_indices[triangle_index])
         else:


### PR DESCRIPTION
Fixes reversed winding order when exporting n-gons in Blender versions older than 2.81.15.

Fixes #737.

edit: 03_skinned_cylinder has it out for me.