### PR TITLE
Import: fixes around buffers and GLB-handling

### DIFF
--- a/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
@@ -14,8 +14,6 @@
 
 import struct
 import base64
-from os.path import dirname, join, isfile, basename
-from urllib.parse import unquote
 
 
 class BinaryData():
@@ -167,19 +165,8 @@ class BinaryData():
         image_name = "Image_" + str(img_idx)
 
         if pyimage.uri:
-            sep = ';base64,'
-            if pyimage.uri[:5] == 'data:':
-                idx = pyimage.uri.find(sep)
-                if idx != -1:
-                    data = pyimage.uri[idx + len(sep):]
-                    return base64.b64decode(data), image_name
-
-            if isfile(join(dirname(gltf.filename), unquote(pyimage.uri))):
-                with open(join(dirname(gltf.filename), unquote(pyimage.uri)), 'rb') as f_:
-                    return f_.read(), basename(join(dirname(gltf.filename), unquote(pyimage.uri)))
-            else:
-                gltf.log.error("Missing file (index " + str(img_idx) + "): " + pyimage.uri)
-                return None, None
+            data, file_name = gltf.load_uri(pyimage.uri)
+            return data, file_name or image_name
 
         if pyimage.buffer_view is None:
             return None, None

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
@@ -159,18 +159,16 @@ class BinaryData():
     def get_image_data(gltf, img_idx):
         """Get data from image."""
         pyimage = gltf.data.images[img_idx]
+        image_name = "Image_" + str(img_idx)
 
         assert(not (pyimage.uri is not None and pyimage.buffer_view is not None))
 
-        image_name = "Image_" + str(img_idx)
-
-        if pyimage.uri:
+        if pyimage.uri is not None:
             data, file_name = gltf.load_uri(pyimage.uri)
             return data, file_name or image_name
 
-        if pyimage.buffer_view is None:
-            return None, None
+        elif pyimage.buffer_view is not None:
+            data = BinaryData.get_buffer_view(gltf, pyimage.buffer_view)
+            return data, image_name
 
-        data = BinaryData.get_buffer_view(gltf, pyimage.buffer_view)
-
-        return data, image_name
+        return None, None

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
@@ -29,6 +29,7 @@ class glTFImporter():
         """initialization."""
         self.filename = filename
         self.import_settings = import_settings
+        self.glb_buffer = None
         self.buffers = {}
         self.accessor_cache = {}
 
@@ -130,7 +131,7 @@ class glTFImporter():
             if type_ == b"BIN\0":
                 if len_ != len(data):
                     return False, "Bad GLB: length of BIN chunk doesn't match"
-                self.buffers[0] = data
+                self.glb_buffer = data
 
         return True, None
 
@@ -191,6 +192,11 @@ class glTFImporter():
             data, _file_name = self.load_uri(buffer.uri)
             if data is not None:
                 self.buffers[buffer_idx] = data
+
+        else:
+            # GLB-stored buffer
+            if buffer_idx == 0 and self.glb_buffer is not None:
+                self.buffers[buffer_idx] = self.glb_buffer
 
     def load_uri(self, uri):
         """Loads a URI.

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
@@ -131,7 +131,6 @@ class glTFImporter():
                     return False, "Bad GLB: length of BIN chunk doesn't match"
                 self.buffers[0] = data
 
-        self.content = None
         return True, None
 
     def load_chunk(self, offset):
@@ -157,19 +156,19 @@ class glTFImporter():
 
         # glTF file
         if not self.is_glb_format:
+            content = self.content.decode('utf-8')
             self.content = None
-            with open(self.filename, 'r') as f:
-                content = f.read()
-                try:
-                    self.data = gltf_from_dict(json.loads(content, parse_constant=glTFImporter.bad_json_value))
-                    return True, None
-                except ValueError as e:
-                    return False, e.args[0]
+            try:
+                self.data = gltf_from_dict(json.loads(content, parse_constant=glTFImporter.bad_json_value))
+                return True, None
+            except ValueError as e:
+                return False, e.args[0]
 
         # glb file
         else:
             # Parsing glb file
             success, txt = self.load_glb()
+            self.content = None
             return success, txt
 
     def is_node_joint(self, node_idx):


### PR DESCRIPTION
* The types of GLB chunks are now checked.
* Handling of the BIN chunk is now in line with the spec:
    * There is zero or one BIN chunk.
    * The BIN chunk is the second chunk in the GLB file if it exists.
    * The first buffer only refers to the data stored in the BIN chunk if its uri property is not set.
* buffer.uri is now URL-decoded (image.uri was already being URL-decoded).
* Put buffer data in memoryviews for cheap slicing.