### PR TITLE
Export: fix #754

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -575,7 +575,10 @@ def extract_primitives(glTF, blender_mesh, blender_object, blender_vertex_groups
 
         #
 
-        if not blender_polygon.material_index in material_idx_to_primitives:
+        if export_settings['gltf_materials'] is False:
+            primitive = material_idx_to_primitives[0]
+            vertex_index_to_new_indices = material_map[0]
+        elif not blender_polygon.material_index in material_idx_to_primitives:
             primitive = material_idx_to_primitives[0]
             vertex_index_to_new_indices = material_map[0]
         else:


### PR DESCRIPTION
Fixes #754. Prevents a mesh from being split into multiple per-material primitives when exporting materials is disabled. A mesh with two triangles with different materials now exports with one primitive when _Geometry > Materials_ is disabled.