### PR TITLE
Draco compression without normals

### DIFF
--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -166,11 +166,13 @@ def __traverse_node(node, f):
 def __compress_primitive(primitive, dll, export_settings):
     attributes = primitive.attributes
 
-    # This is the only attribute type required to be present.
-    enableNormals = 'NORMAL' in attributes
+    # Positions are the only attribute type required to be present.
     if 'POSITION' not in attributes:
         print('Draco exporter: Mesh without positions encountered. Skipping.')
         pass
+
+    # Both, normals and texture coordinates are optional attribute types.
+    enableNormals = 'NORMAL' in attributes
 
     # Begin mesh.
     compressor = dll.createCompressor()

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -172,12 +172,12 @@ def __compress_primitive(primitive, dll, export_settings):
         pass
 
     # Both, normals and texture coordinates are optional attribute types.
-    enableNormals = 'NORMAL' in attributes
-    texCoordAttributes = [attributes[attr] for attr in attributes if attr.startswith('TEXCOORD_')]
+    enable_normals = 'NORMAL' in attributes
+    tex_coord_attrs = [attributes[attr] for attr in attributes if attr.startswith('TEXCOORD_')]
 
     print_console('INFO', ('Draco exporter: Compressing primitive %s normal attribute and with %d ' + 
         'texture coordinate attributes, along with positions.') %
-        ('with' if enableNormals else 'without', len(texCoordAttributes)))
+        ('with' if enable_normals else 'without', len(tex_coord_attrs)))
 
     # Begin mesh.
     compressor = dll.createCompressor()
@@ -186,11 +186,11 @@ def __compress_primitive(primitive, dll, export_settings):
     dll.addPositionAttribute(compressor, attributes['POSITION'].count, attributes['POSITION'].buffer_view.data)
 
     # Process normal attributes.
-    if enableNormals:
+    if enable_normals:
         dll.addNormalAttribute(compressor, attributes['NORMAL'].count, attributes['NORMAL'].buffer_view.data)
 
     # Process texture coordinate attributes.
-    for attribute in texCoordAttributes:
+    for attribute in tex_coord_attrs:
         dll.addTexCoordAttribute(compressor, attribute.count, attribute.buffer_view.data)
 
     # Process faces.
@@ -241,7 +241,7 @@ def __compress_primitive(primitive, dll, export_settings):
             }
         }
 
-        if enableNormals:
+        if enable_normals:
             extension['attributes']['NORMAL'] = dll.getNormalAttributeId(compressor)
 
         for id in range(0, dll.getTexCoordAttributeIdCount(compressor)):

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -242,7 +242,7 @@ def __compress_primitive(primitive, dll, export_settings):
         }
 
         if enableNormals:
-            extension.attributes['NORMAL'] = dll.getNormalAttributeId(compressor)
+            extension['attributes']['NORMAL'] = dll.getNormalAttributeId(compressor)
 
         for id in range(0, dll.getTexCoordAttributeIdCount(compressor)):
             extension['attributes']['TEXCOORD_' + str(id)] = dll.getTexCoordAttributeId(compressor, id)

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -151,7 +151,7 @@ def __dispose_memory(node):
 def __compress_node(node, dll, export_settings):
     """Compress a single node."""
     if not (node.mesh is None):
-        print_console("INFO", "Compressing mesh " + node.name)
+        print_console('INFO', 'Draco exporter: Compressing mesh "%s".' % node.name)
         for primitive in node.mesh.primitives:
             __compress_primitive(primitive, dll, export_settings)
 
@@ -168,11 +168,16 @@ def __compress_primitive(primitive, dll, export_settings):
 
     # Positions are the only attribute type required to be present.
     if 'POSITION' not in attributes:
-        print('Draco exporter: Mesh without positions encountered. Skipping.')
+        print_console('WARNING', 'Draco exporter: Primitive without positions encountered. Skipping.')
         pass
 
     # Both, normals and texture coordinates are optional attribute types.
     enableNormals = 'NORMAL' in attributes
+    texCoordAttributes = [attributes[attr] for attr in attributes if attr.startswith('TEXCOORD_')]
+
+    print_console('INFO', ('Draco exporter: Compressing primitive %s normal attribute and with %d ' + 
+        'texture coordinate attributes, along with positions.') %
+        ('with' if enableNormals else 'without', len(texCoordAttributes)))
 
     # Begin mesh.
     compressor = dll.createCompressor()
@@ -185,7 +190,7 @@ def __compress_primitive(primitive, dll, export_settings):
         dll.addNormalAttribute(compressor, attributes['NORMAL'].count, attributes['NORMAL'].buffer_view.data)
 
     # Process texture coordinate attributes.
-    for attribute in [attributes[attr] for attr in attributes if attr.startswith('TEXCOORD_')]:
+    for attribute in texCoordAttributes:
         dll.addTexCoordAttribute(compressor, attribute.count, attribute.buffer_view.data)
 
     # Process faces.


### PR DESCRIPTION
Allow using the Draco compressor when exporting without normals

Previously, the exporter crashed when exporting without normals but with
enabled Draco compression, because the Draco compressor tried to read
the attribute's normals, which in turn do not exist in this specific export
configuration.