### PR TITLE
Allow exporting non-active Actions outside NLA strip

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -259,8 +259,8 @@ class ExportGLTF2_Base:
     
     export_all_actions = BoolProperty(
         name='Export All Actions',
-        description='Include actions outside of NLA strips',
-        default=True
+        description='Include all actions outside of NLA strips',
+        default=False
     )
 
     export_def_bones = BoolProperty(

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -256,6 +256,12 @@ class ExportGLTF2_Base:
         description='Export NLA Strip animations',
         default=True
     )
+    
+    export_all_actions = BoolProperty(
+        name='Export All Actions',
+        description='Include actions outside of NLA strips',
+        default=True
+    )
 
     export_def_bones = BoolProperty(
         name='Export Deformation bones only',
@@ -401,6 +407,7 @@ class ExportGLTF2_Base:
             else:
                 export_settings['gltf_def_bones'] = False
             export_settings['gltf_nla_strips'] = self.export_nla_strips
+            export_settings['gltf_all_actions'] = self.export_all_actions
         else:
             export_settings['gltf_frame_range'] = False
             export_settings['gltf_move_keyframes'] = False
@@ -717,6 +724,7 @@ class GLTF_PT_export_animation_export(bpy.types.Panel):
         layout.prop(operator, 'export_frame_step')
         layout.prop(operator, 'export_force_sampling')
         layout.prop(operator, 'export_nla_strips')
+        layout.prop(operator, 'export_all_actions')
 
         row = layout.row()
         row.active = operator.export_force_sampling

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -252,14 +252,15 @@ class ExportGLTF2_Base:
     )
 
     export_nla_strips = BoolProperty(
-        name='NLA Strips',
-        description='Export NLA Strip animations',
+        name='Multiple Animations (from NLA Strips)',
+        description='Each animated object will use NLA strips for exported animations. Actions outside NLA strips will NOT be exported.',
         default=True
     )
     
     export_all_actions = BoolProperty(
         name='Export All Actions',
-        description='Include all actions outside of NLA strips',
+        description='Include all actions outside of NLA strips. '
+                    'WARNING: Multi-object scenes may export duplicate actions',
         default=False
     )
 
@@ -689,6 +690,8 @@ class GLTF_PT_export_animation(bpy.types.Panel):
         operator = sfile.active_operator
 
         layout.prop(operator, 'export_current_frame')
+        layout.prop(operator, 'export_nla_strips')
+        layout.prop(operator, 'export_all_actions')
 
 
 class GLTF_PT_export_animation_export(bpy.types.Panel):
@@ -723,8 +726,6 @@ class GLTF_PT_export_animation_export(bpy.types.Panel):
         layout.prop(operator, 'export_frame_range')
         layout.prop(operator, 'export_frame_step')
         layout.prop(operator, 'export_force_sampling')
-        layout.prop(operator, 'export_nla_strips')
-        layout.prop(operator, 'export_all_actions')
 
         row = layout.row()
         row.active = operator.export_force_sampling

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animations.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animations.py
@@ -198,6 +198,16 @@ def __get_blender_actions(blender_object: bpy.types.Object,
         if blender_object.animation_data.action is not None:
             blender_actions.append(blender_object.animation_data.action)
             blender_tracks[blender_object.animation_data.action.name] = None
+        
+        #Export all actions outside of NLA track
+        if export_settings['gltf_all_actions'] is True:
+            for action in bpy.data.actions:
+                if action is None:
+                    continue
+            
+                blender_actions.append(action)
+                blender_tracks[action.name] = None
+
 
         # Collect associated strips from NLA tracks.
         if export_settings['gltf_nla_strips'] is True:
@@ -231,5 +241,7 @@ def __get_blender_actions(blender_object: bpy.types.Object,
 
     # Remove duplicate actions.
     blender_actions = list(set(blender_actions))
+    # sort animations alphabetically (case insensitive) so they have a defined order and match Blender's Action list
+    blender_actions.sort(key = lambda a: a.name.lower())
 
     return [(blender_action, blender_tracks[blender_action.name]) for blender_action in blender_actions]

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animations.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animations.py
@@ -202,9 +202,6 @@ def __get_blender_actions(blender_object: bpy.types.Object,
         #Export all actions outside of NLA track
         if export_settings['gltf_all_actions'] is True:
             for action in bpy.data.actions:
-                if action is None:
-                    continue
-            
                 blender_actions.append(action)
                 blender_tracks[action.name] = None
 


### PR DESCRIPTION
Let users export all animations seen in Blender's Action list; Sort the animations so they alphabetically match the Action list in Blender.

All Action Export is the default behavior of Blender's FBX and Collada exporter, so users will think glTF animation export is broken when they see only [*some* actions export](https://github.com/KhronosGroup/glTF-Blender-IO/issues/578). Typically a user will have one blend for one character, so 'Export All Actions' is an expected default for the majority of use cases. Users can still uncheck 'Export All Actions' if they prefer to only export NLA-strip animations.