### PR TITLE
Import: import data from texture samplers

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
@@ -64,13 +64,13 @@ def __gather_name(blender_shader_node, export_settings):
 
 
 def __gather_wrap_s(blender_shader_node, export_settings):
-    if blender_shader_node.extension == 'CLIP':
+    if blender_shader_node.extension == 'EXTEND':
         return 33071
     return None
 
 
 def __gather_wrap_t(blender_shader_node, export_settings):
-    if blender_shader_node.extension == 'CLIP':
+    if blender_shader_node.extension == 'EXTEND':
         return 33071
     return None
 
@@ -79,7 +79,7 @@ def __gather_wrap_t(blender_shader_node, export_settings):
 def gather_sampler_from_texture_slot(blender_texture: bpy.types.TextureSlot, export_settings):
     magFilter = 9729
     wrap = 10497
-    if blender_texture.texture.extension == 'CLIP':
+    if blender_texture.texture.extension == 'EXTEND':
         wrap = 33071
 
     minFilter = 9986

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_material_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_material_utils.py
@@ -15,6 +15,8 @@
 import bpy
 from .gltf2_blender_image import BlenderImage
 from ..com.gltf2_blender_conversion import texture_transform_gltf_to_blender
+from io_scene_gltf2.io.com.gltf2_io import Sampler
+from io_scene_gltf2.io.com.gltf2_io_debug import print_console
 
 def make_texture_block(gltf, node_tree, tex_info, location, label, name=None, colorspace=None):
     """Creates a block of Shader Nodes for the given TextureInfo.
@@ -48,7 +50,12 @@ def make_texture_block(gltf, node_tree, tex_info, location, label, name=None, co
             if tex_img.image:
                 tex_img.image.colorspace_settings.is_data = True
 
-    # TODO do sampler
+    if pytexture.sampler is not None:
+        pysampler = gltf.data.samplers[pytexture.sampler]
+    else:
+        pysampler = Sampler.from_dict({})
+    set_filtering(tex_img, pysampler)
+    set_wrap_mode(tex_img, pysampler)
 
     # Mapping (transforms UVs for KHR_texture_transform)
 
@@ -93,3 +100,65 @@ def make_texture_block(gltf, node_tree, tex_info, location, label, name=None, co
     node_tree.links.new(tex_img.inputs[0], mapping.outputs[0])
 
     return tex_img
+
+NEAREST = 9728
+LINEAR = 9729
+NEAREST_MIPMAP_NEAREST = 9984
+LINEAR_MIPMAP_NEAREST = 9985
+NEAREST_MIPMAP_LINEAR = 9986
+LINEAR_MIPMAP_LINEAR = 9987
+
+def set_filtering(tex_img, pysampler):
+    """Set the filtering/interpolation on an Image Texture from the glTf sampler."""
+    minf = pysampler.min_filter
+    magf = pysampler.mag_filter
+
+    # Ignore mipmapping
+    if minf in [NEAREST_MIPMAP_NEAREST, NEAREST_MIPMAP_LINEAR]:
+        minf = NEAREST
+    elif minf in [LINEAR_MIPMAP_NEAREST, LINEAR_MIPMAP_LINEAR]:
+        minf = LINEAR
+
+    # If both are nearest or the only specified one was nearest, use nearest.
+    if (minf, magf) in [(NEAREST, NEAREST), (NEAREST, None), (None, NEAREST)]:
+        tex_img.interpolation = 'Closest'
+    else:
+        tex_img.interpolation = 'Linear'
+
+CLAMP_TO_EDGE = 33071
+MIRRORED_REPEAT = 33648
+REPEAT = 10497
+
+def set_wrap_mode(tex_img, pysampler):
+    """Set the extension on an Image Texture node from the pysampler."""
+    wrap_s = pysampler.wrap_s
+    wrap_t = pysampler.wrap_t
+
+    if wrap_s is None:
+        wrap_s = REPEAT
+    if wrap_t is None:
+        wrap_t = REPEAT
+
+    # The extension property on the Image Texture node can only handle the case
+    # where both directions are the same and are either REPEAT or CLAMP_TO_EDGE.
+    if (wrap_s, wrap_t) == (REPEAT, REPEAT):
+        extension = REPEAT
+    elif (wrap_s, wrap_t) == (CLAMP_TO_EDGE, CLAMP_TO_EDGE):
+        extension = CLAMP_TO_EDGE
+    else:
+        print_console('WARNING',
+            'texture wrap mode unsupported: (%s, %s)' % (wrap_name(wrap_s), wrap_name(wrap_t)),
+        )
+        # Default to repeat
+        extension = REPEAT
+
+    if extension == REPEAT:
+        tex_img.extension = 'REPEAT'
+    elif extension == CLAMP_TO_EDGE:
+        tex_img.extension = 'EXTEND'
+
+def wrap_name(wrap):
+    if wrap == CLAMP_TO_EDGE: return 'CLAMP_TO_EDGE'
+    if wrap == MIRRORED_REPEAT: return 'MIRRORED_REPEAT'
+    if wrap == REPEAT: return 'REPEAT'
+    return 'UNKNOWN (%s)' % wrap

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_material_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_material_utils.py
@@ -17,6 +17,7 @@ from .gltf2_blender_image import BlenderImage
 from ..com.gltf2_blender_conversion import texture_transform_gltf_to_blender
 from io_scene_gltf2.io.com.gltf2_io import Sampler
 from io_scene_gltf2.io.com.gltf2_io_debug import print_console
+from io_scene_gltf2.io.com.gltf2_io_constants import TextureFilter, TextureWrap
 
 def make_texture_block(gltf, node_tree, tex_info, location, label, name=None, colorspace=None):
     """Creates a block of Shader Nodes for the given TextureInfo.
@@ -101,33 +102,26 @@ def make_texture_block(gltf, node_tree, tex_info, location, label, name=None, co
 
     return tex_img
 
-NEAREST = 9728
-LINEAR = 9729
-NEAREST_MIPMAP_NEAREST = 9984
-LINEAR_MIPMAP_NEAREST = 9985
-NEAREST_MIPMAP_LINEAR = 9986
-LINEAR_MIPMAP_LINEAR = 9987
-
 def set_filtering(tex_img, pysampler):
     """Set the filtering/interpolation on an Image Texture from the glTf sampler."""
     minf = pysampler.min_filter
     magf = pysampler.mag_filter
 
     # Ignore mipmapping
-    if minf in [NEAREST_MIPMAP_NEAREST, NEAREST_MIPMAP_LINEAR]:
-        minf = NEAREST
-    elif minf in [LINEAR_MIPMAP_NEAREST, LINEAR_MIPMAP_LINEAR]:
-        minf = LINEAR
+    if minf in [TextureFilter.NearestMipmapNearest, TextureFilter.NearestMipmapLinear]:
+        minf = TextureFilter.Nearest
+    elif minf in [TextureFilter.LinearMipmapNearest, TextureFilter.LinearMipmapLinear]:
+        minf = TextureFilter.Linear
 
     # If both are nearest or the only specified one was nearest, use nearest.
-    if (minf, magf) in [(NEAREST, NEAREST), (NEAREST, None), (None, NEAREST)]:
+    if (minf, magf) in [
+        (TextureFilter.Nearest, TextureFilter.Nearest),
+        (TextureFilter.Nearest, None),
+        (None, TextureFilter.Nearest),
+    ]:
         tex_img.interpolation = 'Closest'
     else:
         tex_img.interpolation = 'Linear'
-
-CLAMP_TO_EDGE = 33071
-MIRRORED_REPEAT = 33648
-REPEAT = 10497
 
 def set_wrap_mode(tex_img, pysampler):
     """Set the extension on an Image Texture node from the pysampler."""
@@ -135,30 +129,30 @@ def set_wrap_mode(tex_img, pysampler):
     wrap_t = pysampler.wrap_t
 
     if wrap_s is None:
-        wrap_s = REPEAT
+        wrap_s = TextureWrap.Repeat
     if wrap_t is None:
-        wrap_t = REPEAT
+        wrap_t = TextureWrap.Repeat
 
     # The extension property on the Image Texture node can only handle the case
     # where both directions are the same and are either REPEAT or CLAMP_TO_EDGE.
-    if (wrap_s, wrap_t) == (REPEAT, REPEAT):
-        extension = REPEAT
-    elif (wrap_s, wrap_t) == (CLAMP_TO_EDGE, CLAMP_TO_EDGE):
-        extension = CLAMP_TO_EDGE
+    if (wrap_s, wrap_t) == (TextureWrap.Repeat, TextureWrap.Repeat):
+        extension = TextureWrap.Repeat
+    elif (wrap_s, wrap_t) == (TextureWrap.ClampToEdge, TextureWrap.ClampToEdge):
+        extension = TextureWrap.ClampToEdge
     else:
         print_console('WARNING',
             'texture wrap mode unsupported: (%s, %s)' % (wrap_name(wrap_s), wrap_name(wrap_t)),
         )
         # Default to repeat
-        extension = REPEAT
+        extension = TextureWrap.Repeat
 
-    if extension == REPEAT:
+    if extension == TextureWrap.Repeat:
         tex_img.extension = 'REPEAT'
-    elif extension == CLAMP_TO_EDGE:
+    elif extension == TextureWrap.ClampToEdge:
         tex_img.extension = 'EXTEND'
 
 def wrap_name(wrap):
-    if wrap == CLAMP_TO_EDGE: return 'CLAMP_TO_EDGE'
-    if wrap == MIRRORED_REPEAT: return 'MIRRORED_REPEAT'
-    if wrap == REPEAT: return 'REPEAT'
+    if wrap == TextureWrap.ClampToEdge: return 'CLAMP_TO_EDGE'
+    if wrap == TextureWrap.MirroredRepeat: return 'MIRRORED_REPEAT'
+    if wrap == TextureWrap.Repeat: return 'REPEAT'
     return 'UNKNOWN (%s)' % wrap

--- a/addons/io_scene_gltf2/io/com/gltf2_io_constants.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_constants.py
@@ -103,6 +103,21 @@ class DataType:
         }[num_elems]
 
 
+class TextureFilter(IntEnum):
+    Nearest = 9728
+    Linear = 9729
+    NearestMipmapNearest = 9984
+    LinearMipmapNearest = 9985
+    NearestMipmapLinear = 9986
+    LinearMipmapLinear = 9987
+
+
+class TextureWrap(IntEnum):
+    ClampToEdge = 33071
+    MirroredRepeat = 33648
+    Repeat = 10497
+
+
 #################
 # LEGACY DEFINES
 


### PR DESCRIPTION
Imports the texture filtering (eg. linear or nearest) and the wrap mode (eg. repeat) for textures. The following will now roundtrip successfully

![example](https://user-images.githubusercontent.com/11024420/68831066-16198b80-0673-11ea-838c-ea105ae871b5.png)

Of the nine possible wrap modes in glTF, only two (REPEATxREPEAT and CLAMPxCLAMP) are possible in Blender (using the `extension` property at least). Blender doesn't support different modes in the s and t directions and it doesn't support MIRRORED_REPEAT. So in the end only CLAMPxCLAMP (imported as EXTEND) had been added. A warning is now printed for the wrap modes we can't handle.

The exporter was incorrectly exporting the CLIP mode as CLAMPxCLAMP instead of the EXTEND mode, so that's also been fixed too.

Closes #687.