### PR TITLE
Export: better performance by avoiding pointless image->python data->image roundtrips

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -24,7 +24,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_search_node_tree
 from io_scene_gltf2.io.exp import gltf2_io_binary_data
 from io_scene_gltf2.io.exp import gltf2_io_image_data
 from io_scene_gltf2.io.com import gltf2_io_debug
-from io_scene_gltf2.blender.exp import gltf2_blender_image
+from io_scene_gltf2.blender.exp.gltf2_blender_image import Channel, ExportImage
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 
 
@@ -139,13 +139,13 @@ def __is_slot(sockets_or_slots):
     return isinstance(sockets_or_slots[0], bpy.types.MaterialTextureSlot)
 
 
-def __get_image_data(sockets_or_slots, export_settings) -> gltf2_blender_image.ExportImage:
+def __get_image_data(sockets_or_slots, export_settings) -> ExportImage:
     # For shared resources, such as images, we just store the portion of data that is needed in the glTF property
     # in a helper class. During generation of the glTF in the exporter these will then be combined to actual binary
     # resources.
     if __is_socket(sockets_or_slots):
         results = [__get_tex_from_socket(socket, export_settings) for socket in sockets_or_slots]
-        composed_image = None
+        composed_image = ExportImage()
         for result, socket in zip(results, sockets_or_slots):
             if result.shader_node.image.channels == 0:
                 gltf2_io_debug.print_console("WARNING",
@@ -154,44 +154,45 @@ def __get_image_data(sockets_or_slots, export_settings) -> gltf2_blender_image.E
                 continue
 
             # rudimentarily try follow the node tree to find the correct image data.
-            source_channel = 0
+            src_chan = 0
             for elem in result.path:
                 if isinstance(elem.from_node, bpy.types.ShaderNodeSeparateRGB):
-                    source_channel = {
-                        'R': 0,
-                        'G': 1,
-                        'B': 2
+                   src_chan = {
+                        'R': Channel.R,
+                        'G': Channel.G,
+                        'B': Channel.B,
                     }[elem.from_socket.name]
 
-            image = gltf2_blender_image.ExportImage.from_blender_image(result.shader_node.image)
-
-            target_channel = None
+            dst_chan = None
 
             # some sockets need channel rewriting (gltf pbr defines fixed channels for some attributes)
             if socket.name == 'Metallic':
-                target_channel = 2
+                dst_chan = Channel.B
             elif socket.name == 'Roughness':
-                target_channel = 1
+                dst_chan = Channel.G
             elif socket.name == 'Occlusion' and len(sockets_or_slots) > 1 and sockets_or_slots[1] is not None:
-                target_channel = 0
+                dst_chan = Channel.R
             elif socket.name == 'Alpha' and len(sockets_or_slots) > 1 and sockets_or_slots[1] is not None:
-                composed_image.set_alpha(True)
-                target_channel = 3
+                dst_chan = Channel.A
 
-            if target_channel is not None:
-                if composed_image is None:
-                    composed_image = gltf2_blender_image.ExportImage.white_image(image.width, image.height)
+            if dst_chan is not None:
+                composed_image.fill_image(result.shader_node.image, dst_chan, src_chan)
 
-                composed_image[target_channel] = image[source_channel]
+                # Since metal/roughness are always used together, make sure
+                # the other channel is filled.
+                if socket.name == 'Metallic' and not composed_image.is_filled(Channel.G):
+                    composed_image.fill_white(Channel.G)
+                elif socket.name == 'Roughness' and not composed_image.is_filled(Channel.B):
+                    composed_image.fill_white(Channel.B)
             else:
                 # copy full image...eventually following sockets might overwrite things
-                composed_image = image
+                composed_image = ExportImage.from_blender_image(result.shader_node.image)
 
         return composed_image
 
     elif __is_slot(sockets_or_slots):
         texture = __get_tex_from_slot(sockets_or_slots[0])
-        image = gltf2_blender_image.ExportImage.from_blender_image(texture.image)
+        image = ExportImage.from_blender_image(texture.image)
         return image
     else:
         raise NotImplementedError()

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -37,8 +37,8 @@ def gather_image(
         return None
 
     image_data = __get_image_data(blender_shader_sockets_or_texture_slots, export_settings)
-    if image_data is None:
-        # The blender image has no data
+    if image_data.empty():
+        # The export image has no data
         return None
 
     mime_type = __gather_mime_type(blender_shader_sockets_or_texture_slots, export_settings)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -83,6 +83,9 @@ class ExportImage:
     def is_filled(self, chan: Channel) -> bool:
         return chan in self.fills
 
+    def empty(self) -> bool:
+        return not self.fills
+
     def __on_happy_path(self) -> bool:
         # Whether there is an existing Blender image we can use for this
         # ExportImage because all the channels come from the matching


### PR DESCRIPTION
This PR creates a "happy path" for exporting images where we don't have to round-trip through Python data, which is much faster and uses much less memory.

Fixes #790 and helps with export times generally.

## Problem

The glTF spec requires that eg. the metalllicRoughness texture have the metalness in B and the roughness in G. The exporter will assemble the appropriate image for this even if the material graph reads the metalness from, say, the R channel of one image and the roughness from the G channel of another.

To do this, *all* images are decoded to python data. The code sequence for this looks roughly like this:

    creating export image:
        pixel_data = np.array(blender_image.pixels[:])              (★1)

    pixel data may be modified to insert channels

    encoding export image:
        if created from blender image that's on disk:
            read back data from the disk

        tmp_image = bpy.data.images.new(...)
        tmp_image.pixels = pixel_data.img.flatten().tolist()        (★2)
        save tmp_image to disk and read it back

The lines marked with a ★ are slow and eat up loooots of memory. Eg. `blender_image.pixels[:]` is going to allocate a tuple of width×height×channels floats. It's really bad.

As you can see, sometimes it was possible to skip ★2 but everything did ★1.

However, for many images, like all color textures, normals, or metal/rough/occlusion textures that are already packed the way the exporter likes, this is totally wasted effort: the image data is converted to python data, nothing gets changed, and the python data is converted back to a new temp image, which is then encoded to disk and read back.

In this case it would have been better to just encode the original image!

## Solution

Change `ExportImage` to store some declarative data saying how it's channels should be filled in (ex. it says its R channel should be filled by the G channel of such-and-such Blender image) instead of storing a numpy array. I tried to write a good docstring here, so see it for details.

Then when it comes time to encode, we examine that data and determine whether all we need to do is save some existing Blender image (happy path), or whether we need to do the pixel manipulation to repack the channels (unhappy path).

The unhappy path is basically the same as before, but the happy path can be significantly better :)

## Results

Results seem pretty good. Obviously they depend on how much you can stay on the happy path but since that should include the most common texture types (base color, normal, etc.) it should be pretty often.

Export times:

| | Before | After|
|:---|---|---|
| #790 (8192x8192 normalmap) | OOM | 3s |
| DamagedHelmet | 15s | 7s |
| VC | 17s | 6s |
| Sponza | 91s | 38s |

Reviews and testing are appreciated!