### PR TITLE
Export Animation Names in Consistent Order

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animations.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animations.py
@@ -231,5 +231,7 @@ def __get_blender_actions(blender_object: bpy.types.Object,
 
     # Remove duplicate actions.
     blender_actions = list(set(blender_actions))
+    # sort animations alphabetically (case insensitive) so they have a defined order and match Blender's Action list
+    blender_actions.sort(key = lambda a: a.name.lower())
 
     return [(blender_action, blender_tracks[blender_action.name]) for blender_action in blender_actions]


### PR DESCRIPTION
Animations were previously exported in random order, this is problematic for consistent file diffs and in other use cases it makes it harder for users to find their animation names quickly in external viewers. Make actions export with a defined order that matches the actions list in Blender