### PR TITLE
Import: name layers like Col, UVMap instead of COLOR_0, TEXCOORD_0

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
@@ -63,11 +63,11 @@ class BlenderKHR_materials_pbrSpecularGlossiness():
                 # Create vertexcolor node to get COLOR_0 data
                 if bpy.app.version < (2, 81, 8):
                     attribute_node = node_tree.nodes.new('ShaderNodeAttribute')
-                    attribute_node.attribute_name = 'COLOR_0'
+                    attribute_node.attribute_name = 'Col'
                     attribute_node.location = -500, 0
                 else:
                     vertexcolor_node = node_tree.nodes.new('ShaderNodeVertexColor')
-                    vertexcolor_node.layer_name = 'COLOR_0'
+                    vertexcolor_node.layer_name = 'Col'
                     vertexcolor_node.location = -500, 0
 
                 # links
@@ -84,10 +84,10 @@ class BlenderKHR_materials_pbrSpecularGlossiness():
                 # Create vertexcolor / separate / math nodes
                 if bpy.app.version < (2, 81, 8):
                     attribute_node = node_tree.nodes.new('ShaderNodeAttribute')
-                    attribute_node.attribute_name = 'COLOR_0'
+                    attribute_node.attribute_name = 'Col'
                 else:
                     vertexcolor_node = node_tree.nodes.new('ShaderNodeVertexColor')
-                    vertexcolor_node.layer_name = 'COLOR_0'
+                    vertexcolor_node.layer_name = 'Col'
 
                 separate_vertex_color = node_tree.nodes.new('ShaderNodeSeparateRGB')
                 math_vc_R = node_tree.nodes.new('ShaderNodeMath')
@@ -167,11 +167,11 @@ class BlenderKHR_materials_pbrSpecularGlossiness():
                 # Create vertexcolor / separate / math nodes
                 if bpy.app.version < (2, 81, 8):
                     attribute_node = node_tree.nodes.new('ShaderNodeAttribute')
-                    attribute_node.attribute_name = 'COLOR_0'
+                    attribute_node.attribute_name = 'Col'
                     attribute_node.location = -2000, 250
                 else:
                     vertexcolor_node = node_tree.nodes.new('ShaderNodeVertexColor')
-                    vertexcolor_node.layer_name = 'COLOR_0'
+                    vertexcolor_node.layer_name = 'Col'
                     vertexcolor_node.location = -2000, 250
 
                 separate_vertex_color = node_tree.nodes.new('ShaderNodeSeparateRGB')

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_map_normal.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_map_normal.py
@@ -66,7 +66,7 @@ class BlenderNormalMap():
             if 'texCoord' in tex_info.extensions['KHR_texture_transform']:
                 texcoord_idx = tex_info.extensions['KHR_texture_transform']['texCoord']
 
-        normalmap_node.uv_map = 'TEXCOORD_%d' % texcoord_idx
+        normalmap_node.uv_map = 'UVMap' if texcoord_idx == 0 else 'UVMap.%03d' % texcoord_idx
 
         # Set strength
         if pymaterial.normal_texture.scale is not None:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_material_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_material_utils.py
@@ -94,7 +94,7 @@ def make_texture_block(gltf, node_tree, tex_info, location, label, name=None, co
         if 'texCoord' in tex_info.extensions['KHR_texture_transform']:
             texcoord_idx = tex_info.extensions['KHR_texture_transform']['texCoord']
 
-    uv_map.uv_map = 'TEXCOORD_%d' % texcoord_idx
+    uv_map.uv_map = 'UVMap' if texcoord_idx == 0 else 'UVMap.%03d' % texcoord_idx
 
     # Links
     node_tree.links.new(mapping.inputs[0], uv_map.outputs[0])

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -77,11 +77,11 @@ class BlenderPbr():
                 # Create attribute node to get COLOR_0 data
                 if bpy.app.version < (2, 81, 8):
                     attribute_node = node_tree.nodes.new('ShaderNodeAttribute')
-                    attribute_node.attribute_name = 'COLOR_0'
+                    attribute_node.attribute_name = 'Col'
                     attribute_node.location = -500, 0
                 else:
                     vertexcolor_node = node_tree.nodes.new('ShaderNodeVertexColor')
-                    vertexcolor_node.layer_name = 'COLOR_0'
+                    vertexcolor_node.layer_name = 'Col'
                     vertexcolor_node.location = -500, 0
 
                 if nodetype == "principled":
@@ -108,10 +108,10 @@ class BlenderPbr():
                 # Create attribute / separate / math nodes
                 if bpy.app.version < (2, 81, 8):
                     attribute_node = node_tree.nodes.new('ShaderNodeAttribute')
-                    attribute_node.attribute_name = 'COLOR_0'
+                    attribute_node.attribute_name = 'Col'
                 else:
                     vertexcolor_node = node_tree.nodes.new('ShaderNodeVertexColor')
-                    vertexcolor_node.layer_name = 'COLOR_0'
+                    vertexcolor_node.layer_name = 'Col'
 
                 vc_mult_node = node_tree.nodes.new('ShaderNodeMixRGB')
                 vc_mult_node.blend_type = 'MULTIPLY'
@@ -159,11 +159,11 @@ class BlenderPbr():
                 # Create attribute / separate / math nodes
                 if bpy.app.version < (2, 81, 8):
                     attribute_node = node_tree.nodes.new('ShaderNodeAttribute')
-                    attribute_node.attribute_name = 'COLOR_0'
+                    attribute_node.attribute_name = 'Col'
                     attribute_node.location = -2000, 250
                 else:
                     vertexcolor_node = node_tree.nodes.new('ShaderNodeVertexColor')
-                    vertexcolor_node.layer_name = 'COLOR_0'
+                    vertexcolor_node.layer_name = 'Col'
                     vertexcolor_node.location = -2000, 250
 
                 vc_mult_node = node_tree.nodes.new('ShaderNodeMixRGB')

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
@@ -126,10 +126,10 @@ class BlenderPrimitive():
                 )
                 break
 
-            layer_name = 'COLOR_%d' % set_num
+            layer_name = 'Col' if set_num == 0 else 'Col.%03d' % set_num
             layer = BlenderPrimitive.get_layer(bme.loops.layers.color, layer_name)
 
-            colors = BinaryData.get_data_from_accessor(gltf, attributes[layer_name], cache=True)
+            colors = BinaryData.get_data_from_accessor(gltf, attributes['COLOR_%d' % set_num], cache=True)
 
             # Check whether Blender takes RGB or RGBA colors (old versions only take RGB)
             is_rgba = len(colors[0]) == 4

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
@@ -161,10 +161,10 @@ class BlenderPrimitive():
                 )
                 break
 
-            layer_name = 'TEXCOORD_%d' % set_num
+            layer_name = 'UVMap' if set_num == 0 else 'UVMap.%03d' % set_num
             layer = BlenderPrimitive.get_layer(bme.loops.layers.uv, layer_name)
 
-            uvs = BinaryData.get_data_from_accessor(gltf, attributes[layer_name], cache=True)
+            uvs = BinaryData.get_data_from_accessor(gltf, attributes['TEXCOORD_%d' % set_num], cache=True)
 
             for bidx, pidx in vert_idxs:
                 # UV transform


### PR DESCRIPTION
This is a minor change.

Gives UV and vertex color layers the names they would normally have when created in Blender.

Before/After:

![names-compare](https://user-images.githubusercontent.com/11024420/70200110-15f03700-16d9-11ea-8272-77a115012050.png)
