### PR TITLE
Camera import fixes

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_camera.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_camera.py
@@ -35,6 +35,11 @@ class BlenderCamera():
         # Blender create a perspective camera by default
         if pycamera.type == "orthographic":
             cam.type = "ORTHO"
+        else:
+            if hasattr(pycamera.perspective, "yfov"):
+                cam.angle_y = pycamera.perspective.yfov
+                cam.lens_unit = "FOV"
+                cam.sensor_fit = "VERTICAL"
 
         # TODO: lot's of work for camera here...
         if hasattr(pycamera, "znear"):


### PR DESCRIPTION
According to the specification:

- [Node rotation is stored as quaternion](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#node)
- [Camera field is stored as .yfov](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#cameras)

Tested OK for my use, but I have not written tests.
