### PR TITLE
Only make extensions required if they are really required

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
@@ -298,7 +298,8 @@ class GlTF2Exporter:
         if isinstance(node, gltf2_io_extensions.Extension):
             extension = self.__traverse(node.extension)
             self.__append_unique_and_get_index(self.__gltf.extensions_used, node.name)
-            self.__append_unique_and_get_index(self.__gltf.extensions_required, node.name)
+            if node.required:
+                self.__append_unique_and_get_index(self.__gltf.extensions_required, node.name)
 
             # extensions that lie in the root of the glTF.
             # They need to be converted to a reference at place of occurrence


### PR DESCRIPTION
I have a hacked version that adds some super custom extensions to the blender export. the exporter is gladly quite easy to extend. Unfortunately right now my custom extension is always exported as being required even though I register it like this in gather_materials:

```
 extensions["AA_shadow"] = Extension("AA_shadow", {"shadowTexture": shadow}, False)
```

The last parameter is intended to control if the extension is required or not. unfortunately in the final export step this is not being honored right now