### PR TITLE
Allow addons with multiple extensions

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -353,7 +353,7 @@ class ExportGLTF2_Base:
             preferences = bpy.context.preferences
         for addon_name in preferences.addons.keys():
             try:
-                if hasattr(sys.modules[addon_name], 'glTF2ExportUserExtension'):
+                if hasattr(sys.modules[addon_name], 'glTF2ExportUserExtension') or hasattr(sys.modules[addon_name], 'glTF2ExportUserExtensions'):
                     extension_panel_unregister_functors.append(sys.modules[addon_name].register_panel())
                     self.has_active_extenions = True
             except Exception:
@@ -464,6 +464,10 @@ class ExportGLTF2_Base:
             if hasattr(sys.modules[addon_name], 'glTF2ExportUserExtension'):
                 extension_ctor = sys.modules[addon_name].glTF2ExportUserExtension
                 user_extensions.append(extension_ctor())
+            if hasattr(sys.modules[addon_name], 'glTF2ExportUserExtensions'):
+                extension_ctors = sys.modules[addon_name].glTF2ExportUserExtensions
+                for extension_ctor in extension_ctors:
+                    user_extensions.append(extension_ctor())
         export_settings['gltf_user_extensions'] = user_extensions
 
         return gltf2_blender_export.save(context, export_settings)


### PR DESCRIPTION
This patch allows addons with multiple user extensions. It does so by returning a list of extension constructors which is then added to the list of extensions. 