### PR TITLE
Export: be slightly smarter when exporting existing images

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -179,11 +179,15 @@ class ExportImage:
 
     def __encode_from_image(self, image: bpy.types.Image) -> bytes:
         # See if there is an existing file we can use.
-        if self.file_format == image.file_format:
-            src_path = bpy.path.abspath(image.filepath_raw)
-            if os.path.isfile(src_path):
-                with open(src_path, 'rb') as f:
-                    return f.read()
+        if image.source == 'FILE' and image.file_format == self.file_format and \
+                not image.is_dirty:
+            if image.packed_file is not None:
+                return image.packed_file.data
+            else:
+                src_path = bpy.path.abspath(image.filepath_raw)
+                if os.path.isfile(src_path):
+                    with open(src_path, 'rb') as f:
+                        return f.read()
 
         # Copy to a temp image and save.
         tmp_image = None


### PR DESCRIPTION
Small followup to #820.

When we go to encode an existing Blender image:

* Do not try to use a file for images that don't come from a file.
* Do not try to use a file for images that are dirty.
* Do try to use a packed file if one exists (note that the importer packs images by default).