### PR TITLE
Move .gitignore from addon folder to root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ desktop.ini
 yarn-error.log
 node_modules
 /tests_out
+__pycache__
+*.pyc

--- a/addons/io_scene_gltf2/.gitignore
+++ b/addons/io_scene_gltf2/.gitignore
@@ -1,9 +1,0 @@
-__pycache__/
-blender/__pycache__/
-blender/common/__pycache__/
-blender/export/__pycache__/
-blender/import/__pycache__/
-io/common/__pycache__/
-io/export/__pycache__/
-io/import/__pycache__/
-**.pyc


### PR DESCRIPTION
This is just a nitpick, but I don't see any reason not to move this all up to root.