### PR TITLE
Import/Perf: speed up animation keyframe creation

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
@@ -58,25 +58,31 @@ def make_fcurve(action, co, data_path, index=0, group_name=None, interpolation=N
         group = action.groups[group_name]
         fcurve.group = group
 
-    fcurve.keyframe_points.add(len(co) // 2)
-    fcurve.keyframe_points.foreach_set('co', co)
-
-    # Setting interpolation
-    if interpolation == 'CUBICSPLINE':
-        for kf in fcurve.keyframe_points:
-            kf.interpolation = 'BEZIER'
-            kf.handle_right_type = 'AUTO'
-            kf.handle_left_type = 'AUTO'
+    # Set the default keyframe type in the prefs, then make keyframes
+    if bpy.app.version < (2, 80, 0):
+        prefs = bpy.context.user_preferences.edit
     else:
-        if interpolation == 'LINEAR':
-            blender_interpolation = 'LINEAR'
-        elif interpolation == 'STEP':
-            blender_interpolation = 'CONSTANT'
-        else:
-            blender_interpolation = 'LINEAR'
-        for kf in fcurve.keyframe_points:
-            kf.interpolation = blender_interpolation
+        prefs = bpy.context.preferences.edit
+    try:
+        orig_interp_type = prefs.keyframe_new_interpolation_type
+        orig_handle_type = prefs.keyframe_new_handle_type
 
+        if interpolation == 'CUBICSPLINE':
+            prefs.keyframe_new_interpolation_type = 'BEZIER'
+            prefs.keyframe_new_handle_type = 'AUTO'
+        elif interpolation == 'STEP':
+            prefs.keyframe_new_interpolation_type = 'CONSTANT'
+        elif interpolation == 'LINEAR':
+            prefs.keyframe_new_interpolation_type = 'LINEAR'
+
+        fcurve.keyframe_points.add(len(co) // 2)
+
+    finally:
+        # Restore original prefs
+        prefs.keyframe_new_interpolation_type = orig_interp_type
+        prefs.keyframe_new_handle_type = orig_handle_type
+
+    fcurve.keyframe_points.foreach_set('co', co)
     fcurve.update() # force updating tangents (this may change when tangent will be managed)
 
     return fcurve


### PR DESCRIPTION
We currently loop over all keyframes to set their interpolation type. It's a significant speedup to change the options controlling the default keyframe interpolation in the prefs, create the keyframes, then change the prefs back.

It's these options in the preferences, under Animation > F-Curves:

![prefs](https://user-images.githubusercontent.com/11024420/72025377-8c82d600-323d-11ea-85f8-6fc25618ea51.png)

Gives a pretty great speedup for anything with animations. VC is especially good.

| Model | master | this branch |
|:--|:--|:--|
| [VC](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/VC) | 2.8s | 0.5s |
| [Brainstem](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BrainStem) | 1.5s | 1.1s |
| Level (#862) | 17s | 13s |