### PR TITLE
Add support for use_inherit_rotation and inherit_scale.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -162,21 +162,12 @@ def get_bone_matrix(blender_object_if_armature: typing.Optional[bpy.types.Object
             if bake_bone is None:
                 matrix = pbone.matrix_basis.copy()
             else:
-                if bpy.app.version >= (2, 81, 0):
-                    if (pbone.bone.use_inherit_rotation == False or pbone.bone.inherit_scale != "FULL") and pbone.parent != None:
-                        rest_mat = (pbone.parent.bone.matrix_local.inverted_safe() @ pbone.bone.matrix_local)
-                        matrix = (rest_mat.inverted_safe() @ pbone.parent.matrix.inverted_safe() @ pbone.matrix)
-                    else:
-                        matrix = pbone.matrix
-                        matrix = blender_object_if_armature.convert_space(pose_bone=pbone, matrix=matrix, from_space='POSE', to_space='LOCAL')
-
-                else: #Using Blender 2.80
-                    if (pbone.bone.use_inherit_rotation == False or pbone.bone.use_inherit_scale == False) and pbone.parent != None:
-                        rest_mat = (pbone.parent.bone.matrix_local.inverted_safe() @ pbone.bone.matrix_local)
-                        matrix = (rest_mat.inverted_safe() @ pbone.parent.matrix.inverted_safe() @ pbone.matrix)
-                    else:
-                        matrix = pbone.matrix
-                        matrix = blender_object_if_armature.convert_space(pose_bone=pbone, matrix=matrix, from_space='POSE', to_space='LOCAL')
+                if (pbone.bone.use_inherit_rotation == False or pbone.bone.inherit_scale != "FULL") and pbone.parent != None:
+                    rest_mat = (pbone.parent.bone.matrix_local.inverted_safe() @ pbone.bone.matrix_local)
+                    matrix = (rest_mat.inverted_safe() @ pbone.parent.matrix.inverted_safe() @ pbone.matrix)
+                else:
+                    matrix = pbone.matrix
+                    matrix = blender_object_if_armature.convert_space(pose_bone=pbone, matrix=matrix, from_space='POSE', to_space='LOCAL')
 
 
             data[frame][pbone.name] = matrix

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -162,8 +162,23 @@ def get_bone_matrix(blender_object_if_armature: typing.Optional[bpy.types.Object
             if bake_bone is None:
                 matrix = pbone.matrix_basis.copy()
             else:
-                matrix = pbone.matrix
-                matrix = blender_object_if_armature.convert_space(pose_bone=pbone, matrix=matrix, from_space='POSE', to_space='LOCAL')
+                if bpy.app.version >= (2, 81, 0):
+                    if (pbone.bone.use_inherit_rotation == False or pbone.bone.inherit_scale != "FULL") and pbone.parent != None:
+                        rest_mat = (pbone.parent.bone.matrix_local.inverted_safe() @ pbone.bone.matrix_local)
+                        matrix = (rest_mat.inverted_safe() @ pbone.parent.matrix.inverted_safe() @ pbone.matrix)
+                    else:
+                        matrix = pbone.matrix
+                        matrix = blender_object_if_armature.convert_space(pose_bone=pbone, matrix=matrix, from_space='POSE', to_space='LOCAL')
+
+                else: #Using Blender 2.80
+                    if (pbone.bone.use_inherit_rotation == False or pbone.bone.use_inherit_scale == False) and pbone.parent != None:
+                        rest_mat = (pbone.parent.bone.matrix_local.inverted_safe() @ pbone.bone.matrix_local)
+                        matrix = (rest_mat.inverted_safe() @ pbone.parent.matrix.inverted_safe() @ pbone.matrix)
+                    else:
+                        matrix = pbone.matrix
+                        matrix = blender_object_if_armature.convert_space(pose_bone=pbone, matrix=matrix, from_space='POSE', to_space='LOCAL')
+
+
             data[frame][pbone.name] = matrix
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_joints.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_joints.py
@@ -43,7 +43,14 @@ def gather_joint(blender_object, blender_bone, export_settings):
     else:
         correction_matrix_local = gltf2_blender_math.multiply(
             blender_bone.parent.bone.matrix_local.inverted(), blender_bone.bone.matrix_local)
-    matrix_basis = blender_bone.matrix_basis
+
+    if (blender_bone.bone.use_inherit_rotation == False or blender_bone.bone.inherit_scale != "FULL") and blender_bone.parent != None:
+        rest_mat = (blender_bone.parent.bone.matrix_local.inverted_safe() @ blender_bone.bone.matrix_local)
+        matrix_basis = (rest_mat.inverted_safe() @ blender_bone.parent.matrix.inverted_safe() @ blender_bone.matrix)
+    else:
+        matrix_basis = blender_bone.matrix
+        matrix_basis = blender_object.convert_space(pose_bone=blender_bone, matrix=matrix_basis, from_space='POSE', to_space='LOCAL')
+
     trans, rot, sca = gltf2_blender_extract.decompose_transition(
         gltf2_blender_math.multiply(correction_matrix_local, matrix_basis), export_settings)
     translation, rotation, scale = (None, None, None)


### PR DESCRIPTION
Should fix exporting of animations that have use_inherit_rotation set to false and/or inherit_scale not set to "FULL".

Not 100% sure it works perfectly under all circumstances at the moment. I have tested it with my own models and some test animations (see attached zip) and these export correctly. But there might still be some edge-cases where it fails.

Tested on Blender 2.81a.

Fixes #791

[TestModels.zip](https://github.com/KhronosGroup/glTF-Blender-IO/files/4082890/TestModels.zip)
