### PR TITLE
Export: implement image options change (#882)

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -113,18 +113,18 @@ class ExportGLTF2_Base:
 
     export_image_format = EnumProperty(
         name='Images',
-        items=(('NAME', 'Automatic',
-                'Determine the image format from the blender image name'),
+        items=(('AUTO', 'Automatic',
+                'Save PNGs as PNGs and JPEGs as JPEGs.\n'
+                'If neither one, use PNG'),
                 ('JPEG', 'JPEG Format (.jpg)',
-                'Encode and save textures as .jpg files. Be aware of a possible loss in quality'),
-               ('PNG', 'PNG Format (.png)',
-                'Encode and save textures as .png files')
+                'Save images as JPEGs. (Images that need alpha are saved as PNGs though.)\n'
+                'Be aware of a possible loss in quality'),
                ),
         description=(
             'Output format for images. PNG is lossless and generally preferred, but JPEG might be preferable for web '
             'applications due to the smaller file size'
         ),
-        default='NAME'
+        default='AUTO'
     )
 
     export_texture_dir = StringProperty(


### PR DESCRIPTION
Implements #882, see there for details.

This works especially well for re-exporting imported glTF files since their image names don't usually end in `.jpg`/`.jpeg`. For another example of a file helped by avoiding the JPEG->PNG re-encode, DamagedHelmet goes from

* Export Time: 3.2s → 2.2s
* Filesize: 16M → 8M