### PR TITLE
Import/Perf: pick low-hanging performance fruit for big meshes

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -125,19 +125,14 @@ class BlenderMesh():
         if gltf.import_settings['import_shading'] == "NORMALS":
             mesh.create_normals_split()
 
-        # use_smooth for faces
+        use_smooths = []  # whether to smooth for each poly
         face_idx = 0
         for prim in pymesh.primitives:
-            if 'NORMAL' not in prim.attributes:
-                face_idx += prim.num_faces
-                continue
-
-            if gltf.import_settings['import_shading'] == "FLAT":
-                for fi in range(face_idx, face_idx + prim.num_faces):
-                    mesh.polygons[fi].use_smooth = False
+            if gltf.import_settings['import_shading'] == "FLAT" or \
+                    'NORMAL' not in prim.attributes:
+                use_smooths += [False] * prim.num_faces
             elif gltf.import_settings['import_shading'] == "SMOOTH":
-                for fi in range(face_idx, face_idx + prim.num_faces):
-                    mesh.polygons[fi].use_smooth = True
+                use_smooths += [True] * prim.num_faces
             elif gltf.import_settings['import_shading'] == "NORMALS":
                 mesh_loops = mesh.loops
                 for fi in range(face_idx, face_idx + prim.num_faces):
@@ -147,14 +142,16 @@ class BlenderMesh():
                     for loop_idx in range(poly.loop_start, poly.loop_start + poly.loop_total):
                         vi = mesh_loops[loop_idx].vertex_index
                         if poly.normal.dot(bme.verts[vi].normal) <= 0.9999999:
-                            poly.use_smooth = True
+                            use_smooths.append(True)
                             break
-
+                    else:
+                        use_smooths.append(False)
             else:
                 # shouldn't happen
-                pass
+                assert False
 
             face_idx += prim.num_faces
+        mesh.polygons.foreach_set('use_smooth', use_smooths)
 
         # Custom normals, now that every update is done
         if gltf.import_settings['import_shading'] == "NORMALS":

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
@@ -140,15 +140,15 @@ class BlenderPrimitive():
                 )
 
             for bidx, pidx in vert_idxs:
+                color = colors[pidx]
+                col = (
+                    color_linear_to_srgb(color[0]),
+                    color_linear_to_srgb(color[1]),
+                    color_linear_to_srgb(color[2]),
+                    color[3] if is_rgba else 1.0,
+                )[:blender_num_components]
                 for loop in bme_verts[bidx].link_loops:
-                    color = colors[pidx]
-                    col = (
-                        color_linear_to_srgb(color[0]),
-                        color_linear_to_srgb(color[1]),
-                        color_linear_to_srgb(color[2]),
-                        color[3] if is_rgba else 1.0,
-                    )
-                    loop[layer] = col[:blender_num_components]
+                    loop[layer] = col
 
             set_num += 1
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
@@ -96,9 +96,10 @@ class BlenderPrimitive():
         pyprimitive.num_faces = 0
         for face in faces:
             try:
-                face = bme_faces.new(tuple(
-                    bme_verts[pidx_to_bidx[i]]
-                    for i in face
+                face = bme_faces.new((
+                    bme_verts[pidx_to_bidx[face[0]]],
+                    bme_verts[pidx_to_bidx[face[1]]],
+                    bme_verts[pidx_to_bidx[face[2]]],
                 ))
 
                 if material_index is not None:


### PR DESCRIPTION
So I tried importing the model from [T72167: glTF file loads extremely slowly (5+ min)](https://developer.blender.org/T72167). Seems a lot of time is spent in mesh creation, which is pretty slow for big models, but there was some low-hanging fruit that was really easy to pick. This knocks off about 40% of the import time for me.

| Shading option | before | after |
|:---|:---|:---|
| Use Normal Data | 4 min 6 sec | 2 min 30 sec |
| Smooth Shading | 3 min 12 sec | 1 min 38 sec |

The difference is pretty much undetectable in small models.