### PR TITLE
Export/UserExts: bugfix for when addons are missing script files

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -471,11 +471,15 @@ class ExportGLTF2_Base:
         else:
             preferences = bpy.context.preferences
         for addon_name in preferences.addons.keys():
-            if hasattr(sys.modules[addon_name], 'glTF2ExportUserExtension'):
-                extension_ctor = sys.modules[addon_name].glTF2ExportUserExtension
+            try:
+                module = sys.modules[addon_name]
+            except Exception:
+                continue
+            if hasattr(module, 'glTF2ExportUserExtension'):
+                extension_ctor = module.glTF2ExportUserExtension
                 user_extensions.append(extension_ctor())
-            if hasattr(sys.modules[addon_name], 'glTF2ExportUserExtensions'):
-                extension_ctors = sys.modules[addon_name].glTF2ExportUserExtensions
+            if hasattr(module, 'glTF2ExportUserExtensions'):
+                extension_ctors = module.glTF2ExportUserExtensions
                 for extension_ctor in extension_ctors:
                     user_extensions.append(extension_ctor())
         export_settings['gltf_user_extensions'] = user_extensions


### PR DESCRIPTION
Minor bugfix for loading user extensions.

We iterates over all enabled addons and do `sys.modules[addon_name]` to get their module. Sometimes though this raises an error which makes exporting fail.

(The easiest way to get this to happen is to go into the `scripts/addons` folder and rename, let's say `io_scene_obj`, to something else so that Blender can't find it. It will be listed as "Missing script files" in the Addons pane.)

This PR just skips those addons.