### PR TITLE
Import: omit UV transform/UVMap material nodes when possible

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_texture.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_texture.py
@@ -64,10 +64,16 @@ def texture(
     x -= 340
 
     # UV Transform (for KHR_texture_transform)
-    mapping = mh.node_tree.nodes.new('ShaderNodeMapping')
-    mapping.location = x - 160, y + 30
-    mapping.vector_type = 'POINT'
-    if tex_info.extensions and 'KHR_texture_transform' in tex_info.extensions:
+    needs_tex_transform = 'KHR_texture_transform' in (tex_info.extensions or {})
+    if needs_tex_transform:
+        mapping = mh.node_tree.nodes.new('ShaderNodeMapping')
+        mapping.location = x - 160, y + 30
+        mapping.vector_type = 'POINT'
+        # Outputs
+        mh.node_tree.links.new(uv_socket, mapping.outputs[0])
+        # Inputs
+        uv_socket = mapping.inputs[0]
+
         transform = tex_info.extensions['KHR_texture_transform']
         transform = texture_transform_gltf_to_blender(transform)
         mapping.inputs['Location'].default_value[0] = transform['offset'][0]
@@ -75,12 +81,8 @@ def texture(
         mapping.inputs['Rotation'].default_value[2] = transform['rotation']
         mapping.inputs['Scale'].default_value[0] = transform['scale'][0]
         mapping.inputs['Scale'].default_value[1] = transform['scale'][1]
-    # Outputs
-    mh.node_tree.links.new(uv_socket, mapping.outputs[0])
-    # Inputs
-    uv_socket = mapping.inputs[0]
 
-    x -= 260
+        x -= 260
 
     # UV Map
     uv_map = mh.node_tree.nodes.new('ShaderNodeUVMap')

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_texture.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_texture.py
@@ -85,17 +85,17 @@ def texture(
         x -= 260
 
     # UV Map
-    uv_map = mh.node_tree.nodes.new('ShaderNodeUVMap')
-    uv_map.location = x - 160, y - 70
-    # Get UVMap
     uv_idx = tex_info.tex_coord or 0
     try:
         uv_idx = tex_info.extensions['KHR_texture_transform']['texCoord']
     except Exception:
         pass
-    uv_map.uv_map = 'UVMap' if uv_idx == 0 else 'UVMap.%03d' % uv_idx
-    # Outputs
-    mh.node_tree.links.new(uv_socket, uv_map.outputs[0])
+    if uv_idx != 0 or needs_tex_transform:
+        uv_map = mh.node_tree.nodes.new('ShaderNodeUVMap')
+        uv_map.location = x - 160, y - 70
+        uv_map.uv_map = 'UVMap' if uv_idx == 0 else 'UVMap.%03d' % uv_idx
+        # Outputs
+        mh.node_tree.links.new(uv_socket, uv_map.outputs[0])
 
 def set_filtering(tex_img, pysampler):
     """Set the filtering/interpolation on an Image Texture from the glTf sampler."""


### PR DESCRIPTION
Minor enhancement for materials. Makes the node tree a little simpler in the common case.

* Omit the Mapping node for a texture when there is no KHR_texture_transform to apply
* Omit the UVMap node when there is no Mapping node and we're using the 0th UV set

![out](https://user-images.githubusercontent.com/11024420/73619348-a3c1a300-45f2-11ea-9d60-b0cbd8bae507.png)
