### PR TITLE
Import: set scene's frame_{start,end} when restoring animation

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_utils.py
@@ -32,7 +32,7 @@ def simulate_stash(obj, track_name, action, start_frame=None):
 
 def restore_animation_on_object(obj, anim_name):
     if not getattr(obj, 'animation_data', None):
-        return
+        return None
 
     for track in obj.animation_data.nla_tracks:
         if track.name != anim_name:
@@ -41,9 +41,10 @@ def restore_animation_on_object(obj, anim_name):
             continue
 
         obj.animation_data.action = track.strips[0].action
-        return
+        return track.strips[0].action
 
     obj.animation_data.action = None
+    return None
 
 def make_fcurve(action, co, data_path, index=0, group_name=None, interpolation=None):
     try:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -76,7 +76,7 @@ class BlenderScene():
 
             # Restore first animation
             anim_name = gltf.data.animations[0].track_name
-            BlenderAnimation.restore_animation(gltf, 'root', anim_name)
+            BlenderAnimation.restore_animation(gltf, anim_name)
 
     @staticmethod
     def set_active_object(gltf):


### PR DESCRIPTION
Minor enhancement for animations. When restoring an animation, set the scene's start/end frame so it will loop at the proper places when you play it in the Timeline.

![out](https://user-images.githubusercontent.com/11024420/73787519-181a5480-4761-11ea-8e44-68f83de6cf05.png)
