### PR TITLE
Import: manage morph weights at node level

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
@@ -96,20 +96,9 @@ class BlenderGlTF():
             # Something is wrong in file, there is no nodes
             return
 
-        for node_idx, node in enumerate(gltf.data.nodes):
-
+        for node in gltf.data.nodes:
             # Weight animation management
             node.weight_animation = False
-
-            # skin management
-            if node.skin is not None and node.mesh is not None:
-                if not hasattr(gltf.data.skins[node.skin], "node_ids"):
-                    gltf.data.skins[node.skin].node_ids = []
-
-                gltf.data.skins[node.skin].node_ids.append(node_idx)
-
-            # Lights management
-            node.correction_needed = False
 
         # Dispatch animation
         if gltf.data.animations:
@@ -138,8 +127,7 @@ class BlenderGlTF():
         # Meshes
         if gltf.data.meshes:
             for mesh in gltf.data.meshes:
-                mesh.blender_name = {}  # cache Blender mesh (keyed by skin_idx)
-                mesh.is_weight_animated = False
+                mesh.blender_name = {}  # caches Blender mesh name
 
         # Calculate names for each mesh's shapekeys
         for mesh in gltf.data.meshes or []:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -75,22 +75,10 @@ class BlenderMesh():
 
         set_extras(mesh, pymesh.extras, exclude=['targetNames'])
 
-        pymesh.blender_name[skin_idx] = mesh.name
-
         # Clear accessor cache after all primitives are done
         gltf.accessor_cache = {}
 
         return mesh
-
-    @staticmethod
-    def set_mesh(gltf, pymesh, obj):
-        """Sets mesh data after creation."""
-        # set default weights for shape keys, and names, if not set by convention on extras data
-        if pymesh.weights is not None:
-            for i in range(len(pymesh.weights)):
-                if pymesh.shapekey_names[i] is None: # No default value if shapekeys was not created
-                    continue
-                obj.data.shape_keys.key_blocks[pymesh.shapekey_names[i]].value = pymesh.weights[i]
 
     @staticmethod
     def bmesh_to_mesh(gltf, pymesh, bme, mesh):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -181,39 +181,42 @@ class BlenderNode():
 
     @staticmethod
     def create_mesh_object(gltf, pynode, name):
-        instance = False
-        if gltf.data.meshes[pynode.mesh].blender_name.get(pynode.skin) is not None:
-            # Mesh is already created, only create instance
-            # Except is current node is animated with path weight
-            # Or if previous instance is animation at node level
-            if pynode.weight_animation is True:
-                instance = False
-            else:
-                if gltf.data.meshes[pynode.mesh].is_weight_animated is True:
-                    instance = False
-                else:
-                    instance = True
-                    mesh = bpy.data.meshes[gltf.data.meshes[pynode.mesh].blender_name[pynode.skin]]
+        pymesh = gltf.data.meshes[pynode.mesh]
+        name = pymesh.name or name
 
-        if instance is False:
-            if pynode.name:
-                gltf.log.info("Blender create Mesh node " + pynode.name)
+        # Key to cache the Blender mesh by.
+        # Same cache key = instances of the same Blender mesh.
+        cache_key = None
+        if not pymesh.shapekey_names:
+            cache_key = (pynode.skin,)
+        else:
+            # Unlike glTF, all instances of a Blender mesh share shapekeys.
+            # So two instances that might have different morph weights need
+            # different cache keys.
+            if pynode.weight_animation is False:
+                cache_key = (pynode.skin, tuple(pynode.weights or []))
             else:
-                gltf.log.info("Blender create Mesh node")
+                cache_key = None  # don't use the cache at all
 
+        if cache_key is not None and cache_key in pymesh.blender_name:
+            mesh = bpy.data.meshes[pymesh.blender_name[cache_key]]
+        else:
+            gltf.log.info("Blender create Mesh node %s", name)
             mesh = BlenderMesh.create(gltf, pynode.mesh, pynode.skin)
-
-        if pynode.weight_animation is True:
-            # flag this mesh instance as created only for this node, because of weight animation
-            gltf.data.meshes[pynode.mesh].is_weight_animated = True
-
-        mesh_name = gltf.data.meshes[pynode.mesh].name
-        if not name and mesh_name:
-            name = mesh_name
+            if cache_key is not None:
+                pymesh.blender_name[cache_key] = mesh.name
 
         obj = bpy.data.objects.new(name, mesh)
 
-        if instance == False:
-            BlenderMesh.set_mesh(gltf, gltf.data.meshes[pynode.mesh], obj)
+        if pymesh.shapekey_names:
+            BlenderNode.set_morph_weights(gltf, pynode, obj)
 
         return obj
+
+    @staticmethod
+    def set_morph_weights(gltf, pynode, obj):
+        pymesh = gltf.data.meshes[pynode.mesh]
+        weights = pynode.weights or pymesh.weights or []
+        for i, weight in enumerate(weights):
+            if pymesh.shapekey_names[i] is not None:
+                obj.data.shape_keys.key_blocks[pymesh.shapekey_names[i]].value = weight


### PR DESCRIPTION
Fixes #312.  
Also see #290.

This will use the `pynode.weights` property to set a mesh's shapekey weights.

It changes the key for the `pymesh.blender_name` cache to take into account both the skin and the morph weights. To be precise, two instances of the same mesh in glTF will be instances of the same mesh in Blender if

* if they are skinned, they have the same `pynode.skin`
* if their mesh has morph targets, they have the same `pynode.weights`
* if their mesh has morph targets, neither one has its morph weights animated

@julienduroure I think this should satisfy what you said [here](https://github.com/KhronosGroup/glTF-Blender-IO/issues/290#issuecomment-462125634).

----

Here's an [example](https://github.com/KhronosGroup/glTF-Blender-IO/files/4156994/MorphCube.zip):

* all cubes are instances of the same mesh in glTF
* the left-most cube has its `pynode.weights` animated
* the next two cubes both have no `pynode.weights` property
* the last two cubes both have `pynode.weights = [0.5, 0.5]`.

Cubes with the same letter are instances of the same mesh

![morphs](https://user-images.githubusercontent.com/11024420/73801254-7fdf9800-477f-11ea-841a-2ff19a3d8786.png)
