### PR TITLE
Enable a gltf_gltf2_hook

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
@@ -24,6 +24,7 @@ from io_scene_gltf2.blender.exp.gltf2_blender_gltf2_exporter import GlTF2Exporte
 from io_scene_gltf2.io.com.gltf2_io_debug import print_console, print_newline
 from io_scene_gltf2.io.exp import gltf2_io_export
 from io_scene_gltf2.io.exp import gltf2_io_draco_compression_extension
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 def save(context, export_settings):
@@ -60,6 +61,10 @@ def __export(export_settings):
 
 def __gather_gltf(exporter, export_settings):
     active_scene_idx, scenes, animations = gltf2_blender_gather.gather_gltf2(export_settings)
+
+    plan = {'active_scene_idx': active_scene_idx, 'scenes': scenes, 'animations': animations}
+    export_user_extensions('gather_gltf_hook', export_settings, plan)
+    active_scene_idx, scenes, animations = plan['active_scene_idx'], plan['scenes'], plan['animations']
 
     if export_settings['gltf_draco_mesh_compression']:
         gltf2_io_draco_compression_extension.compress_scene_primitives(scenes, export_settings)

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_user_extensions.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_user_extensions.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def export_user_extensions(hook_name, export_settings, gltf2_object, *args):
-    if gltf2_object.extensions is None:
-        gltf2_object.extensions = {}
+def export_user_extensions(hook_name, export_settings, *args):
+    if args and hasattr(args[0], "extensions"):
+        if args[0].extensions is None:
+            args[0].extensions = {}
 
     for extension in export_settings['gltf_user_extensions']:
         hook = getattr(extension, hook_name, None)
         if hook is not None:
-            hook(gltf2_object, *args, export_settings)
+            hook(*args, export_settings)

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_user_extensions.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_user_extensions.py
@@ -20,4 +20,8 @@ def export_user_extensions(hook_name, export_settings, *args):
     for extension in export_settings['gltf_user_extensions']:
         hook = getattr(extension, hook_name, None)
         if hook is not None:
-            hook(*args, export_settings)
+            try:
+                hook(*args, export_settings)
+            except Exception as e:
+                print(hook_name, "fails on", extension)
+                print(str(e))


### PR DESCRIPTION
This patch allows the user to create a gltf2_hook that returns a new list of scenes and animations. The purpose of this is to allow a second pass that can do more things than what currently the exporter does. 

As an example, the exporter checks if an object in bpy.data.objects is exported, and in that case, it checks if it has animations. If it has animations, it exports the animation.

If you want to use glTF2 as an animation library, its not possible, because the animations wont be exported. EXT_property_animation (although not ratified yet), can't be implemented neither as you cant export material animations. 

With a second pass, we allow this use cases and more. 

@scurest @emackey  @julienduroure 