### PR TITLE
Export KHR_materials_clearcoat

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -174,6 +174,10 @@ def __get_image_data(sockets_or_slots, export_settings) -> ExportImage:
                 dst_chan = Channel.R
             elif socket.name == 'Alpha' and len(sockets_or_slots) > 1 and sockets_or_slots[1] is not None:
                 dst_chan = Channel.A
+            elif socket.name == 'Clearcoat':
+                dst_chan = Channel.R
+            elif socket.name == 'Clearcoat Roughness':
+                dst_chan = Channel.G
 
             if dst_chan is not None:
                 composed_image.fill_image(result.shader_node.image, dst_chan, src_chan)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -271,7 +271,7 @@ def __gather_clearcoat_extension(blender_material, export_settings):
             clearcoat_extension['clearcoatRoughnessTexture'] = combined_texture
 
     if __has_image_node_from_socket(clearcoat_normal_socket):
-        clearcoat_extension['clearcoatNormalTexture'] = gltf2_blender_gather_texture_info.gather_texture_info(
+        clearcoat_extension['clearcoatNormalTexture'] = gltf2_blender_gather_material_normal_texture_info_class.gather_material_normal_texture_info_class(
             (clearcoat_normal_socket,),
             export_settings
         )

--- a/docs/blender_docs/io_scene_gltf2.rst
+++ b/docs/blender_docs/io_scene_gltf2.rst
@@ -54,6 +54,7 @@ with the following channels of information:
 - Baked Ambient Occlusion
 - Normal Map
 - Emissive
+- Clearcoat (requires ``KHR_materials_clearcoat``)
 
 .. figure:: /images/addons_io-gltf2_material-channels.jpg
 


### PR DESCRIPTION
Based on https://github.com/KhronosGroup/glTF/pull/1756.

To do:
- [x] ~~Further testing.~~
- [x] ~~Attach extension to root material, pending further discussion.~~
- [x] ~~Write clearcoatTexture and clearcoatRoughnessTexture to R and G channels respectively.~~

Example:
- [Archive.zip](https://github.com/KhronosGroup/glTF-Blender-IO/files/4227358/Archive.zip)
- Screenshot (left without clearcoat, right with clearcoat)

![Screen Shot 2020-02-19 at 12 51 20 PM](https://user-images.githubusercontent.com/1848368/74875099-96a4f380-5316-11ea-87ac-bd2cd5cead44.png)

