### PR TITLE
Import/Export: assume Blender vertex colors are RGBA

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -671,20 +671,12 @@ def extract_primitives(glTF, blender_mesh, blender_object, blender_vertex_groups
                 for color_index in range(0, color_max):
                     color_name = COLOR_PREFIX + str(color_index)
                     color = vertex_colors[color_name].data[loop_index].color
-                    if len(color) == 3:
-                        colors.append([
-                            color_srgb_to_scene_linear(color[0]),
-                            color_srgb_to_scene_linear(color[1]),
-                            color_srgb_to_scene_linear(color[2]),
-                            1.0
-                        ])
-                    else:
-                        colors.append([
-                            color_srgb_to_scene_linear(color[0]),
-                            color_srgb_to_scene_linear(color[1]),
-                            color_srgb_to_scene_linear(color[2]),
-                            color[3]
-                        ])
+                    colors.append([
+                        color_srgb_to_scene_linear(color[0]),
+                        color_srgb_to_scene_linear(color[1]),
+                        color_srgb_to_scene_linear(color[2]),
+                        color[3]
+                    ])
 
             #
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py
@@ -196,13 +196,7 @@ class BlenderPrimitive():
 
             colors = BinaryData.get_data_from_accessor(gltf, attributes['COLOR_%d' % set_num], cache=True)
 
-            # Check whether Blender takes RGB or RGBA colors (old versions only take RGB)
             is_rgba = len(colors[0]) == 4
-            blender_num_components = len(bme_verts[0].link_loops[0][layer])
-            if is_rgba and blender_num_components == 3:
-                gltf2_io_debug.print_console("WARNING",
-                    "this Blender doesn't support RGBA vertex colors; dropping A"
-                )
 
             for bidx, pidx in vert_idxs:
                 color = colors[pidx]
@@ -211,7 +205,7 @@ class BlenderPrimitive():
                     color_linear_to_srgb(color[1]),
                     color_linear_to_srgb(color[2]),
                     color[3] if is_rgba else 1.0,
-                )[:blender_num_components]
+                )
                 for loop in bme_verts[bidx].link_loops:
                     loop[layer] = col
 


### PR DESCRIPTION
Since <2.80 support was dropped, we can assume all vertex colors in Blender are RGBA.  
Mentioned [in #745](https://github.com/KhronosGroup/glTF-Blender-IO/issues/745#issuecomment-558030453).

This will conflict with #922. I can rebase it whenever.

