### PR TITLE
Import: guess original bind pose from inverseBindMatrices

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -870,11 +870,22 @@ class ImportGLTF2(Operator, ImportHelper):
         default="TEMPERANCE",
     )
 
+    guess_original_bind_pose: BoolProperty(
+        name='Guess original bind pose',
+        description=(
+            'Try to guess the original bind pose for skinned meshes from '
+            'the inverse bind matrices.\n'
+            'When off, use default/rest pose as bind pose'
+        ),
+        default=True,
+    )
+
     def draw(self, context):
         layout = self.layout
 
         layout.prop(self, 'import_pack_images')
         layout.prop(self, 'import_shading')
+        layout.prop(self, 'guess_original_bind_pose')
         layout.prop(self, 'bone_heuristic')
 
     def execute(self, context):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -14,6 +14,7 @@
 
 import bpy
 from mathutils import Vector, Quaternion, Matrix
+from ...io.imp.gltf2_io_binary import BinaryData
 
 from ..com.gltf2_blender_math import scale_rot_swap_matrix, nearby_signed_perm_matrix
 
@@ -364,13 +365,40 @@ def pick_bind_pose(gltf):
     Pick the bind pose for all bones. Skinned meshes will be retargeted onto
     this bind pose during mesh creation.
     """
+    # Record inverse bind matrices. We're going to milk them for information
+    # about the original bind pose.
+    inv_binds = {'root': Matrix.Identity(4)}
+    for skin in gltf.data.skins or []:
+        if skin.inverse_bind_matrices is None:
+            continue
+
+        # Assume inverse bind matrices are calculated relative to the skeleton
+        skel = skin.skeleton
+        if skel is not None:
+            if skel in skin.joints:
+                skel = gltf.vnodes[skel].parent
+            if skel not in inv_binds:
+                inv_binds[skel] = Matrix.Identity(4)
+
+        skin_inv_binds = BinaryData.get_data_from_accessor(gltf, skin.inverse_bind_matrices)
+        skin_inv_binds = [gltf.matrix_gltf_to_blender(m) for m in skin_inv_binds]
+        for i, joint in enumerate(skin.joints):
+            inv_binds[joint] = skin_inv_binds[i]
+
     for vnode_id in gltf.vnodes:
         vnode = gltf.vnodes[vnode_id]
         if vnode.type == VNode.Bone:
-            # For now, use the node TR for bind pose.
-            # TODO: try calculating from inverseBindMatices?
+            # Initialize bind pose to default pose (from gltf.data.nodes)
             vnode.bind_trans = Vector(vnode.base_trs[0])
             vnode.bind_rot = Quaternion(vnode.base_trs[1])
+
+            # Try to guess bind pose from inverse bind matrices
+            if vnode_id in inv_binds and vnode.parent in inv_binds:
+                # (bind matrix) = (parent bind matrix) (bind local). Solve for bind local...
+                bind_local = inv_binds[vnode.parent] @ inv_binds[vnode_id].inverted_safe()
+                t, r, _s = bind_local.decompose()
+                vnode.bind_trans = t
+                vnode.bind_rot = r
 
             # Initialize editbones to match bind pose
             vnode.editbone_trans = Vector(vnode.bind_trans)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -365,25 +365,26 @@ def pick_bind_pose(gltf):
     Pick the bind pose for all bones. Skinned meshes will be retargeted onto
     this bind pose during mesh creation.
     """
-    # Record inverse bind matrices. We're going to milk them for information
-    # about the original bind pose.
-    inv_binds = {'root': Matrix.Identity(4)}
-    for skin in gltf.data.skins or []:
-        if skin.inverse_bind_matrices is None:
-            continue
+    if gltf.import_settings['guess_original_bind_pose']:
+        # Record inverse bind matrices. We're going to milk them for information
+        # about the original bind pose.
+        inv_binds = {'root': Matrix.Identity(4)}
+        for skin in gltf.data.skins or []:
+            if skin.inverse_bind_matrices is None:
+                continue
 
-        # Assume inverse bind matrices are calculated relative to the skeleton
-        skel = skin.skeleton
-        if skel is not None:
-            if skel in skin.joints:
-                skel = gltf.vnodes[skel].parent
-            if skel not in inv_binds:
-                inv_binds[skel] = Matrix.Identity(4)
+            # Assume inverse bind matrices are calculated relative to the skeleton
+            skel = skin.skeleton
+            if skel is not None:
+                if skel in skin.joints:
+                    skel = gltf.vnodes[skel].parent
+                if skel not in inv_binds:
+                    inv_binds[skel] = Matrix.Identity(4)
 
-        skin_inv_binds = BinaryData.get_data_from_accessor(gltf, skin.inverse_bind_matrices)
-        skin_inv_binds = [gltf.matrix_gltf_to_blender(m) for m in skin_inv_binds]
-        for i, joint in enumerate(skin.joints):
-            inv_binds[joint] = skin_inv_binds[i]
+            skin_inv_binds = BinaryData.get_data_from_accessor(gltf, skin.inverse_bind_matrices)
+            skin_inv_binds = [gltf.matrix_gltf_to_blender(m) for m in skin_inv_binds]
+            for i, joint in enumerate(skin.joints):
+                inv_binds[joint] = skin_inv_binds[i]
 
     for vnode_id in gltf.vnodes:
         vnode = gltf.vnodes[vnode_id]
@@ -392,13 +393,14 @@ def pick_bind_pose(gltf):
             vnode.bind_trans = Vector(vnode.base_trs[0])
             vnode.bind_rot = Quaternion(vnode.base_trs[1])
 
-            # Try to guess bind pose from inverse bind matrices
-            if vnode_id in inv_binds and vnode.parent in inv_binds:
-                # (bind matrix) = (parent bind matrix) (bind local). Solve for bind local...
-                bind_local = inv_binds[vnode.parent] @ inv_binds[vnode_id].inverted_safe()
-                t, r, _s = bind_local.decompose()
-                vnode.bind_trans = t
-                vnode.bind_rot = r
+            if gltf.import_settings['guess_original_bind_pose']:
+                # Try to guess bind pose from inverse bind matrices
+                if vnode_id in inv_binds and vnode.parent in inv_binds:
+                    # (bind matrix) = (parent bind matrix) (bind local). Solve for bind local...
+                    bind_local = inv_binds[vnode.parent] @ inv_binds[vnode_id].inverted_safe()
+                    t, r, _s = bind_local.decompose()
+                    vnode.bind_trans = t
+                    vnode.bind_rot = r
 
             # Initialize editbones to match bind pose
             vnode.editbone_trans = Vector(vnode.bind_trans)


### PR DESCRIPTION
Try to guess the original bind pose for bones from the inverse bind matrices. This puts skinned meshes in edit mode back much closer to how they were before the vnode stuff went in.

![out](https://user-images.githubusercontent.com/11024420/75111531-833ca580-5600-11ea-9101-aa20d0becbb8.png)

This assumes the inverse bind matrices were computed the obvious way

    (bind matrix for bone b) =
        (bind local for (child of) skeleton root) *
        ... *
        (bind local for grandparent of b) *
        (bind local for parent of b) *
        (bind local for b)

    (inverse bind matrix for bone b) = inverse((bind matrix for bone b))

Any scale is just discarded since edit bones don't have scales. If we can't guess the original bind local for a bone, we fallback to using the value from the default/rest pose.

### Possible problems?

This worked for all the files I tested with (I re-tested with all the models fire posted, CesiumMan, Monster, etc.)

However I'm sort of nervous about how it will work on "weirder" glTF files, so I thought to add an import option (on by default) to enable this. If you don't want to add it though, I can just drop the second commit.

Possible problems:

* The glTF might just not contain enough info to reconstruct the bind local (eg. no skin.skeleton, "gaps" in the joint tree like X -> Y -> Z where X and Z are joints but Y isn't)
* A node might have more than one inverse bind matrix if its used in multiple skins (this will use whichever one comes last)
* inverseBindMatrices might not actually contain the "real" inverse bind matrices computed with the formula above (eg. the inverse binds might be pre-applied so inverseBindMatrices are all 1)
* And sometimes it's apparently better to retarget onto the default pose even if we *can* find the original pose (Brainstem is the only case I found)


![brainout](https://user-images.githubusercontent.com/11024420/75111534-88015980-5600-11ea-90ad-f2cc5c429468.png)
