### PR TITLE
Import: add mechanism for "local rotations" of vnodes

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -58,12 +58,14 @@ class BlenderBoneAnim():
         else:
             translation_keyframes = (gltf.loc_gltf_to_blender(vals) for vals in values)
 
+        final_translations = vnode.base_locs_to_final_locs(translation_keyframes)
+
         # Calculate pose bone trans from final bone trans
         edit_trans, edit_rot = vnode.editbone_trans, vnode.editbone_rot
         edit_rot_inv = edit_rot.conjugated()
         pose_translations = [
             edit_rot_inv @ (trans - edit_trans)
-            for trans in translation_keyframes
+            for trans in final_translations
         ]
 
         BlenderBoneAnim.fill_fcurves(
@@ -93,12 +95,14 @@ class BlenderBoneAnim():
         else:
             quat_keyframes = [gltf.quaternion_gltf_to_blender(vals) for vals in values]
 
+        final_rots = vnode.base_rots_to_final_rots(quat_keyframes)
+
         # Calculate pose bone rotation from final bone rotation
         edit_rot = vnode.editbone_rot
         edit_rot_inv = edit_rot.conjugated()
         pose_rots = [
             edit_rot_inv @ rot
-            for rot in quat_keyframes
+            for rot in final_rots
         ]
 
         # Manage antipodal quaternions
@@ -133,10 +137,13 @@ class BlenderBoneAnim():
         else:
             scale_keyframes = [gltf.scale_gltf_to_blender(vals) for vals in values]
 
+        final_scales = vnode.base_scales_to_final_scales(scale_keyframes)
+        pose_scales = final_scales  # no change needed
+
         BlenderBoneAnim.fill_fcurves(
             obj.animation_data.action,
             keys,
-            scale_keyframes,
+            pose_scales,
             group_name,
             blender_path,
             animation.samplers[channel.sampler].interpolation

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -73,20 +73,21 @@ class BlenderNodeAnim():
                 blender_path = "location"
                 group_name = "Location"
                 num_components = 3
+                values = [gltf.loc_gltf_to_blender(vals) for vals in values]
+                values = vnode.base_locs_to_final_locs(values)
 
                 if vnode.parent is not None and gltf.vnodes[vnode.parent].type == VNode.Bone:
                     # Nodes with a bone parent need to be translated
                     # backwards by their bone length (always 1 currently)
                     off = Vector((0, -1, 0))
-                    values = [gltf.loc_gltf_to_blender(vals) + off for vals in values]
-                else:
-                    values = [gltf.loc_gltf_to_blender(vals) for vals in values]
+                    values = [vals + off for vals in values]
 
             elif channel.target.path == "rotation":
                 blender_path = "rotation_quaternion"
                 group_name = "Rotation"
                 num_components = 4
                 values = [gltf.quaternion_gltf_to_blender(vals) for vals in values]
+                values = vnode.base_rots_to_final_rots(values)
 
                 # Manage antipodal quaternions
                 for i in range(1, len(values)):
@@ -98,6 +99,7 @@ class BlenderNodeAnim():
                 group_name = "Scale"
                 num_components = 3
                 values = [gltf.scale_gltf_to_blender(vals) for vals in values]
+                values = vnode.base_scales_to_final_scales(values)
 
             coords = [0] * (2 * len(keys))
             coords[::2] = (key[0] * fps for key in keys)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -78,7 +78,7 @@ class BlenderNode():
             set_extras(obj, pynode.extras)
 
         # Set transform
-        trans, rot, scale = vnode.trs
+        trans, rot, scale = vnode.trs()
         obj.location = trans
         obj.rotation_mode = 'QUATERNION'
         obj.rotation_quaternion = rot
@@ -161,7 +161,7 @@ class BlenderNode():
 
             # BoneTRS = EditBone * PoseBone
             # Set PoseBone to make BoneTRS = vnode.trs.
-            t, r, s = vnode.trs
+            t, r, s = vnode.trs()
             et, er = vnode.editbone_trans, vnode.editbone_rot
             pose_bone.location = er.conjugated() @ (t - et)
             pose_bone.rotation_mode = 'QUATERNION'

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -349,35 +349,13 @@ def correct_cameras_and_lights(gltf):
     if gltf.camera_correction is None:
         return
 
-    trs = (Vector((0, 0, 0)), gltf.camera_correction, Vector((1, 1, 1)))
+    for id, vnode in gltf.vnodes.items():
+        needs_correction = \
+           vnode.camera_node_idx is not None or \
+           vnode.light_node_idx is not None
 
-    ids = list(gltf.vnodes.keys())
-    for id in ids:
-        vnode = gltf.vnodes[id]
-
-        # Move the camera/light onto a new child and set its rotation
-        # TODO: "hard apply" the rotation without creating a new node
-        #       (like we'll need to do for bones)
-
-        if vnode.camera_node_idx is not None:
-            new_id = str(id) + '.camera-correction'
-            gltf.vnodes[new_id] = VNode()
-            gltf.vnodes[new_id].name = vnode.name + ' Correction'
-            gltf.vnodes[new_id].base_trs = trs
-            gltf.vnodes[new_id].camera_node_idx = vnode.camera_node_idx
-            gltf.vnodes[new_id].parent = id
-            vnode.children.append(new_id)
-            vnode.camera_node_idx = None
-
-        if vnode.light_node_idx is not None:
-            new_id = str(id) + '.light-correction'
-            gltf.vnodes[new_id] = VNode()
-            gltf.vnodes[new_id].name = vnode.name + ' Correction'
-            gltf.vnodes[new_id].base_trs = trs
-            gltf.vnodes[new_id].light_node_idx = vnode.light_node_idx
-            gltf.vnodes[new_id].parent = id
-            vnode.children.append(new_id)
-            vnode.light_node_idx = None
+        if needs_correction:
+            local_rotation(gltf, id, gltf.camera_correction)
 
 
 def pick_bind_pose(gltf):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -15,6 +15,8 @@
 import bpy
 from mathutils import Vector, Quaternion, Matrix
 
+from ..com.gltf2_blender_math import scale_rot_swap_matrix
+
 def compute_vnodes(gltf):
     """Computes the tree of virtual nodes.
     Copies the glTF nodes into a tree of VNodes, then performs a series of
@@ -45,16 +47,59 @@ class VNode:
         self.parent = None
         self.type = VNode.Object
         self.is_arma = False
-        self.trs = (
+        self.base_trs = (
             Vector((0, 0, 0)),
             Quaternion((1, 0, 0, 0)),
             Vector((1, 1, 1)),
         )
+        # Additional rotations before/after the base TRS.
+        # Allows per-vnode axis adjustment. See local_rotation.
+        self.rotation_after = Quaternion((1, 0, 0, 0))
+        self.rotation_before = Quaternion((1, 0, 0, 0))
+
         # Indices of the glTF node where the mesh, etc. came from.
         # (They can get moved around.)
         self.mesh_node_idx = None
         self.camera_node_idx = None
         self.light_node_idx = None
+
+    def trs(self):
+        # (final TRS) = (rotation after) (base TRS) (rotation before)
+        t, r, s = self.base_trs
+        m = scale_rot_swap_matrix(self.rotation_before)
+        return (
+            self.rotation_after @ t,
+            self.rotation_after @ r @ self.rotation_before,
+            m @ s,
+        )
+
+    def base_locs_to_final_locs(self, base_locs):
+        ra = self.rotation_after
+        return [ra @ loc for loc in base_locs]
+
+    def base_rots_to_final_rots(self, base_rots):
+        ra, rb = self.rotation_after, self.rotation_before
+        return [ra @ rot @ rb for rot in base_rots]
+
+    def base_scales_to_final_scales(self, base_scales):
+        m = scale_rot_swap_matrix(self.rotation_before)
+        return [m @ scale for scale in base_scales]
+
+def local_rotation(gltf, vnode_id, rot):
+    """Appends a local rotation to vnode's world transform:
+    (new world transform) = (old world transform) @ (rot)
+    without changing the world transform of vnode's children.
+
+    For correctness, rot must be a signed permutation of the axes
+    (eg. (X Y Z)->(X -Z Y)) OR vnode's scale must always be uniform.
+    """
+    gltf.vnodes[vnode_id].rotation_before @= rot
+
+    # Append the inverse rotation after children's TRS to cancel it out.
+    rot_inv = rot.conjugated()
+    for child in gltf.vnodes[vnode_id].children:
+        gltf.vnodes[child].rotation_after = \
+            rot_inv @ gltf.vnodes[child].rotation_after
 
 
 def init_vnodes(gltf):
@@ -67,7 +112,7 @@ def init_vnodes(gltf):
         gltf.vnodes[i] = vnode
         vnode.name = pynode.name or 'Node_%d' % i
         vnode.children = list(pynode.children or [])
-        vnode.trs = get_node_trs(gltf, pynode)
+        vnode.base_trs = get_node_trs(gltf, pynode)
         if pynode.mesh is not None:
             vnode.mesh_node_idx = i
         if pynode.camera is not None:
@@ -216,7 +261,7 @@ def move_skinned_meshes(gltf):
         )
         if ok_to_move:
             reparent(gltf, id, new_parent=arma)
-            vnode.trs = (
+            vnode.base_trs = (
                 Vector((0, 0, 0)),
                 Quaternion((1, 0, 0, 0)),
                 Vector((1, 1, 1)),
@@ -318,7 +363,7 @@ def correct_cameras_and_lights(gltf):
             new_id = str(id) + '.camera-correction'
             gltf.vnodes[new_id] = VNode()
             gltf.vnodes[new_id].name = vnode.name + ' Correction'
-            gltf.vnodes[new_id].trs = trs
+            gltf.vnodes[new_id].base_trs = trs
             gltf.vnodes[new_id].camera_node_idx = vnode.camera_node_idx
             gltf.vnodes[new_id].parent = id
             vnode.children.append(new_id)
@@ -328,7 +373,7 @@ def correct_cameras_and_lights(gltf):
             new_id = str(id) + '.light-correction'
             gltf.vnodes[new_id] = VNode()
             gltf.vnodes[new_id].name = vnode.name + ' Correction'
-            gltf.vnodes[new_id].trs = trs
+            gltf.vnodes[new_id].base_trs = trs
             gltf.vnodes[new_id].light_node_idx = vnode.light_node_idx
             gltf.vnodes[new_id].parent = id
             vnode.children.append(new_id)
@@ -345,8 +390,8 @@ def pick_bind_pose(gltf):
         if vnode.type == VNode.Bone:
             # For now, use the node TR for bind pose.
             # TODO: try calculating from inverseBindMatices?
-            vnode.bind_trans = Vector(vnode.trs[0])
-            vnode.bind_rot = Quaternion(vnode.trs[1])
+            vnode.bind_trans = Vector(vnode.base_trs[0])
+            vnode.bind_rot = Quaternion(vnode.base_trs[1])
 
             # Initialize editbones to match bind pose
             vnode.editbone_trans = Vector(vnode.bind_trans)


### PR DESCRIPTION
This adds a way to perform a "local" rotation of a vnode, where the world transform of the vnode is rotated

```
(vnode's new world transform) = (vnode's old world transform) (local rotation)
```

without changing the world transform of any of vnode's children.

Because of non-uniform scalings, the local rotation has to be restricted to be a rearrangement of the local axes (eg. something like (X,Y,Z) -> (X,-Z,Y)); more on this below.

This is used for

* rotating cameras/lights without inserting an extra "correction" node (done in this PR)
* rotating bones so they look nicer (will do in a followup PR)

### How it works

We add the local rotation on the right the local TRS for the vnode. Then we add the inverse rotation to the left of the local TRS of its children to cancel it out.

    (vnode's new local transform) = (vnode's old local transform) (local rotation)
    (child's new local transform) = (local rotation inverse) (child's old local transform)

So vnode's world transform gets multiplied by the local rotation, but the world transform of its children doesn't change.

So now every vnode's local transform looks like

```
(local TRS) = (rotation after) (original TRS from glTF file) (rotation before)
            =     Rot[ra]         Trans[t] Rot[r] Scale[s]       Rot[rb]
```

We need to put this in TRS form. To do this I used this fact

> If Rot[rb] is a signed permutation matrix (ie. something like (X,Y,Z) -> (X,-Z,Y) that just rearranges the axes and flips signs), then
>
>     Scale[s] Rot[rb] = Rot[rb] Scale[M s]
>
> where M is the inverse of the corresponding unsigned permutation matrix.

(If we knew s was always uniform we wouldn't need the matrix: we'd have `Scale[s] Rot[rb] = Rot[rb] Scale[s]`.)

Then

```
Rot[ra] Trans[t] Rot[r] Scale[s] Rot[rb] =
Trans[Rot[ra] t] Rot[ra] Rot[r] Scale[s] Rot[rb] =    (use L Trans[t] = Trans[Lt] L)
Trans[Rot[ra] t] Rot[ra] Rot[r] Rot[rb] Scale[M s] =  (use fact above)
Trans[Rot[ra] t] Rot[ra r rb] Scale[M s]              (combine rotations)
```

This is used for adjusting the base TRS values from the glTF file to the final TRS values that should be used in Blender, both in the static pose (`VNode.trs()`) and for animated data (`VNode.base_locs_to_final_locs`, etc.).