### PR TITLE
Import: prettify bones

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -835,11 +835,23 @@ class ImportGLTF2(Operator, ImportHelper):
         description="How normals are computed during import",
         default="NORMALS")
 
+    bone_tip_heuristic: EnumProperty(
+        name="Bone Dir",
+        items=(
+            ("BLENDER", "Blender (+Y)",
+                "Round-trips bone directions in glTFs exported from Blender.\n"
+                "Bone tips are placed on their local +Y axis (in glTF space)"),
+        ),
+        description="Heuristic for placing bone tips. Tries to make bones pretty",
+        default="BLENDER",
+    )
+
     def draw(self, context):
         layout = self.layout
 
         layout.prop(self, 'import_pack_images')
         layout.prop(self, 'import_shading')
+        layout.prop(self, 'bone_tip_heuristic')
 
     def execute(self, context):
         return self.import_gltf2(context)

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -841,9 +841,12 @@ class ImportGLTF2(Operator, ImportHelper):
             ("BLENDER", "Blender (+Y)",
                 "Round-trips bone directions in glTFs exported from Blender.\n"
                 "Bone tips are placed on their local +Y axis (in glTF space)"),
+            ("TEMPERANCE", "Temperance",
+                "Okay for many different models.\n"
+                "Bone tips are placed at a child's root")
         ),
         description="Heuristic for placing bone tips. Tries to make bones pretty",
-        default="BLENDER",
+        default="TEMPERANCE",
     )
 
     def draw(self, context):

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -835,7 +835,7 @@ class ImportGLTF2(Operator, ImportHelper):
         description="How normals are computed during import",
         default="NORMALS")
 
-    bone_tip_heuristic: EnumProperty(
+    bone_heuristic: EnumProperty(
         name="Bone Dir",
         items=(
             ("BLENDER", "Blender (+Y)",
@@ -845,7 +845,7 @@ class ImportGLTF2(Operator, ImportHelper):
                 "Okay for many different models.\n"
                 "Bone tips are placed at a child's root")
         ),
-        description="Heuristic for placing bone tips. Tries to make bones pretty",
+        description="Heuristic for placing bones. Tries to make bones pretty",
         default="TEMPERANCE",
     )
 
@@ -854,7 +854,7 @@ class ImportGLTF2(Operator, ImportHelper):
 
         layout.prop(self, 'import_pack_images')
         layout.prop(self, 'import_shading')
-        layout.prop(self, 'bone_tip_heuristic')
+        layout.prop(self, 'bone_heuristic')
 
     def execute(self, context):
         return self.import_gltf2(context)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_bone.py
@@ -58,12 +58,14 @@ class BlenderBoneAnim():
         else:
             translation_keyframes = (gltf.loc_gltf_to_blender(vals) for vals in values)
 
+        final_translations = vnode.base_locs_to_final_locs(translation_keyframes)
+
         # Calculate pose bone trans from final bone trans
         edit_trans, edit_rot = vnode.editbone_trans, vnode.editbone_rot
         edit_rot_inv = edit_rot.conjugated()
         pose_translations = [
             edit_rot_inv @ (trans - edit_trans)
-            for trans in translation_keyframes
+            for trans in final_translations
         ]
 
         BlenderBoneAnim.fill_fcurves(
@@ -93,12 +95,14 @@ class BlenderBoneAnim():
         else:
             quat_keyframes = [gltf.quaternion_gltf_to_blender(vals) for vals in values]
 
+        final_rots = vnode.base_rots_to_final_rots(quat_keyframes)
+
         # Calculate pose bone rotation from final bone rotation
         edit_rot = vnode.editbone_rot
         edit_rot_inv = edit_rot.conjugated()
         pose_rots = [
             edit_rot_inv @ rot
-            for rot in quat_keyframes
+            for rot in final_rots
         ]
 
         # Manage antipodal quaternions
@@ -133,10 +137,13 @@ class BlenderBoneAnim():
         else:
             scale_keyframes = [gltf.scale_gltf_to_blender(vals) for vals in values]
 
+        final_scales = vnode.base_scales_to_final_scales(scale_keyframes)
+        pose_scales = final_scales  # no change needed
+
         BlenderBoneAnim.fill_fcurves(
             obj.animation_data.action,
             keys,
-            scale_keyframes,
+            pose_scales,
             group_name,
             blender_path,
             animation.samplers[channel.sampler].interpolation

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -73,20 +73,21 @@ class BlenderNodeAnim():
                 blender_path = "location"
                 group_name = "Location"
                 num_components = 3
+                values = [gltf.loc_gltf_to_blender(vals) for vals in values]
+                values = vnode.base_locs_to_final_locs(values)
 
                 if vnode.parent is not None and gltf.vnodes[vnode.parent].type == VNode.Bone:
                     # Nodes with a bone parent need to be translated
                     # backwards by their bone length (always 1 currently)
                     off = Vector((0, -1, 0))
-                    values = [gltf.loc_gltf_to_blender(vals) + off for vals in values]
-                else:
-                    values = [gltf.loc_gltf_to_blender(vals) for vals in values]
+                    values = [vals + off for vals in values]
 
             elif channel.target.path == "rotation":
                 blender_path = "rotation_quaternion"
                 group_name = "Rotation"
                 num_components = 4
                 values = [gltf.quaternion_gltf_to_blender(vals) for vals in values]
+                values = vnode.base_rots_to_final_rots(values)
 
                 # Manage antipodal quaternions
                 for i in range(1, len(values)):
@@ -98,6 +99,7 @@ class BlenderNodeAnim():
                 group_name = "Scale"
                 num_components = 3
                 values = [gltf.scale_gltf_to_blender(vals) for vals in values]
+                values = vnode.base_scales_to_final_scales(values)
 
             coords = [0] * (2 * len(keys))
             coords[::2] = (key[0] * fps for key in keys)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -78,8 +78,9 @@ class BlenderNodeAnim():
 
                 if vnode.parent is not None and gltf.vnodes[vnode.parent].type == VNode.Bone:
                     # Nodes with a bone parent need to be translated
-                    # backwards by their bone length (always 1 currently)
-                    off = Vector((0, -1, 0))
+                    # backwards from the tip to the root
+                    bone_length = gltf.vnodes[vnode.parent].bone_length
+                    off = Vector((0, -bone_length, 0))
                     values = [vals + off for vals in values]
 
             elif channel.target.path == "rotation":

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -78,7 +78,7 @@ class BlenderNode():
             set_extras(obj, pynode.extras)
 
         # Set transform
-        trans, rot, scale = vnode.trs
+        trans, rot, scale = vnode.trs()
         obj.location = trans
         obj.rotation_mode = 'QUATERNION'
         obj.rotation_quaternion = rot
@@ -161,7 +161,7 @@ class BlenderNode():
 
             # BoneTRS = EditBone * PoseBone
             # Set PoseBone to make BoneTRS = vnode.trs.
-            t, r, s = vnode.trs
+            t, r, s = vnode.trs()
             et, er = vnode.editbone_trans, vnode.editbone_rot
             pose_bone.location = er.conjugated() @ (t - et)
             pose_bone.rotation_mode = 'QUATERNION'

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -96,8 +96,8 @@ class BlenderNode():
                 obj.parent_bone = parent_vnode.blender_bone_name
 
                 # Nodes with a bone parent need to be translated
-                # backwards by their bone length (always 1 currently)
-                obj.location += Vector((0, -1, 0))
+                # backwards from the tip to the root
+                obj.location += Vector((0, -parent_vnode.bone_length, 0))
 
         bpy.data.scenes[gltf.blender_scene].collection.objects.link(obj)
 
@@ -138,6 +138,7 @@ class BlenderNode():
             editbone.head = arma_mat @ Vector((0, 0, 0))
             editbone.tail = arma_mat @ Vector((0, 1, 0))
             editbone.align_roll(arma_mat @ Vector((0, 0, 1)) - editbone.head)
+            editbone.length = vnode.bone_length
 
             if isinstance(id, int):
                 pynode = gltf.data.nodes[id]

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -385,12 +385,16 @@ def prettify_bones(gltf):
         vnode = gltf.vnodes[vnode_id]
 
         if vnode.type == VNode.Bone:
+            vnode.bone_length = pick_bone_length(gltf, vnode_id)
             rotate_edit_bone(gltf, vnode_id, Quaternion((2**0.5/2,2**0.5/2,0,0)))
 
         for child in vnode.children:
             visit(child)
 
     visit('root')
+
+def pick_bone_length(gltf, bone_id):
+    return 0.5
 
 def rotate_edit_bone(gltf, bone_id, rot):
     """Rotate one edit bone without affecting anything else."""

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -427,9 +427,9 @@ def pick_bone_rotation(gltf, bone_id, parent_rot):
     if bpy.app.debug_value == 100:
         return None
 
-    if gltf.import_settings['bone_tip_heuristic'] == 'BLENDER':
+    if gltf.import_settings['bone_heuristic'] == 'BLENDER':
         return Quaternion((2**0.5/2, 2**0.5/2, 0, 0))
-    elif gltf.import_settings['bone_tip_heuristic'] == 'TEMPERANCE':
+    elif gltf.import_settings['bone_heuristic'] == 'TEMPERANCE':
         return temperance(gltf, bone_id, parent_rot)
 
 def temperance(gltf, bone_id, parent_rot):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -349,35 +349,13 @@ def correct_cameras_and_lights(gltf):
     if gltf.camera_correction is None:
         return
 
-    trs = (Vector((0, 0, 0)), gltf.camera_correction, Vector((1, 1, 1)))
+    for id, vnode in gltf.vnodes.items():
+        needs_correction = \
+           vnode.camera_node_idx is not None or \
+           vnode.light_node_idx is not None
 
-    ids = list(gltf.vnodes.keys())
-    for id in ids:
-        vnode = gltf.vnodes[id]
-
-        # Move the camera/light onto a new child and set its rotation
-        # TODO: "hard apply" the rotation without creating a new node
-        #       (like we'll need to do for bones)
-
-        if vnode.camera_node_idx is not None:
-            new_id = str(id) + '.camera-correction'
-            gltf.vnodes[new_id] = VNode()
-            gltf.vnodes[new_id].name = vnode.name + ' Correction'
-            gltf.vnodes[new_id].base_trs = trs
-            gltf.vnodes[new_id].camera_node_idx = vnode.camera_node_idx
-            gltf.vnodes[new_id].parent = id
-            vnode.children.append(new_id)
-            vnode.camera_node_idx = None
-
-        if vnode.light_node_idx is not None:
-            new_id = str(id) + '.light-correction'
-            gltf.vnodes[new_id] = VNode()
-            gltf.vnodes[new_id].name = vnode.name + ' Correction'
-            gltf.vnodes[new_id].base_trs = trs
-            gltf.vnodes[new_id].light_node_idx = vnode.light_node_idx
-            gltf.vnodes[new_id].parent = id
-            vnode.children.append(new_id)
-            vnode.light_node_idx = None
+        if needs_correction:
+            local_rotation(gltf, id, gltf.camera_correction)
 
 
 def pick_bind_pose(gltf):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -386,7 +386,9 @@ def prettify_bones(gltf):
 
         if vnode.type == VNode.Bone:
             vnode.bone_length = pick_bone_length(gltf, vnode_id)
-            rotate_edit_bone(gltf, vnode_id, Quaternion((2**0.5/2,2**0.5/2,0,0)))
+            rot = pick_bone_rotation(gltf, vnode_id)
+            if rot is not None:
+                rotate_edit_bone(gltf, vnode_id, rot)
 
         for child in vnode.children:
             visit(child)
@@ -415,6 +417,15 @@ def pick_bone_length(gltf, bone_id):
         return vnode.editbone_trans.length
 
     return 1
+
+def pick_bone_rotation(gltf, bone_id):
+    """Heuristic for bone rotation.
+    A bone's tip lies on its local +Y axis so rotating a bone let's us
+    adjust the bone direction.
+    """
+    if gltf.import_settings['bone_tip_heuristic'] == 'BLENDER':
+        return Quaternion((2**0.5/2, 2**0.5/2, 0, 0))
+
 
 def rotate_edit_bone(gltf, bone_id, rot):
     """Rotate one edit bone without affecting anything else."""

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -393,8 +393,28 @@ def prettify_bones(gltf):
 
     visit('root')
 
+MIN_BONE_LENGTH = 0.004  # too small and bones get deleted
+
 def pick_bone_length(gltf, bone_id):
-    return 0.5
+    """Heuristic for bone length."""
+    vnode = gltf.vnodes[bone_id]
+
+    child_locs = [
+        gltf.vnodes[child].editbone_trans
+        for child in vnode.children
+        if gltf.vnodes[child].type == VNode.Bone
+    ]
+    child_locs = [loc for loc in child_locs if loc.length > MIN_BONE_LENGTH]
+    if child_locs:
+        return min(loc.length for loc in child_locs)
+
+    if gltf.vnodes[vnode.parent].type == VNode.Bone:
+        return gltf.vnodes[vnode.parent].bone_length
+
+    if vnode.editbone_trans.length > MIN_BONE_LENGTH:
+        return vnode.editbone_trans.length
+
+    return 1
 
 def rotate_edit_bone(gltf, bone_id, rot):
     """Rotate one edit bone without affecting anything else."""

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -15,6 +15,8 @@
 import bpy
 from mathutils import Vector, Quaternion, Matrix
 
+from ..com.gltf2_blender_math import scale_rot_swap_matrix
+
 def compute_vnodes(gltf):
     """Computes the tree of virtual nodes.
     Copies the glTF nodes into a tree of VNodes, then performs a series of
@@ -45,16 +47,59 @@ class VNode:
         self.parent = None
         self.type = VNode.Object
         self.is_arma = False
-        self.trs = (
+        self.base_trs = (
             Vector((0, 0, 0)),
             Quaternion((1, 0, 0, 0)),
             Vector((1, 1, 1)),
         )
+        # Additional rotations before/after the base TRS.
+        # Allows per-vnode axis adjustment. See local_rotation.
+        self.rotation_after = Quaternion((1, 0, 0, 0))
+        self.rotation_before = Quaternion((1, 0, 0, 0))
+
         # Indices of the glTF node where the mesh, etc. came from.
         # (They can get moved around.)
         self.mesh_node_idx = None
         self.camera_node_idx = None
         self.light_node_idx = None
+
+    def trs(self):
+        # (final TRS) = (rotation after) (base TRS) (rotation before)
+        t, r, s = self.base_trs
+        m = scale_rot_swap_matrix(self.rotation_before)
+        return (
+            self.rotation_after @ t,
+            self.rotation_after @ r @ self.rotation_before,
+            m @ s,
+        )
+
+    def base_locs_to_final_locs(self, base_locs):
+        ra = self.rotation_after
+        return [ra @ loc for loc in base_locs]
+
+    def base_rots_to_final_rots(self, base_rots):
+        ra, rb = self.rotation_after, self.rotation_before
+        return [ra @ rot @ rb for rot in base_rots]
+
+    def base_scales_to_final_scales(self, base_scales):
+        m = scale_rot_swap_matrix(self.rotation_before)
+        return [m @ scale for scale in base_scales]
+
+def local_rotation(gltf, vnode_id, rot):
+    """Appends a local rotation to vnode's world transform:
+    (new world transform) = (old world transform) @ (rot)
+    without changing the world transform of vnode's children.
+
+    For correctness, rot must be a signed permutation of the axes
+    (eg. (X Y Z)->(X -Z Y)) OR vnode's scale must always be uniform.
+    """
+    gltf.vnodes[vnode_id].rotation_before @= rot
+
+    # Append the inverse rotation after children's TRS to cancel it out.
+    rot_inv = rot.conjugated()
+    for child in gltf.vnodes[vnode_id].children:
+        gltf.vnodes[child].rotation_after = \
+            rot_inv @ gltf.vnodes[child].rotation_after
 
 
 def init_vnodes(gltf):
@@ -67,7 +112,7 @@ def init_vnodes(gltf):
         gltf.vnodes[i] = vnode
         vnode.name = pynode.name or 'Node_%d' % i
         vnode.children = list(pynode.children or [])
-        vnode.trs = get_node_trs(gltf, pynode)
+        vnode.base_trs = get_node_trs(gltf, pynode)
         if pynode.mesh is not None:
             vnode.mesh_node_idx = i
         if pynode.camera is not None:
@@ -216,7 +261,7 @@ def move_skinned_meshes(gltf):
         )
         if ok_to_move:
             reparent(gltf, id, new_parent=arma)
-            vnode.trs = (
+            vnode.base_trs = (
                 Vector((0, 0, 0)),
                 Quaternion((1, 0, 0, 0)),
                 Vector((1, 1, 1)),
@@ -318,7 +363,7 @@ def correct_cameras_and_lights(gltf):
             new_id = str(id) + '.camera-correction'
             gltf.vnodes[new_id] = VNode()
             gltf.vnodes[new_id].name = vnode.name + ' Correction'
-            gltf.vnodes[new_id].trs = trs
+            gltf.vnodes[new_id].base_trs = trs
             gltf.vnodes[new_id].camera_node_idx = vnode.camera_node_idx
             gltf.vnodes[new_id].parent = id
             vnode.children.append(new_id)
@@ -328,7 +373,7 @@ def correct_cameras_and_lights(gltf):
             new_id = str(id) + '.light-correction'
             gltf.vnodes[new_id] = VNode()
             gltf.vnodes[new_id].name = vnode.name + ' Correction'
-            gltf.vnodes[new_id].trs = trs
+            gltf.vnodes[new_id].base_trs = trs
             gltf.vnodes[new_id].light_node_idx = vnode.light_node_idx
             gltf.vnodes[new_id].parent = id
             vnode.children.append(new_id)
@@ -345,8 +390,8 @@ def pick_bind_pose(gltf):
         if vnode.type == VNode.Bone:
             # For now, use the node TR for bind pose.
             # TODO: try calculating from inverseBindMatices?
-            vnode.bind_trans = Vector(vnode.trs[0])
-            vnode.bind_rot = Quaternion(vnode.trs[1])
+            vnode.bind_trans = Vector(vnode.base_trs[0])
+            vnode.bind_rot = Quaternion(vnode.base_trs[1])
 
             # Initialize editbones to match bind pose
             vnode.editbone_trans = Vector(vnode.bind_trans)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -424,6 +424,9 @@ def pick_bone_rotation(gltf, bone_id, parent_rot):
     A bone's tip lies on its local +Y axis so rotating a bone let's us
     adjust the bone direction.
     """
+    if bpy.app.debug_value == 100:
+        return None
+
     if gltf.import_settings['bone_tip_heuristic'] == 'BLENDER':
         return Quaternion((2**0.5/2, 2**0.5/2, 0, 0))
     elif gltf.import_settings['bone_tip_heuristic'] == 'TEMPERANCE':


### PR DESCRIPTION
Depends on #945. You can see how the local rotation stuff gets used if you want.

----

Fixes  #324.  
Also see #455.

This attempts to rotate/resize edit bones so they're more readable. It's based on some simple heuristics. There's lots of stuff that you might want to do differently, but I think this is a good start. Anyway all the tools to set lengths and rotate editbones are now in place at least.

An import option was added to control the heuristic for bone directions (it doesn't affect bone lengths). The only two options currently are:

### Blender (+Y)

This rotates bones so their tips lie on their local +Y axis (in glTF space). This option will round-trip bone directions when re-importing models exported from Blender.

(Also see #879)

### Temperance (this is the default)

Name is provisional. It works well for many different models so I made it the default. It tries to place the bone tip on whichever axis is closest to the centroid of its children. Leaf bones are rotated the same way as their parents.

![final](https://user-images.githubusercontent.com/11024420/75213104-c60c9380-574e-11ea-9b13-0352aa9d8f9a.jpeg)

Generally it's not too bad for character models at least.