### PR TITLE
Fix export of multi-armature models

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_drivers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_drivers.py
@@ -27,6 +27,9 @@ def get_sk_drivers(blender_armature):
     for child in blender_armature.children:
         if not child.data:
             continue
+        # child.data can be an armature - which has no shapekeys
+        if not hasattr(child.data, 'shape_keys'):
+	        continue
         if not child.data.shape_keys:
             continue
         if not child.data.shape_keys.animation_data:


### PR DESCRIPTION
Fix export failing when .shape_keys does not exist in an Armature's child.data; Since Armatures can parent Armatures, child.data can also be an Armature (which has no .shape_keys attribute)