### PR TITLE
Export: workaround for #932

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_mesh.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_mesh.py
@@ -39,8 +39,8 @@ def gather_mesh(blender_mesh: bpy.types.Mesh,
         extensions=__gather_extensions(blender_mesh, vertex_groups, modifiers, export_settings),
         extras=__gather_extras(blender_mesh, vertex_groups, modifiers, export_settings),
         name=__gather_name(blender_mesh, vertex_groups, modifiers, export_settings),
+        weights=__gather_weights(blender_mesh, vertex_groups, modifiers, export_settings),
         primitives=__gather_primitives(blender_mesh, blender_object, vertex_groups, modifiers, material_names, export_settings),
-        weights=__gather_weights(blender_mesh, vertex_groups, modifiers, export_settings)
     )
 
     if len(mesh.primitives) == 0:
@@ -134,15 +134,6 @@ def __gather_weights(blender_mesh: bpy.types.Mesh,
                      modifiers: Optional[bpy.types.ObjectModifiers],
                      export_settings
                      ) -> Optional[List[float]]:
-
-    # Seems that in some files, when using Apply Modifier, shape_keys return an error
-    # ReferenceError: StructRNA of type Mesh has been removed
-    # Because shapekeys are not exported in that case, we can return None
-    try:
-        blender_mesh.shape_keys
-    except:
-        return None
-
     if not export_settings[MORPH] or not blender_mesh.shape_keys:
         return None
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
@@ -59,6 +59,8 @@ def gather_primitives(
             material = gltf2_blender_gather_materials.gather_material(blender_material,
                                                                   double_sided,
                                                                   export_settings)
+            # NOTE: gather_material may invalidate blender_mesh (see #932),
+            # so make sure not to access blender_mesh again after this point
         except IndexError:
             # no material at that index
             pass


### PR DESCRIPTION
Adds a really simple workaround for #932.

We know the problem is accessing blender_mesh in gather_weights after calling gather_material from gather_primitives. So this just swaps the order of gather_weights and gather_primitives. Now blender_mesh is never accessed again after calling gather_material.

Removes the workaround from f2f3b83 so weights will get gathered again.