### PR TITLE
Fix export of vertex groups in skinned model

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -709,6 +709,9 @@ def extract_primitives(glTF, blender_mesh, blender_object, blender_vertex_groups
                     #
 
                     vertex_group_index = group_element.group
+                    
+                    if vertex_group_index < 0 or vertex_group_index >= len(blender_vertex_groups):
+                        continue
                     vertex_group_name = blender_vertex_groups[vertex_group_index].name
 
                     joint_index = None


### PR DESCRIPTION
Export failed when vertex_group_index was out of range