### PR TITLE
Import: bugfix for when glTF scenes have no nodes

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -97,7 +97,7 @@ class BlenderScene():
                     return  # no nodes
                 vnode = gltf.vnodes[vnode.children[0]]
 
-        if gltf.vnodes[vnode.parent].type != VNode.DummyRoot:
-            vnode = gltf.vnodes[vnode.parent]
+        if vnode.type == VNode.Bone:
+            vnode = gltf.vnodes[vnode.bone_arma]
 
         bpy.context.view_layer.objects.active = vnode.blender_object

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -77,17 +77,27 @@ class BlenderScene():
         """Make the first root object from the default glTF scene active.
         If no default scene, use the first scene, or just any root object.
         """
-        if gltf.data.scenes:
-            pyscene = gltf.data.scenes[gltf.data.scene or 0]
-            vnode = gltf.vnodes[pyscene.nodes[0]]
-            if gltf.vnodes[vnode.parent].type != VNode.DummyRoot:
-                vnode = gltf.vnodes[vnode.parent]
+        vnode = None
 
-        else:
+        if gltf.data.scene is not None:
+            pyscene = gltf.data.scenes[gltf.data.scene]
+            if pyscene.nodes:
+                vnode = gltf.vnodes[pyscene.nodes[0]]
+
+        if not vnode:
+            for pyscene in gltf.data.scenes or []:
+                if pyscene.nodes:
+                    vnode = gltf.vnodes[pyscene.nodes[0]]
+                    break
+
+        if not vnode:
             vnode = gltf.vnodes['root']
             if vnode.type == VNode.DummyRoot:
                 if not vnode.children:
                     return  # no nodes
                 vnode = gltf.vnodes[vnode.children[0]]
+
+        if gltf.vnodes[vnode.parent].type != VNode.DummyRoot:
+            vnode = gltf.vnodes[vnode.parent]
 
         bpy.context.view_layer.objects.active = vnode.blender_object


### PR DESCRIPTION
The set_active_object function currently assumes that glTF scenes have nodes properties, but actually the spec says `nodes` is not required. So the importer will currently fails on a file like this

````json
{"asset":{"version":"2.0"}, "scenes":[{}]}
````

This fixes it by looking in the next place where there are no nodes on a scene. No change for any files that already work.

When the chosen node is a bone, the old code would make its parent active. I also changed this so it makes its armature active. These are always the same thing assuming the glTF file is valid, but making the arma active is a little more robust if the glTF file is invalid or the vnode code changes in the future.