### PR TITLE
Test: test that animation names roundtrip

### DIFF
--- a/tests/test/test.js
+++ b/tests/test/test.js
@@ -1053,6 +1053,17 @@ describe('Importer / Exporter (Roundtrip)', function() {
                 };
                 assert.deepStrictEqual(customNormalHash, expectedCustomNormalHash);
             });
+
+            it('roundtrips animation names', function() {
+                let dir = '07_nla-anim';
+                let outDirPath = path.resolve(OUT_PREFIX, 'roundtrip', dir, outDirName);
+                let gltfPath = path.resolve(outDirPath, dir + '.gltf');
+                const asset = JSON.parse(fs.readFileSync(gltfPath));
+
+                const expectedAnimNames = ["Action2", "Action1", "Action3"];
+                const animNames = asset.animations.map(anim => anim.name);
+                assert.deepStrictEqual(animNames.sort(), expectedAnimNames.sort());
+            });
         });
     });
 });


### PR DESCRIPTION
Adds a roundtrip test for `07_nla-anim` that would have caught #953.

I wasn't sure how I should order it relative to the other tests, so I just put it at the bottom of the file.