### PR TITLE
Export: remove ability to undo an export (fix #570)

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -76,7 +76,7 @@ class ExportGLTF2_Base:
         from io_scene_gltf2.io.exp import gltf2_io_draco_compression_extension
         self.is_draco_available = gltf2_io_draco_compression_extension.dll_exists()
 
-    bl_options = {'UNDO', 'PRESET'}
+    bl_options = {'PRESET'}
 
     export_format: EnumProperty(
         name='Format',


### PR DESCRIPTION
Fixes #570. See [my comment there](https://github.com/KhronosGroup/glTF-Blender-IO/issues/570#issuecomment-599849380). Undoing an export doesn't really make sense anyway. 