### PR TITLE
Fix: Exporting with "Skinning" disabled makes errors

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -66,7 +66,7 @@ class ShapeKey:
 
 def convert_swizzle_normal(loc, armature, blender_object, export_settings):
     """Convert a normal data from Blender coordinate system to glTF coordinate system."""
-    if not armature:
+    if (not armature) or (not blender_object):
         # Classic case. Mesh is not skined, no need to apply armature transfoms on vertices / normals / tangents
         if export_settings[gltf2_blender_export_keys.YUP]:
             return Vector((loc[0], loc[2], -loc[1]))
@@ -85,7 +85,7 @@ def convert_swizzle_normal(loc, armature, blender_object, export_settings):
 
 def convert_swizzle_location(loc, armature, blender_object, export_settings):
     """Convert a location from Blender coordinate system to glTF coordinate system."""
-    if not armature:
+    if (not armature) or (not blender_object):
         # Classic case. Mesh is not skined, no need to apply armature transfoms on vertices / normals / tangents
         if export_settings[gltf2_blender_export_keys.YUP]:
             return Vector((loc[0], loc[2], -loc[1]))
@@ -107,7 +107,7 @@ def convert_swizzle_tangent(tan, armature, blender_object, export_settings):
     if tan[0] == 0.0 and tan[1] == 0.0 and tan[2] == 0.0:
         print_console('WARNING', 'Tangent has zero length.')
 
-    if not armature:
+    if (not armature) or (not blender_object):
         # Classic case. Mesh is not skined, no need to apply armature transfoms on vertices / normals / tangents
         if export_settings[gltf2_blender_export_keys.YUP]:
             return Vector((tan[0], tan[2], -tan[1], 1.0))


### PR DESCRIPTION
Reproduction: 

- Take any model with an armature (like https://github.com/castle-engine/demo-models/blob/master/blender/skinned_animation/simple_skin_test.blend )
- Export, selecting "Geometry->Apply Modifiers" and "Animation->Use Current Frame", but unselecting "Animation->Animation", "Animation->Shape Keys", "Animation->Skinning".

Export fails with the following error:

```
16:34:26 | INFO: Starting glTF 2.0 export
16:34:26 | INFO: Extracting primitive: Cube
Traceback (most recent call last):
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/__init__.py", line 502, in execute
    return gltf2_blender_export.save(context, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py", line 42, in save
    json, buffer = __export(export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py", line 55, in __export
    __gather_gltf(exporter, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py", line 64, in __gather_gltf
    active_scene_idx, scenes, animations = gltf2_blender_gather.gather_gltf2(export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather.py", line 37, in gather_gltf2
    scenes.append(__gather_scene(blender_scene, export_settings))
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cache.py", line 65, in wrapper_cached
    result = func(*args)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather.py", line 60, in __gather_scene
    blender_scene, None, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py", line 47, in gather_node
    node = __gather_node(blender_object, library, blender_scene, dupli_object_parent, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cache.py", line 65, in wrapper_cached
    result = func(*args)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py", line 61, in __gather_node
    children=__gather_children(blender_object, blender_scene, export_settings),
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py", line 135, in __gather_children
    blender_scene, None, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py", line 47, in gather_node
    node = __gather_node(blender_object, library, blender_scene, dupli_object_parent, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cache.py", line 65, in wrapper_cached
    result = func(*args)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py", line 65, in __gather_node
    mesh=__gather_mesh(blender_object, library, export_settings),
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py", line 333, in __gather_mesh
    export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cache.py", line 65, in wrapper_cached
    result = func(*args)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_mesh.py", line 44, in gather_mesh
    primitives=__gather_primitives(blender_mesh, library, blender_object, vertex_groups, modifiers, material_names, export_settings),
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_mesh.py", line 136, in __gather_primitives
    export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cache.py", line 65, in wrapper_cached
    result = func(*args)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py", line 51, in gather_primitives
    vertex_groups, modifiers, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cache.py", line 65, in wrapper_cached
    result = func(*args)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py", line 98, in __gather_cache_primitives
    None, blender_mesh, library, blender_object, vertex_groups, modifiers, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py", line 642, in extract_primitives
    v = convert_swizzle_location(vertex.co, armature, blender_object, export_settings)
  File "/home/michalis/installed/blender/2.82/scripts/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py", line 96, in convert_swizzle_location
    apply_matrix = armature.matrix_world.inverted() @ blender_object.matrix_world
AttributeError: 'NoneType' object has no attribute 'matrix_world'
```

The problem is reproducible with the exporter version from Blender 2.82a, and with the latest GitHub version (at this commit https://github.com/KhronosGroup/glTF-Blender-IO/commit/73e3c3a26c0f8e1ea0608ff3ee7933e4d0146039 when I tested).

This pull request contains a simple solution to this (I just added safeguards in case `blender_object` is not set). I am not sure whether this is the correct solution (I didn't found a core reason _why_ is `blender_object` equal to None in such case), although it works in practice.
