### PR TITLE
Import: add "Fortune" bone heuristic

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -859,12 +859,17 @@ class ImportGLTF2(Operator, ImportHelper):
     bone_heuristic: EnumProperty(
         name="Bone Dir",
         items=(
-            ("BLENDER", "Blender (+Y)",
-                "Round-trips bone directions in glTFs exported from Blender.\n"
+            ("BLENDER", "Blender (best for re-importing)",
+                "Good for re-importing glTFs exported from Blender.\n"
                 "Bone tips are placed on their local +Y axis (in glTF space)"),
-            ("TEMPERANCE", "Temperance",
-                "Okay for many different models.\n"
-                "Bone tips are placed at a child's root")
+            ("TEMPERANCE", "Temperance (average)",
+                "Decent all-around strategy.\n"
+                "A bone with one child has its tip placed on the local axis\n"
+                "closest to its child"),
+            ("FORTUNE", "Fortune (may look better, less accurate)",
+                "Might look better than Temperance, but also might have errors.\n"
+                "A bone with one child has its tip placed at its child's root.\n"
+                "Non-uniform scalings may get messed up though, so beware"),
         ),
         description="Heuristic for placing bones. Tries to make bones pretty",
         default="TEMPERANCE",

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_vnode.py
@@ -429,7 +429,7 @@ def pick_bone_rotation(gltf, bone_id, parent_rot):
 
     if gltf.import_settings['bone_heuristic'] == 'BLENDER':
         return Quaternion((2**0.5/2, 2**0.5/2, 0, 0))
-    elif gltf.import_settings['bone_heuristic'] == 'TEMPERANCE':
+    elif gltf.import_settings['bone_heuristic'] in ['TEMPERANCE', 'FORTUNE']:
         return temperance(gltf, bone_id, parent_rot)
 
 def temperance(gltf, bone_id, parent_rot):
@@ -445,7 +445,11 @@ def temperance(gltf, bone_id, parent_rot):
     if child_locs:
         centroid = sum(child_locs, Vector((0, 0, 0)))
         rot = Vector((0, 1, 0)).rotation_difference(centroid)
-        rot = nearby_signed_perm_matrix(rot).to_quaternion()
+        if gltf.import_settings['bone_heuristic'] == 'TEMPERANCE':
+            # Snap to the local axes; required for local_rotation to be
+            # accurate when vnode has a non-uniform scaling.
+            # FORTUNE skips this, so it may look better, but may have errors.
+            rot = nearby_signed_perm_matrix(rot).to_quaternion()
         return rot
 
     return parent_rot


### PR DESCRIPTION
Closes #967. See there for details.

The "Fortune" bone heuristic helps bones look better in files where their local axes are weird, but in exchange may be inaccurate when a bone has a non-uniform scaling.

I also tried to improve the UI text for the bone dir options a bit.