### PR TITLE
Export: less naive file format detection (fix #986)

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -103,7 +103,7 @@ def __gather_mime_type(sockets_or_slots, export_image, export_settings):
 
     if export_settings["gltf_image_format"] == "AUTO":
         image = export_image.blender_image()
-        if image is not None and image.file_format == 'JPEG':
+        if image is not None and __is_blender_image_a_jpeg(image):
             return "image/jpeg"
         return "image/png"
 
@@ -244,3 +244,10 @@ def __get_texname_from_slot(sockets_or_slots, export_settings):
 
     elif isinstance(sockets_or_slots[0], bpy.types.MaterialTextureSlot):
         return sockets_or_slots[0].texture.image.name
+
+
+def __is_blender_image_a_jpeg(image: bpy.types.Image) -> bool:
+    if image.source != 'FILE':
+        return False
+    path = image.filepath_raw.lower()
+    return path.endswith('.jpg') or path.endswith('.jpeg') or path.endswith('.jpe')

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -272,15 +272,24 @@ class ExportImage:
 
     def __encode_from_image(self, image: bpy.types.Image) -> bytes:
         # See if there is an existing file we can use.
+        data = None
         if image.source == 'FILE' and image.file_format == self.file_format and \
                 not image.is_dirty:
             if image.packed_file is not None:
-                return image.packed_file.data
+                data = image.packed_file.data
             else:
                 src_path = bpy.path.abspath(image.filepath_raw)
                 if os.path.isfile(src_path):
                     with open(src_path, 'rb') as f:
-                        return f.read()
+                        data = f.read()
+        # Check magic number is right
+        if data:
+            if self.file_format == 'PNG':
+                if data.startswith(b'\x89PNG'):
+                    return data
+            elif self.file_format == 'JPEG':
+                if data.startswith(b'\xff\xd8\xff'):
+                    return data
 
         # Copy to a temp image and save.
         tmp_image = None


### PR DESCRIPTION
Fixes #986 

There are two parts:

### Fix detection of JPEG images

Checking if `image.file_format == 'JPEG'` turns out to be too naive a way to determine if an image is a JPEG. Reading [the docs](https://docs.blender.org/api/current/bpy.types.Image.html) more carefully, I see that `file_format` is the "format used for re-saving this file", not the format it was loaded with, which does not appear to be accessible to us.

So this adds a more defensive check `__is_blender_image_a_jpeg`. See how it looks to you.

### Don't assume an already-encoded image has the "right" format

The importer currently trusts that when it gets already-encoded data for an image with, say `file_format == 'JPEG'`, that data is JPEG data. This is obviously not true (it might be PSD data), so the encoder now does a sanity check with the magic numbers before it okays already-encoded data. If it fails, it encodes the image itself.

---
Testing is appreciated!