### PR TITLE
Import: set camera near/far (fix #1002)

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_camera.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_camera.py
@@ -35,18 +35,27 @@ class BlenderCamera():
         # Blender create a perspective camera by default
         if pycamera.type == "orthographic":
             cam.type = "ORTHO"
+
+            # TODO: xmag/ymag
+
+            cam.clip_start = pycamera.orthographic.znear
+            cam.clip_end = pycamera.orthographic.zfar
+
         else:
             if hasattr(pycamera.perspective, "yfov"):
                 cam.angle_y = pycamera.perspective.yfov
                 cam.lens_unit = "FOV"
                 cam.sensor_fit = "VERTICAL"
 
-        # TODO: lot's of work for camera here...
-        if hasattr(pycamera, "znear"):
-            cam.clip_start = pycamera.znear
+            # TODO: fov/aspect ratio
 
-        if hasattr(pycamera, "zfar"):
-            cam.clip_end = pycamera.zfar
+            cam.clip_start = pycamera.perspective.znear
+            if pycamera.perspective.zfar is not None:
+                cam.clip_end = pycamera.perspective.zfar
+            else:
+                # Infinite projection
+                cam.clip_end = 1e12  # some big number
+
 
         obj = bpy.data.objects.new(pycamera.name, cam)
         return obj

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_camera.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_camera.py
@@ -42,10 +42,9 @@ class BlenderCamera():
             cam.clip_end = pycamera.orthographic.zfar
 
         else:
-            if hasattr(pycamera.perspective, "yfov"):
-                cam.angle_y = pycamera.perspective.yfov
-                cam.lens_unit = "FOV"
-                cam.sensor_fit = "VERTICAL"
+            cam.angle_y = pycamera.perspective.yfov
+            cam.lens_unit = "FOV"
+            cam.sensor_fit = "VERTICAL"
 
             # TODO: fov/aspect ratio
 


### PR DESCRIPTION
Fixes #1002.

There was code for this, but I think it was old and used hasattr instead the new gltf_io classes. (I also removed the other hasattr check for yfov.)

For infinite perspective projection, this just puts a big number (1e12) in the far field. The infinite projection matrix is the limit of the finite projection matrix as far -> infinity, so theoretically this is okayish, I guess. Not sure what else to do there.