### PR TITLE
Import: use .png/.jpg for temporary files created when importing images

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_image.py
@@ -52,7 +52,11 @@ class BlenderImage():
                 img_data, img_name = BinaryData.get_image_data(gltf, img_idx)
                 if img_data is None:
                     return
-                tmp_file = tempfile.NamedTemporaryFile(prefix='gltfimg', delete=False)
+                tmp_file = tempfile.NamedTemporaryFile(
+                    prefix='gltfimg-',
+                    suffix=_img_extension(img),
+                    delete=False,
+                )
                 tmp_file.write(img_data)
                 tmp_file.close()
                 path = tmp_file.name
@@ -74,3 +78,10 @@ class BlenderImage():
 def _uri_to_path(uri):
     uri = urllib.parse.unquote(uri)
     return normpath(uri)
+
+def _img_extension(img):
+    if img.mime_type == 'image/png':
+        return '.png'
+    if img.mime_type == 'image/jpeg':
+        return '.jpg'
+    return None


### PR DESCRIPTION
The tempfile created when importing an embedded image currently has a name like `gltfimgii5zujup`.  
With this PR, it will look like `gltfimg-ii5zujup.jpg`.

Mostly thinking of #998, but this also makes it slightly nicer if the user unpacks the image since the unpacked file will now have the right file extension.