### PR TITLE
Import: use friendly filenames for temp image files (fix #1026) 

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_image.py
@@ -32,6 +32,7 @@ class BlenderImage():
     def create(gltf, img_idx):
         """Image creation."""
         img = gltf.data.images[img_idx]
+        img_name = img.name
 
         if img.blender_image_name is not None:
             # Image is already used somewhere
@@ -43,16 +44,17 @@ class BlenderImage():
                 # Image stored in a file
                 img_from_file = True
                 path = join(dirname(gltf.filename), _uri_to_path(img.uri))
-                img_name = basename(path)
+                img_name = img_name or basename(path)
                 if not isfile(path):
                     gltf.log.error("Missing file (index " + str(img_idx) + "): " + img.uri)
                     return
             else:
                 # Image stored as data => create a tempfile, pack, and delete file
                 img_from_file = False
-                img_data, img_name = BinaryData.get_image_data(gltf, img_idx)
+                img_data = BinaryData.get_image_data(gltf, img_idx)
                 if img_data is None:
                     return
+                img_name = img_name or 'Image_%d' % img_idx
                 tmp_dir = tempfile.TemporaryDirectory(prefix='gltfimg-')
                 filename = _filenamify(img_name) or 'Image_%d' % img_idx
                 filename += _img_extension(img)

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
@@ -161,16 +161,14 @@ class BinaryData():
     def get_image_data(gltf, img_idx):
         """Get data from image."""
         pyimage = gltf.data.images[img_idx]
-        image_name = "Image_" + str(img_idx)
 
-        assert(not (pyimage.uri is not None and pyimage.buffer_view is not None))
+        assert not (
+            pyimage.uri is not None and
+            pyimage.buffer_view is not None
+        )
 
         if pyimage.uri is not None:
-            data, file_name = gltf.load_uri(pyimage.uri)
-            return data, file_name or image_name
-
-        elif pyimage.buffer_view is not None:
-            data = BinaryData.get_buffer_view(gltf, pyimage.buffer_view)
-            return data, image_name
-
-        return None, None
+            return gltf.load_uri(pyimage.uri)
+        if pyimage.buffer_view is not None:
+            return BinaryData.get_buffer_view(gltf, pyimage.buffer_view)
+        return None

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
@@ -175,7 +175,7 @@ class glTFImporter():
         buffer = self.data.buffers[buffer_idx]
 
         if buffer.uri:
-            data, _file_name = self.load_uri(buffer.uri)
+            data = self.load_uri(buffer.uri)
             if data is not None:
                 self.buffers[buffer_idx] = data
 
@@ -185,20 +185,18 @@ class glTFImporter():
                 self.buffers[buffer_idx] = self.glb_buffer
 
     def load_uri(self, uri):
-        """Loads a URI.
-        Returns the data and the filename of the resource, if there is one.
-        """
+        """Loads a URI."""
         sep = ';base64,'
         if uri.startswith('data:'):
             idx = uri.find(sep)
             if idx != -1:
                 data = uri[idx + len(sep):]
-                return memoryview(base64.b64decode(data)), None
+                return memoryview(base64.b64decode(data))
 
         path = join(dirname(self.filename), unquote(uri))
         try:
             with open(path, 'rb') as f_:
-                return memoryview(f_.read()), basename(path)
+                return memoryview(f_.read())
         except Exception:
             self.log.error("Couldn't read file: " + path)
-            return None, None
+            return None


### PR DESCRIPTION
This fixes #1026 with my second idea, giving temp images nicer filenames in the importer. The exporter will use the nicer filename when re-exporting, and you'll also get nicer filenames when unpacking images.

The filename is based on the image name.

* Example before: `/tmp/gltfimg-lo9zagn6.png`  
* Example after: `/tmp/gltfimg-lo9zagn6/Image_0.png`

------

The second commit will use pyimage.name for an image name when possible (currently pyimage.name is ignored). The order of preference for an image name is now

* image.name
* if the image is from a file, the filename
* `'Image_%d' % img_idx`