### PR TITLE
Change the way sampled keyframe types are determined.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -271,19 +271,19 @@ def __gather_interpolation(channels: typing.Tuple[bpy.types.FCurve],
             # If only single keyframe revert to STEP
             if max_keyframes < 2:
                 return 'STEP'
-            else:
-                blender_keyframe = [c for c in channels if c is not None][0].keyframe_points[0]
 
-                # For sampled animations: CONSTANT are STEP, other are LINEAR
-                return {
-                    "BEZIER": "LINEAR",
-                    "LINEAR": "LINEAR",
-                    "CONSTANT": "STEP"
-                }[blender_keyframe.interpolation]
+            # If all keyframes are CONSTANT, we can use STEP.
+            if all(all(k.interpolation == 'CONSTANT' for k in c.keyframe_points) for c in channels if c is not None):
+                return 'STEP'
 
+            # Otherwise, sampled keyframes use LINEAR interpolation.
+            return 'LINEAR'
+
+    # Non-sampled keyframes implies that all keys are of the same type, and that the
+    # type is supported by glTF (because we checked in needs_baking).
     blender_keyframe = [c for c in channels if c is not None][0].keyframe_points[0]
 
-    # Select the interpolation method. Any unsupported method will fallback to STEP
+    # Select the interpolation method.
     return {
         "BEZIER": "CUBICSPLINE",
         "LINEAR": "LINEAR",


### PR DESCRIPTION
We already check for "mixed" (different interpolations within one channel) and unknown interpolations.  But there was a bit of bad logic at the end, where we try to discover if `STEP` can be used even after sampling.  This would end up crashing for unknown types, and also didn't fall back to LINEAR even if some LINEAR keys appeared after some CONSTANT ones.

Fixes #1027.

I targeted this to 2.83 release, since it's a bugfix.  Let me know if that's OK.