### PR TITLE
Tests: update for Blender 2.90

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,11 @@ jobs:
       - image: node:8-stretch
     parallelism: 2
     environment:
+      BLENDER_MAJOR: 2
+      BLENDER_MINOR: 90
       TEST_FILTERS: >-
-        blender28_export
-        blender28_roundtrip
+        blender_export
+        blender_roundtrip
     steps:
       - checkout
       - run:
@@ -21,27 +23,22 @@ jobs:
             apt -q update && apt install --no-install-recommends -y -q \
               libglu1-mesa \
               libxi6
-            if [[ $FILTER =~ blender28 ]]; then
-              BLENDER28_URL="https://builder.blender.org$(curl -s https://builder.blender.org/download/ | \
-                grep -oe '[^\"]*blender-2\.83[^\"]*linux64[^\"]*' | \
-                tail -n1)"
-              BLENDER28_VERSION=$(echo $BLENDER28_URL | grep -Po 'blender-2\.\K[0-9]+')
-              echo "Installing Blender 2.${BLENDER28_VERSION}"
-              mkdir /opt/blender28
-              echo "Downloading from: $BLENDER28_URL"
-              curl -SL "$BLENDER28_URL" | \
-                tar -Jx -C /opt/blender28 --strip-components=1
-              ln -s /opt/blender28/blender /usr/local/bin/blender28
-            fi
+            echo "Looking for: Blender $BLENDER_MAJOR.$BLENDER_MINOR"
+            BLENDER_URL="https://builder.blender.org$(curl -s https://builder.blender.org/download/ | \
+              grep -oe '[^\"]*blender-'$BLENDER_MAJOR'\.'$BLENDER_MINOR'[^\"]*linux64[^\"]*' | \
+              tail -n1)"
+            mkdir /opt/blender
+            echo "Downloading from: $BLENDER_URL"
+            curl -SL "$BLENDER_URL" | \
+              tar -Jx -C /opt/blender --strip-components=1
+            ln -s /opt/blender/blender /usr/local/bin/blender
+            blender --version
       - run:
           name: Setup Tests
           command: |
-            FILTERS=($TEST_FILTERS)
-            FILTER=${FILTERS[$CIRCLE_NODE_INDEX]}
-            if [[ $FILTER =~ blender28 ]]; then
-              rm -rf /opt/blender28/2.8*/scripts/addons/io_scene_gltf2
-              cp -r addons/io_scene_gltf2 /opt/blender28/2.8*/scripts/addons
-            fi
+            ADDON_DIR=/opt/blender/$BLENDER_MAJOR.$BLENDER_MINOR/scripts/addons
+            rm -rf $ADDON_DIR/io_scene_gltf2
+            cp -r addons/io_scene_gltf2 $ADDON_DIR
             cd tests
             yarn install
             mkdir -p /out

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ These quality-assurance checks improve the reliability of Blender glTF I/O.
 Running the Tests Locally
 -------------------------
 
-To run the tests locally, your system should be modified to include `blender28` as shell scripts (or Windows `.bat` files) in the path that launch their respective versions of Blender, including all command-line arguments.
+To run the tests locally, your system should have a `blender` executable in the path that launches the desired version of Blender.
 
 The latest version of [Yarn](https://yarnpkg.com/en/) should also be installed.
 
-Then, in the `tests` folder of this repository, run `yarn install`, followed by `yarn run test`.  You can limit the test suite to one version of Blender with `yarn run test-blender28`.
+Then, in the `tests` folder of this repository, run `yarn install`, followed by `yarn run test`.

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "test": "mocha --reporter mochawesome",
     "test-bail": "mocha -b --reporter mochawesome",
-    "test-blender28": "mocha -b --reporter mochawesome -g blender28",
     "lint": "eslint **/*.js",
     "lint:fix": "eslint --fix **/*.js"
   },

--- a/tests/test/test.js
+++ b/tests/test/test.js
@@ -19,7 +19,7 @@ const validator = require('gltf-validator');
 const OUT_PREFIX = process.env.OUT_PREFIX || '../tests_out';
 
 const blenderVersions = [
-    "blender28"
+    "blender"
 ];
 
 const validator_info_keys = [


### PR DESCRIPTION
Made an attempt to update the tests for 2.90. Should do 1-5 of #1040. See if this looks okay.

* I renamed hard-coded `blender-28` names to `blender`.
* The tests now call the `blender` command instead of `blender-28`.
* At the next Blender version, it should be enough to bump the new `BLENDER_MAJOR` and `BLENDER_MINOR` variables at the top of the CI script.