### PR TITLE
Export: allow combining different-sized textures (eg for ORM)

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -26,6 +26,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials_pbr_metall
 from ..com.gltf2_blender_extras import generate_extras
 from io_scene_gltf2.blender.exp import gltf2_blender_get
 from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
+from io_scene_gltf2.io.com.gltf2_io_debug import print_console
 
 
 @cached
@@ -192,7 +193,13 @@ def __gather_orm_texture(blender_material, export_settings):
     else:
         result = (occlusion, roughness_socket, metallic_socket)
 
-    # Double-check this will past the filter in texture_info (otherwise there are different resolutions or other problems).
+    if not gltf2_blender_gather_texture_info.check_same_size_images(result):
+        print_console("INFO",
+            "Occlusion and metal-roughness texture will be exported separately "
+            "(use same-sized images if you want them combined)")
+        return None
+
+    # Double-check this will past the filter in texture_info
     info = gltf2_blender_gather_texture_info.gather_texture_info(result, export_settings)
     if info is None:
         return None

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -19,7 +19,6 @@ from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture
 from io_scene_gltf2.blender.exp import gltf2_blender_search_node_tree
 from io_scene_gltf2.blender.exp import gltf2_blender_get
-from io_scene_gltf2.io.com.gltf2_io_debug import print_console
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
 from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
@@ -128,3 +127,21 @@ def __get_tex_from_socket(socket):
     if result[0].shader_node.image is None:
         return None
     return result[0]
+
+
+def check_same_size_images(
+    blender_shader_sockets: typing.Tuple[bpy.types.NodeSocket],
+) -> bool:
+    """Check that all sockets leads to images of the same size."""
+    if not blender_shader_sockets or not all(blender_shader_sockets):
+        return False
+
+    sizes = set()
+    for socket in blender_shader_sockets:
+        tex = __get_tex_from_socket(socket)
+        if tex is None:
+            return False
+        size = tex.shader_node.image.size
+        sizes.add((size[0], size[1]))
+
+    return len(sizes) == 1

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -56,19 +56,6 @@ def __filter_texture_info(blender_shader_sockets_or_texture_slots, export_settin
             # sockets do not lead to a texture --> discard
             return False
 
-        resolution = __get_tex_from_socket(blender_shader_sockets_or_texture_slots[0]).shader_node.image.size
-        if any(any(a != b for a, b in zip(__get_tex_from_socket(elem).shader_node.image.size, resolution))
-               for elem in blender_shader_sockets_or_texture_slots):
-            def format_image(image_node):
-                return "{} ({}x{})".format(image_node.image.name, image_node.image.size[0], image_node.image.size[1])
-
-            images = [format_image(__get_tex_from_socket(elem).shader_node) for elem in
-                      blender_shader_sockets_or_texture_slots]
-
-            print_console("ERROR", "Image sizes do not match. In order to be merged into one image file, "
-                                   "images need to be of the same size. Images: {}".format(images))
-            return False
-
     return True
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -123,41 +123,44 @@ class ExportImage:
     def __encode_unhappy(self) -> bytes:
         # We need to assemble the image out of channels.
         # Do it with numpy and image.pixels.
-        result = None
 
-        img_fills = {
-            chan: fill
-            for chan, fill in self.fills.items()
-            if isinstance(fill, FillImage)
-        }
-        # Loop over images instead of dst_chans; ensures we only decode each
-        # image once even if it's used in multiple channels.
-        image_names = list(set(fill.image.name for fill in img_fills.values()))
-        for image_name in image_names:
-            image = bpy.data.images[image_name]
+        # Find all Blender images used
+        images = []
+        for fill in self.fills.values():
+            if isinstance(fill, FillImage):
+                if fill.image not in images:
+                    images.append(fill.image)
 
-            if result is None:
-                dim = (image.size[0], image.size[1])
-                result = np.ones(dim[0] * dim[1] * 4, np.float32)
-                tmp_buf = np.empty(dim[0] * dim[1] * 4, np.float32)
-            # Images should all be the same size (should be guaranteed by
-            # gather_texture_info).
-            assert (image.size[0], image.size[1]) == dim
+        if not images:
+            # No ImageFills; use a 1x1 white pixel
+            pixels = np.array([1.0, 1.0, 1.0, 1.0])
+            return self.__encode_from_numpy_array(pixels, (1, 1))
 
-            image.pixels.foreach_get(tmp_buf)
+        width = max(image.size[0] for image in images)
+        height = max(image.size[1] for image in images)
 
-            for dst_chan, img_fill in img_fills.items():
-                if img_fill.image == image:
-                    result[int(dst_chan)::4] = tmp_buf[int(img_fill.src_chan)::4]
+        out_buf = np.ones(width * height * 4, np.float32)
+        tmp_buf = np.empty(width * height * 4, np.float32)
+
+        for image in images:
+            if image.size[0] == width and image.size[1] == height:
+                image.pixels.foreach_get(tmp_buf)
+            else:
+                # Image is the wrong size; make a temp copy and scale it.
+                with TmpImageGuard() as guard:
+                    _make_temp_image_copy(guard, src_image=image)
+                    tmp_image = guard.image
+                    tmp_image.scale(width, height)
+                    tmp_image.pixels.foreach_get(tmp_buf)
+
+            # Copy any channels for this image to the output
+            for dst_chan, fill in self.fills.items():
+                if isinstance(fill, FillImage) and fill.image == image:
+                    out_buf[int(dst_chan)::4] = tmp_buf[int(fill.src_chan)::4]
 
         tmp_buf = None  # GC this
 
-        if result is None:
-            # No ImageFills; use a 1x1 white pixel
-            dim = (1, 1)
-            result = np.array([1.0, 1.0, 1.0, 1.0])
-
-        return self.__encode_from_numpy_array(result, dim)
+        return self.__encode_from_numpy_array(out_buf, (width, height))
 
     def __encode_from_numpy_array(self, pixels: np.ndarray, dim: Tuple[int, int]) -> bytes:
         with TmpImageGuard() as guard:


### PR DESCRIPTION
Thinking about #1058...

The exporter currently wants all textures to be the same size when it combines them (eg for ORM textures). It's actually really easy to lift this restriction.

Test Input:

![out](https://user-images.githubusercontent.com/11024420/81259950-a6bb9d80-8ffe-11ea-93ff-87e8bcc8e94a.png)

Output Texture with this PR:

![out2](https://user-images.githubusercontent.com/11024420/81259970-b1763280-8ffe-11ea-88e6-21e6be9fd052.png)

----

First commit is just a refactor that adds a TmpImageGuard class that replaces the `try-finally` stuff with a `with`. This lets me abstract out a function for creating a temp copy of an image easier and cleans the logic up a little.

Second commit changes the code for combining the input images. The output dimensions are computed as the max of the input image dimensions. If an input image isn't the same size as the output, it's copied to a temp image, the temp image is scaled with `image.scale`, and that new image is used instead.

And finally the last commit just removes the check in gather_texture_info that wants all input images to be the same size.