### PR TITLE
Export: small bugfix for occlusion textures

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -191,7 +191,7 @@ def __get_image_data(sockets_or_slots, export_settings) -> ExportImage:
                 dst_chan = Channel.B
             elif socket.name == 'Roughness':
                 dst_chan = Channel.G
-            elif socket.name == 'Occlusion' and len(sockets_or_slots) > 1 and sockets_or_slots[1] is not None:
+            elif socket.name == 'Occlusion':
                 dst_chan = Channel.R
             elif socket.name == 'Alpha' and len(sockets_or_slots) > 1 and sockets_or_slots[1] is not None:
                 dst_chan = Channel.A


### PR DESCRIPTION
When an occlusion texture is used, no metallic/roughness texture is used, and the occlusion comes from a channel other than R, the emitted occlusion texture will be wrong; the channel the occlusion is in doesn't get rearranged to the R channel.

Example:

![ss-a](https://user-images.githubusercontent.com/11024420/81900866-47700700-9583-11ea-9e18-8c52c1b865a4.png)

This should fix it.

That same `and len(sockets_or_slots) > 1 and sockets_or_slots[1] is not None` on the Alpha branch two lines over is suspicious too, but I didn't mess with it.
