### PR TITLE
Fix exporting EXTEND textures

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
@@ -39,7 +39,7 @@ def gather_sampler(blender_shader_node: bpy.types.Node, export_settings):
 
 
 def __filter_sampler(blender_shader_node, export_settings):
-    if not blender_shader_node.interpolation == 'Closest' and not blender_shader_node.extension == 'CLIP':
+    if not blender_shader_node.interpolation == 'Closest' and not blender_shader_node.extension == 'EXTEND':
         return False
     return True
 


### PR DESCRIPTION
I want to export a texture with `Linear` interpolation and `Extend` wrapping. This currently does not create a sampler in the exported file. A sampler is only created when the `Closest` interpolation is used.

This might be a leftover of 34e23a81ab2dced0b81d62615caa2c0a0b6b93d2.