### PR TITLE
Export KHR_materials_transmission.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -296,7 +296,7 @@ def __gather_transmission_extension(blender_material, export_settings):
     transmission_extension = {}
     transmission_slots = ()
 
-    transmission_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, 'Transmission')
+    transmission_socket = gltf2_blender_get.get_socket(blender_material, 'Transmission')
 
     if isinstance(transmission_socket, bpy.types.NodeSocket) and not transmission_socket.is_linked:
         transmission_extension['transmissionFactor'] = transmission_socket.default_value

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -141,7 +141,11 @@ def __gather_extensions(blender_material, export_settings):
     if clearcoat_extension:
         extensions["KHR_materials_clearcoat"] = clearcoat_extension
 
-    # TODO KHR_materials_pbrSpecularGlossiness
+    # KHR_materials_transmission
+
+    transmission_extension = __gather_transmission_extension(blender_material, export_settings)
+    if transmission_extension:
+        extensions["KHR_materials_transmission"] = transmission_extension
 
     return extensions if extensions else None
 
@@ -284,3 +288,34 @@ def __gather_clearcoat_extension(blender_material, export_settings):
         )
 
     return Extension('KHR_materials_clearcoat', clearcoat_extension, False)
+
+def __gather_transmission_extension(blender_material, export_settings):
+    transmission_enabled = False
+    has_transmission_texture = False
+
+    transmission_extension = {}
+    transmission_slots = ()
+
+    transmission_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, 'Transmission')
+
+    if isinstance(transmission_socket, bpy.types.NodeSocket) and not transmission_socket.is_linked:
+        transmission_extension['transmissionFactor'] = transmission_socket.default_value
+        transmission_enabled = transmission_extension['transmissionFactor'] > 0
+    elif __has_image_node_from_socket(transmission_socket):
+        transmission_extension['transmissionFactor'] = 1
+        has_transmission_texture = True
+        transmission_enabled = True
+
+    if not transmission_enabled:
+        return None
+
+    # Pack transmission channel (R).
+    if has_transmission_texture:
+        transmission_slots = (transmission_socket,)
+
+    if len(transmission_slots) > 0:
+        combined_texture = gltf2_blender_gather_texture_info.gather_texture_info(transmission_slots, export_settings)
+        if has_transmission_texture:
+            transmission_extension['transmissionTexture'] = combined_texture
+
+    return Extension('KHR_materials_transmission', transmission_extension, False)

--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -55,6 +55,7 @@ with the following channels of information:
 - Normal Map
 - Emissive
 - Clearcoat (requires ``KHR_materials_clearcoat``)
+- Transmission (requires ``KHR_materials_transmission``)
 
 .. figure:: /images/addons_import-export_scene-gltf2_material-channels.jpg
 
@@ -343,6 +344,8 @@ are supported directly by this add-on:
 
 - ``KHR_draco_mesh_compression``
 - ``KHR_lights_punctual``
+- ``KHR_materials_clearcoat``
+- ``KHR_materials_transmission``
 - ``KHR_materials_unlit``
 - ``KHR_texture_transform``
 


### PR DESCRIPTION
Based on https://github.com/KhronosGroup/glTF/pull/1698.

Tested in BabylonJS and looks pretty close. I plan to try implementing a loader in three.js as well, and will test in more detail then.

**Blender**:

*(I had enabled refraction for this screenshot, and perhaps shouldn't have for the purposes of this extension)*

![Screen Shot 2020-06-15 at 10 14 34 PM](https://user-images.githubusercontent.com/1848368/84734439-ae535800-af55-11ea-8895-874a77fc5f2c.png)


**BabylonJS**:

![Screen Shot 2020-06-15 at 10 10 53 PM](https://user-images.githubusercontent.com/1848368/84734194-29683e80-af55-11ea-9251-65ecd6e1c37c.png)
