### PR TITLE
Fix #1090 lamp corrective node children must be empty array, not None

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -436,7 +436,7 @@ def __get_correction_node(blender_object, export_settings):
                              correction_quaternion[3], correction_quaternion[0]]
     return gltf2_io.Node(
         camera=None,
-        children=None,
+        children=[],
         extensions=None,
         extras=None,
         matrix=None,


### PR DESCRIPTION
Fix #1090 lamp corrective node children must be empty array, not None