### PR TITLE
Export textures in original format unless consolidation is requested

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The glTF-Blender-IO authors.
+# Copyright 2018-2020 The glTF-Blender-IO authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -113,13 +113,16 @@ class ExportGLTF2_Base:
 
     export_image_format: EnumProperty(
         name='Images',
-        items=(('AUTO', 'Automatic',
-                'Save PNGs as PNGs and JPEGs as JPEGs.\n'
-                'If neither one, use PNG'),
-                ('JPEG', 'JPEG Format (.jpg)',
-                'Save images as JPEGs. (Images that need alpha are saved as PNGs though.)\n'
-                'Be aware of a possible loss in quality'),
-               ),
+        items=(
+            ('AUTO', 'Automatic',
+            'Where possible, consolidate related textures into a single file and save it as PNG,\n'
+            'otherwise save PNGs as PNGs and JPEGs as JPEGs.'),
+            ('ASIS', 'Keep as-is',
+            'Where possible, keep image format the same, otherwise save as PNGs.'),
+            ('JPEG', 'JPEG Format (.jpg)',
+            'Save images as JPEGs. (Images that need alpha are saved as PNGs though.)\n'
+            'Be aware of a possible loss in quality'),
+        ),
         description=(
             'Output format for images. PNG is lossless and generally preferred, but JPEG might be preferable for web '
             'applications due to the smaller file size'

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The glTF-Blender-IO authors.
+# Copyright 2018-2020 The glTF-Blender-IO authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ def __gather_mime_type(sockets_or_slots, export_image, export_settings):
         if socket.name == "Alpha":
             return "image/png"
 
-    if export_settings["gltf_image_format"] == "AUTO":
+    if export_settings["gltf_image_format"] in ["AUTO", "ASIS"]:
         image = export_image.blender_image()
         if image is not None and __is_blender_image_a_jpeg(image):
             return "image/jpeg"

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The glTF-Blender-IO authors.
+# Copyright 2018-2020 The glTF-Blender-IO authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -193,7 +193,10 @@ def __gather_orm_texture(blender_material, export_settings):
     else:
         result = (occlusion, roughness_socket, metallic_socket)
 
-    if not gltf2_blender_gather_texture_info.check_same_size_images(result):
+    if export_settings["gltf_image_format"] == "ASIS":
+        return None
+
+    elif not gltf2_blender_gather_texture_info.check_same_size_images(result):
         print_console("INFO",
             "Occlusion and metal-roughness texture will be exported separately "
             "(use same-sized images if you want them combined)")

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -88,12 +88,12 @@ class ExportImage:
 
     def blender_image(self) -> Optional[bpy.types.Image]:
         """If there's an existing Blender image we can use,
-        returns it. Otherwise (if channels need packing),
-        returns None.
+        returns it. Otherwise (if channels need packing or there are multiple
+        Blender images), returns None.
         """
         if self.__on_happy_path():
-            for fill in self.fills.values():
-                return fill.image
+            images = list(set([fill.image for fill in self.fills.values()]))
+            return images[0] if len(images) == 1 else None
         return None
 
     def __on_happy_path(self) -> bool:


### PR DESCRIPTION
Current behaviour:

1. Import GLB with separate O/R/M JPEG textures
2. Export GLB
3. Observe growth of file size due to O/R/M textures were packed into single ORM texture and saved as PNG instead of JPEG (while it could've been used)

Proposed behaviour:

1. Import GLB with separate O/R/M JPEG textures
2. Export GLB
3. Observe growth of file size due to O/R/M textures were packed into single ORM texture and saved as JPEG since all source textures were JPEG
