### PR TITLE
Allow to call a pre and post callbacks

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -485,6 +485,8 @@ class ExportGLTF2_Base:
             bpy.path.ensure_ext(self.filepath,self.filename_ext)))[0] + '.bin'
 
         user_extensions = []
+        pre_export_callbacks = []
+        post_export_callbacks = []
 
         import sys
         preferences = bpy.context.preferences
@@ -500,7 +502,13 @@ class ExportGLTF2_Base:
                 extension_ctors = module.glTF2ExportUserExtensions
                 for extension_ctor in extension_ctors:
                     user_extensions.append(extension_ctor())
+            if hasattr(module, 'glTF2_pre_export_callback'):
+                pre_export_callbacks.append(module.glTF2_pre_export_callback)
+            if hasattr(module, 'glTF2_post_export_callback'):
+                post_export_callbacks.append(module.glTF2_post_export_callback)
         export_settings['gltf_user_extensions'] = user_extensions
+        export_settings['pre_export_callbacks'] = pre_export_callbacks
+        export_settings['post_export_callbacks'] = post_export_callbacks
 
         return gltf2_blender_export.save(context, export_settings)
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
@@ -39,7 +39,15 @@ def save(context, export_settings):
 
     __notify_start(context)
     start_time = time.time()
+    pre_export_callbacks = export_settings["pre_export_callbacks"]
+    for callback in pre_export_callbacks:
+        callback(export_settings)
+
     json, buffer = __export(export_settings)
+
+    post_export_callbacks = export_settings["post_export_callbacks"]
+    for callback in post_export_callbacks:
+        callback(export_settings)
     __write_file(json, buffer, export_settings)
 
     end_time = time.time()


### PR DESCRIPTION
This patch allows to add a callback to be executed before and after the execution of the export. This is useful to do some preprocessing on the scene, for example to do something like asked in https://github.com/KhronosGroup/glTF-Blender-IO/issues/1104

