### PR TITLE
Import: bugfix for occlusion in specgloss

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
@@ -79,7 +79,8 @@ def pbr_specular_glossiness(mh):
     )
 
     if mh.pymat.occlusion_texture is not None:
-        node = make_settings_node(mh, location=(610, -1060))
+        node = make_settings_node(mh)
+        node.location = (610, -1060)
         occlusion(
             mh,
             location=(510, -970),


### PR DESCRIPTION
Broken by #1065. The signature of make_settings_node changed, but this callsite wasn't updated.