### PR TITLE
Ignore Muted Material Nodes

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -59,7 +59,7 @@ def get_socket(blender_material: bpy.types.Material, name: str):
             # because the newer one is always present in all Principled BSDF materials.
             type = bpy.types.ShaderNodeEmission
             name = "Color"
-            nodes = [n for n in blender_material.node_tree.nodes if isinstance(n, type)]
+            nodes = [n for n in blender_material.node_tree.nodes if isinstance(n, type) and not n.mute]
             inputs = sum([[input for input in node.inputs if input.name == name] for node in nodes], [])
             if inputs:
                 return inputs[0]
@@ -71,7 +71,7 @@ def get_socket(blender_material: bpy.types.Material, name: str):
             name = "Color"
         else:
             type = bpy.types.ShaderNodeBsdfPrincipled
-        nodes = [n for n in blender_material.node_tree.nodes if isinstance(n, type)]
+        nodes = [n for n in blender_material.node_tree.nodes if isinstance(n, type) and not n.mute]
         inputs = sum([[input for input in node.inputs if input.name == name] for node in nodes], [])
         if inputs:
             return inputs[0]


### PR DESCRIPTION
I have a setup where I am baking a lightmap of an object. I have both a Principled BSDF for the baking phase and a Background node for exporting so that the baked texture shows up as `KHR_materials_unlit`. When I want to bake, I connect the BSDF to the output, and before exporting, I swap to the Background node.

Unfortunately, the exporter doesn't check if nodes are actually connected to the output. The only way I can export an unlit material is to delete the Principled BSDF node entirely. I'm not sure if Blender has a quick way to check if a node is actually connected to an output, but a quick fix that I am currently using is to just ignore muted material nodes and mute the node that I don't wan't exported.

<img width="673" alt="Screen Shot 2020-07-08 at 3 45 54 AM" src="https://user-images.githubusercontent.com/889879/86909816-87f48880-c0cd-11ea-9657-553a3e817b17.png">
