### PR TITLE
Import: add option to glue pieces of a mesh together

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -862,6 +862,18 @@ class ImportGLTF2(Operator, ImportHelper):
         default=True
     )
 
+    merge_vertices: BoolProperty(
+        name='Merge Vertices',
+        description=(
+            'The glTF format requires discontinuous normals, UVs, and '
+            'other vertex attributes to be stored as separate vertices, '
+            'as required for rendering on typical graphics hardware.\n'
+            'This option attempts to combine co-located vertices where possible.\n'
+            'Currently cannot combine verts with different normals'
+        ),
+        default=False,
+    )
+
     import_shading: EnumProperty(
         name="Shading",
         items=(("NORMALS", "Use Normal Data", ""),
@@ -906,6 +918,7 @@ class ImportGLTF2(Operator, ImportHelper):
         layout.use_property_decorate = False  # No animation.
 
         layout.prop(self, 'import_pack_images')
+        layout.prop(self, 'merge_vertices')
         layout.prop(self, 'import_shading')
         layout.prop(self, 'guess_original_bind_pose')
         layout.prop(self, 'bone_heuristic')


### PR DESCRIPTION
Done on top of #1121. (So look at the third commit.)  
Makes a start on #1069.

This adds an option "Glue Pieces Together" (off by default) that serves to partially invert the exporter's splitting of a mesh into pieces with continuous normals/UVs/colors/etc. (As always, tell me if you have a better idea for the option name).

It *cannot* glue along discontinuous normals though, since that would require using per-loop normals which, as I've said before, presents difficulties. That means it works best for models with smooth normals. For example, it will import CesiumMan in one piece. It improves the cube in the OP of #1069 to just 6 pieces, but getting to 1 piece would require gluing discontinuous normals.

(This simplification versus the prototype (not gluing along discontinuous normals) also makes it so that all tests would pass if it were turned on.)

The code impact on the new importer from #1121 is quite small, which makes it easy to flip this on or off with an option. For the future, adding per-loop normal support is a bit more annoying, but still fits into the new code structure without too much trouble.

Performance impact (unlike my last prototype) is quite minimal.

@emackey

![out](https://user-images.githubusercontent.com/11024420/87516029-5c7c1b80-c642-11ea-9b84-0f56f049d561.png)