### PR TITLE
Better filtering of exported nodes

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -125,8 +125,6 @@ def __filter_node(blender_object, blender_scene, export_settings):
             else:
                 # Not instanced, not linked -> We don't keep this object
                 return False
-    if blender_object.visible_get() is False:
-        return False
     if export_settings[gltf2_blender_export_keys.SELECTED] and blender_object.select_get() is False:
         return False
 


### PR DESCRIPTION
This PR deals with parent nodes and ancestor nodes that have been filtered out of glTF export, typically by "use_selected" failing to select the parents of live children.  Previously, such nodes would be completely excluded, leaving a hole in the scene graph with a disconnected section below.

In this PR, if a given node fails the export filter, but that node has descendants that pass the export filter, then the failed node is still a critical node to include in the glTF node hierarchy.  The failed node will not export any mesh, skin, camera, or weights.  But as a parent or ancestor of live descendants, the node will still include its transformations, animations, extras, and extensions, which may have visible effects on the descendants.

This PR could use a bit of additional testing, with animations and skinning in play.