### PR TITLE
Import: bugfix for skinned mesh normals not being renormalized

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -540,11 +540,17 @@ def skin_into_bind_pose(gltf, skin_idx, vert_joints, vert_weights, locs, vert_no
     if len(vert_normals) != 0:
         vert_normals[:] = mul_mats_vecs(skinning_mats_3x3, vert_normals)
         # Don't translate normals!
+        normalize_vecs(vert_normals)
 
 
 def mul_mats_vecs(mats, vecs):
     """Given [m1,m2,...] and [v1,v2,...], returns [m1@v1,m2@v2,...]. 3D only."""
     return np.matmul(mats, vecs.reshape(len(vecs), 3, 1)).reshape(len(vecs), 3)
+
+
+def normalize_vecs(vectors):
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    np.divide(vectors, norms, out=vectors, where=norms != 0)
 
 
 def merge_duplicate_verts(vert_locs, vert_normals, vert_joints, vert_weights, sk_vert_locs, loop_vidxs, edge_vidxs):


### PR DESCRIPTION
Bug introduced in #1121.

I forgot to renormalize normals after skinning them into the bind pose. The old code for `skin_normal` re-normalized here

https://github.com/KhronosGroup/glTF-Blender-IO/blob/f5128eb4b72ab9366441bc054b96589d973a6177/addons/io_scene_gltf2/blender/imp/gltf2_blender_primitive.py#L111

The bug is visible as too many polys being marked flat in models that have big scale factors. The code for marking polys flat depends on the dot product of two normals being >=1 only when they are equal, which isn't true if the normals have lengths >=1.

This is a bugfix, so PRed against the 2.90 branch.