### PR TITLE
Export joint indices as uint8 when possible

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
@@ -161,9 +161,12 @@ def __gather_skins(blender_primitive, export_settings):
 
             # joints
             internal_joint = blender_primitive["attributes"][joint_id]
+            component_type=gltf2_io_constants.ComponentType.UnsignedShort
+            if max(internal_joint) < 256:
+                component_type = gltf2_io_constants.ComponentType.UnsignedByte
             joint = array_to_accessor(
                 internal_joint,
-                component_type=gltf2_io_constants.ComponentType.UnsignedShort,
+                component_type,
                 data_type=gltf2_io_constants.DataType.Vec4,
             )
             attributes[joint_id] = joint

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
@@ -161,7 +161,7 @@ def __gather_skins(blender_primitive, export_settings):
 
             # joints
             internal_joint = blender_primitive["attributes"][joint_id]
-            component_type=gltf2_io_constants.ComponentType.UnsignedShort
+            component_type = gltf2_io_constants.ComponentType.UnsignedShort
             if max(internal_joint) < 256:
                 component_type = gltf2_io_constants.ComponentType.UnsignedByte
             joint = array_to_accessor(


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/glTF-Blender-IO/issues/1124. I tested this on a rig with <256 joints and a rig with >256 joints. Both exported the expected accessor type, had correct joint data, passed validation, and could be imported back into Blender with the correct result. Clearly, making the change was easy; creating the rig with >256 joints turned out to be a much longer detour.