### PR TITLE
Update gltf2_blender_gltf2_exporter.py to allow for extensions in the asset node

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
@@ -23,6 +23,7 @@ from io_scene_gltf2.io.exp import gltf2_io_binary_data
 from io_scene_gltf2.io.exp import gltf2_io_buffer
 from io_scene_gltf2.io.exp import gltf2_io_image_data
 from io_scene_gltf2.blender.exp import gltf2_blender_export_keys
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
 
 class GlTF2Exporter:
@@ -44,6 +45,8 @@ class GlTF2Exporter:
             generator='Khronos glTF Blender I/O v' + get_version_string(),
             min_version=None,
             version='2.0')
+        
+        export_user_extensions('gather_asset_hook', export_settings, asset)
 
         self.__gltf = gltf2_io.Gltf(
             accessors=[],
@@ -103,6 +106,8 @@ class GlTF2Exporter:
             gltf2_io.MaterialNormalTextureInfoClass,
             gltf2_io.MaterialOcclusionTextureInfoClass
         ]
+        
+        self.__traverse(asset)
 
     @property
     def glTF(self):

--- a/example-addons/example_gltf_extension/readme.md
+++ b/example-addons/example_gltf_extension/readme.md
@@ -1,0 +1,21 @@
+Here you'll find information on how to add extensions to a glTF file from an external Blender addon.
+
+Add a class named "gltf2ExportUserExtension" to your addon and instanciate an object of the class io_scene_gltf2.io.com.gltf2_io_extensions.Extension
+
+class glTF2ExportUserExtension:
+
+    def __init__(self):
+        from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
+        self.Extension = Extension
+
+
+Next, define functions that contain the data of the extension you would like to include. Write those functions for each type you want to include extensions for. Currently implemented are:
+
+gather_node_hook(self, gltf2_object, blender_object, export_settings)
+gather_material_hook(self, gltf2_material, blender_material, export_settings)
+...
+
+
+
+
+


### PR DESCRIPTION
It's a small change that will allow external addon authors to add extensions to the asset node of the glTF file. The format follows all other extensions and naming conventions. You can add the extension by implementing the function _gather_asset_hook(self, gltf2_asset, export_settings)_ in your addon.