### PR TITLE
Export: stopgap for zero-weight verts producing invalid files (#308)

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -286,6 +286,7 @@ def extract_primitives(glTF, blender_mesh, library, blender_object, blender_vert
                         bones.append((joint, weight))
                 bones.sort(key=lambda x: x[1], reverse=True)
                 bones = tuple(bones)
+                if not bones: bones = ((0, 1.0),)  # HACK for verts with zero weight (#308)
                 vert += (bones,)
 
             for shape_key in shape_keys:


### PR DESCRIPTION
This is a stopgap against producing invalid glTFs with zero weight verts when a vert is not assigned to a bone. It doesn't fix these verts, but it produces a valid and consistent file by assigning them to the 0th joint of the skin (which is how the Three.js viewer was already treating them). I think we should get this in for 2.90 and then work on a real fix later, so PRed against 2.90.

If you have a root bone that always has the default TRS (so that skinning with it is the same as not skinning) then you're in luck because this also happens to be correct for your file! For example, this fixes the tree from #308.

Fixes #308 (in the sense that there are no more zero-weights). I'll file another issue with a .blend that does not happen to be fixed by this to continue the discussion about how to _really_ fix this.　　edit: filed at #1151.

----

Test file. Two verts are unassigned, two are assigned to the bone. The unassigned verts behave as if they weren't skinned. Our exported file should look like the right side. (Cube is for scale.)

![first](https://user-images.githubusercontent.com/11024420/88677824-5d399680-d0b3-11ea-869c-ad5ca448465e.png)

Exporting with master produces an invalid file with zero-weight verts. Appearance in Three/Babylon/Blender(re-import). None of them are correct, but all of them are different.

![sec](https://user-images.githubusercontent.com/11024420/88677920-7f331900-d0b3-11ea-9dec-aee48093832d.png)

Exporting with this branch produces a valid file. Again, none of them are correct, but they are now all consistent.

![third](https://user-images.githubusercontent.com/11024420/88678939-958da480-d0b4-11ea-8ef1-053d0b173329.png)