### PR TITLE
Import: bugfix for primitives having different numbers of TEXCOORD_{n}s

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -200,7 +200,7 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
                     uvs = BinaryData.decode_accessor(gltf, prim.attributes['TEXCOORD_%d' % uv_i], cache=True)
                     uvs = uvs[indices]
                 else:
-                    uvs = np.zeros((len(indices), 3), dtype=np.float32)
+                    uvs = np.zeros((len(indices), 2), dtype=np.float32)
                 loop_uvs[uv_i] = np.concatenate((loop_uvs[uv_i], uvs))
 
             for col_i in range(num_cols):


### PR DESCRIPTION
Copy-paste error from #1121.

This prevented importing meshes whose primitives have different numbers of TEXCOORD_n sets.

edit: switched base branch to 2.90.