### PR TITLE
Export: always write texture samplers

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
@@ -20,9 +20,6 @@ from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extension
 
 @cached
 def gather_sampler(blender_shader_node: bpy.types.Node, export_settings):
-    if not __filter_sampler(blender_shader_node, export_settings):
-        return None
-
     sampler = gltf2_io.Sampler(
         extensions=__gather_extensions(blender_shader_node, export_settings),
         extras=__gather_extras(blender_shader_node, export_settings),
@@ -36,12 +33,6 @@ def gather_sampler(blender_shader_node: bpy.types.Node, export_settings):
     export_user_extensions('gather_sampler_hook', export_settings, sampler, blender_shader_node)
 
     return sampler
-
-
-def __filter_sampler(blender_shader_node, export_settings):
-    if not blender_shader_node.interpolation == 'Closest' and not blender_shader_node.extension == 'EXTEND':
-        return False
-    return True
 
 
 def __gather_extensions(blender_shader_node, export_settings):

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
@@ -16,6 +16,7 @@ import bpy
 from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
+from io_scene_gltf2.io.com.gltf2_io_constants import TextureFilter, TextureWrap
 
 
 @cached
@@ -68,14 +69,14 @@ def __gather_extras(blender_shader_node, export_settings):
 
 def __gather_mag_filter(blender_shader_node, export_settings):
     if blender_shader_node.interpolation == 'Closest':
-        return 9728  # NEAREST
-    return 9729  # LINEAR
+        return TextureFilter.Nearest
+    return TextureFilter.Linear
 
 
 def __gather_min_filter(blender_shader_node, export_settings):
     if blender_shader_node.interpolation == 'Closest':
-        return 9984  # NEAREST_MIPMAP_NEAREST
-    return 9986  # NEAREST_MIPMAP_LINEAR
+        return TextureFilter.NearestMipmapNearest
+    return TextureFilter.NearestMipmapLinear
 
 
 def __gather_name(blender_shader_node, export_settings):
@@ -84,11 +85,11 @@ def __gather_name(blender_shader_node, export_settings):
 
 def __gather_wrap_s(blender_shader_node, export_settings):
     if blender_shader_node.extension == 'EXTEND':
-        return 33071
+        return TextureWrap.ClampToEdge
     return None
 
 
 def __gather_wrap_t(blender_shader_node, export_settings):
     if blender_shader_node.extension == 'EXTEND':
-        return 33071
+        return TextureWrap.ClampToEdge
     return None

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_sampler.py
@@ -32,7 +32,30 @@ def gather_sampler(blender_shader_node: bpy.types.Node, export_settings):
 
     export_user_extensions('gather_sampler_hook', export_settings, sampler, blender_shader_node)
 
+    if not sampler.extensions and not sampler.extras and not sampler.name:
+        return __sampler_by_value(
+            sampler.mag_filter,
+            sampler.min_filter,
+            sampler.wrap_s,
+            sampler.wrap_t,
+            export_settings,
+        )
+
     return sampler
+
+
+@cached
+def __sampler_by_value(mag_filter, min_filter, wrap_s, wrap_t, export_settings):
+    # @cached function to dedupe samplers with the same settings.
+    return gltf2_io.Sampler(
+        extensions=None,
+        extras=None,
+        mag_filter=mag_filter,
+        min_filter=min_filter,
+        name=None,
+        wrap_s=wrap_s,
+        wrap_t=wrap_t,
+    )
 
 
 def __gather_extensions(blender_shader_node, export_settings):


### PR DESCRIPTION
Fixes #307.

According to the spec, when texture filtering options are not defined

> **Default Filtering Implementation Note:** When filtering options are defined, runtime must use them. Otherwise, it is free to adapt filtering to performance or quality goals.

But the exporter currently skips writing a sampler for eg. a LINEAR/REPEAT texture node, acting as if the default filtering were linear.

This deletes the __filter_sampler function and always writes a texture sampler.

The exporter already wrote duplicate samplers, but removing __filter_sampler exacerbates this problem since most textures will have the same LINEAR/REPEAT sampler. So the second commit adds a `@cache`d function for deduping identical samplers.

The third commit is just a minor refactor to use the named constants for sampler values instead of numbers + comments.