### PR TITLE
Import: allow undo

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -844,6 +844,7 @@ class ImportGLTF2(Operator, ImportHelper):
     """Load a glTF 2.0 file"""
     bl_idname = 'import_scene.gltf'
     bl_label = 'Import glTF 2.0'
+    bl_options = {'PRESET', 'UNDO'}
 
     filter_glob: StringProperty(default="*.glb;*.gltf", options={'HIDDEN'})
 


### PR DESCRIPTION
Fixes #1163.

I just copied the same bl_options as the OBJ/FBX importer.

(I don't know what `PRESET` does. The docs just say "Display a preset button with the operators settings".)