### PR TITLE
Import: convert glTF meters to the units of the Blender scene

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_gltf.py
@@ -50,21 +50,14 @@ class BlenderGlTF():
 
     @staticmethod
     def set_convert_functions(gltf):
-        gltf.yup2zup = bpy.app.debug_value != 100
-
         if bpy.app.debug_value != 100:
-            # unit_scale = (Blender units) / (meters)
-            gltf.unit_scale = 1.0 / bpy.context.scene.unit_settings.scale_length
-        else:
-            gltf.unit_scale = 1
-        u = gltf.unit_scale
+            # Unit conversion factor in (Blender units) per meter
+            u = 1.0 / bpy.context.scene.unit_settings.scale_length
 
-        if gltf.yup2zup:
             # glTF Y-Up space --> Blender Z-up space
             # X,Y,Z --> X,-Z,Y
             def convert_loc(x): return u * Vector([x[0], -x[2], x[1]])
             def convert_quat(q): return Quaternion([q[3], q[0], -q[2], q[1]])
-            def convert_normal(n): return Vector([n[0], -n[2], n[1]])
             def convert_scale(s): return Vector([s[0], s[2], s[1]])
             def convert_matrix(m):
                 return Matrix([
@@ -73,10 +66,17 @@ class BlenderGlTF():
                     [   m[1],   -m[ 9],    m[5],  m[13]*u],
                     [ m[3]/u, -m[11]/u,  m[7]/u,    m[15]],
                 ])
-                # m[3],m[11],m[7] should probably be zero, maybe we don't
-                # need to divide them...
 
-            # TODO: move loc/normal conversion for a numpy array here too
+            # Batch versions operate in place on a numpy array
+            def convert_locs_batch(locs):
+                # x,y,z -> x,-z,y
+                locs[:, [1,2]] = locs[:, [2,1]]
+                locs[:, 1] *= -1
+                # Unit conversion
+                if u != 1: locs *= u
+            def convert_normals_batch(ns):
+                ns[:, [1,2]] = ns[:, [2,1]]
+                ns[:, 1] *= -1
 
             # Correction for cameras and lights.
             # glTF: right = +X, forward = -Z, up = +Y
@@ -88,17 +88,20 @@ class BlenderGlTF():
         else:
             def convert_loc(x): return Vector(x)
             def convert_quat(q): return Quaternion([q[3], q[0], q[1], q[2]])
-            def convert_normal(n): return Vector(n)
             def convert_scale(s): return Vector(s)
             def convert_matrix(m):
                 return Matrix([m[0::4], m[1::4], m[2::4], m[3::4]])
+
+            def convert_locs_batch(_locs): return
+            def convert_normals_batch(_ns): return
 
             # Same convention, no correction needed.
             gltf.camera_correction = None
 
         gltf.loc_gltf_to_blender = convert_loc
+        gltf.locs_batch_gltf_to_blender = convert_locs_batch
         gltf.quaternion_gltf_to_blender = convert_quat
-        gltf.normal_gltf_to_blender = convert_normal
+        gltf.normals_batch_gltf_to_blender = convert_normals_batch
         gltf.scale_gltf_to_blender = convert_scale
         gltf.matrix_gltf_to_blender = convert_matrix
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -238,6 +238,11 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
         for sk_locs in sk_vert_locs:
             locs_yup_to_zup(sk_locs)
 
+    if gltf.unit_scale != 1:
+        vert_locs *= gltf.unit_scale
+        for sk_locs in sk_vert_locs:
+            sk_locs *= gltf.unit_scale
+
     if num_joint_sets:
         skin_into_bind_pose(
             gltf, skin_idx, vert_joints, vert_weights,

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -232,16 +232,10 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
     for sk_locs in sk_vert_locs:
         sk_locs += vert_locs
 
-    if gltf.yup2zup:
-        locs_yup_to_zup(vert_locs)
-        locs_yup_to_zup(vert_normals)
-        for sk_locs in sk_vert_locs:
-            locs_yup_to_zup(sk_locs)
-
-    if gltf.unit_scale != 1:
-        vert_locs *= gltf.unit_scale
-        for sk_locs in sk_vert_locs:
-            sk_locs *= gltf.unit_scale
+    gltf.locs_batch_gltf_to_blender(vert_locs)
+    gltf.normals_batch_gltf_to_blender(vert_normals)
+    for sk_locs in sk_vert_locs:
+        gltf.locs_batch_gltf_to_blender(sk_locs)
 
     if num_joint_sets:
         skin_into_bind_pose(
@@ -490,12 +484,6 @@ def colors_linear_to_srgb(color):
     small_result = np.where(color < 0.0, 0.0, color * 12.92)
     large_result = 1.055 * np.power(color, 1.0 / 2.4, where=not_small) - 0.055
     color[:] = np.where(not_small, large_result, small_result)
-
-
-def locs_yup_to_zup(vecs):
-    # x,y,z -> x,-z,y
-    vecs[:, [1,2]] = vecs[:, [2,1]]
-    vecs[:, 1] *= -1
 
 
 def uvs_gltf_to_blender(uvs):


### PR DESCRIPTION
This is fast to do since we use numpy now. I also refactored slightly so all the glTF->Blenders conversions are defined in set_convert_functions again.

When debug_value == 100, the unit change is skipped, just like the Yup2Zup conversion.

The DAE importer has an option that lets you disable the unit conversion, but I figured we could always add one later if we want. The only problem I could think of is loss of float precision when the scale_length is very small/large.

Cf #365.