### PR TITLE
Import/Perf: ensure normalized accessors decode to float32s

### DIFF
--- a/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_binary.py
@@ -183,8 +183,8 @@ class BinaryData():
                 array = np.maximum(-1.0, array / 32767.0)
             elif accessor.component_type == 5123:  # uint16
                 array = array / 65535.0
-            else:
-                array = array.astype(np.float64)
+
+            array = array.astype(np.float32, copy=False)
 
         return array
 


### PR DESCRIPTION
Normalized accessors currently decode to numpy arrays of float64s. Blender stores float32s internally I think, and it makes a big performance difference that we get this type right when using foreach_set.

This is kind of a lazy implementation because it still decodes to float64s, it just casts afterwards lol.

Import times tested with original.glb from #1166, which uses normalized vertex colors:

* master: 7.4s
* this branch: 5.3s