### PR TITLE
Export: detect when a file will be overwritten (#718)

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -76,8 +76,11 @@ def on_export_format_changed(self, context):
     operator = sfile.active_operator
     if operator.check(context):
         # Weird hack to force the filepicker to notice filename changed
-        bpy.ops.file.filenum(increment=1)
+        from os.path import basename
+        filepath = operator.filepath
         bpy.ops.file.filenum(increment=-1)
+        if basename(operator.filepath) != basename(filepath):
+            bpy.ops.file.filenum(increment=1)
 
 
 class ExportGLTF2_Base:

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -74,6 +74,8 @@ def on_export_format_changed(self, context):
     # Update the file extension when the format (.glb/.gltf) changes
     sfile = context.space_data
     operator = sfile.active_operator
+    if operator.bl_idname != "EXPORT_SCENE_OT_gltf":
+        return
     if operator.check(context):
         # Weird hack to force the filepicker to notice filename changed
         from os.path import basename

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -364,18 +364,25 @@ class ExportGLTF2_Base:
     def check(self, _context):
         # Ensure file extension matches format
         import os
-        filepath = self.filepath
-        desired_ext = '.glb' if self.export_format == 'GLB' else '.gltf'
-        root, ext = os.path.splitext(filepath)
-        ext_lower = ext.lower()
-        if ext_lower not in ['.glb', '.gltf']:
-            filepath = filepath + desired_ext
-        elif ext_lower != desired_ext:
-            filepath = root + desired_ext
+        filename = os.path.basename(self.filepath)
+        if filename:
+            filepath = self.filepath
+            desired_ext = '.glb' if self.export_format == 'GLB' else '.gltf'
 
-        if filepath != self.filepath:
-            self.filepath = filepath
-            return True
+            stem, ext = os.path.splitext(filename)
+            if stem.startswith('.') and not ext:
+                stem, ext = '', stem
+
+            ext_lower = ext.lower()
+            if ext_lower not in ['.glb', '.gltf']:
+                filepath = filepath + desired_ext
+            elif ext_lower != desired_ext:
+                filepath = filepath[:-len(ext)]  # strip off ext
+                filepath += desired_ext
+
+            if filepath != self.filepath:
+                self.filepath = filepath
+                return True
 
         return False
 


### PR DESCRIPTION
Fixes #718.

Detects (ie. the picker turns red) when you're going to overwrite a file. The file extension is now shown on the picker screen. It updates whenever you change the filename or change the format option.

I think the behavior for scripting is the same as master except in the obscure case when glTF extensions would "double-up"

````py
bpy.ops.export_scene.gltf(filepath='a.gltf', export_format='GLB')
# master => a.gltf.glb
# this branch => a.glb
bpy.ops.export_scene.gltf(filepath='a.glb', export_format='GLTF_EMBEDDED')
# master => a.glb.gltf
# this branch => a.gltf
````