### PR TITLE
Docs: Mention requirements for sampling driver-controlled shape keys.

### DIFF
--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -385,7 +385,7 @@ Only active action of each objects will be taken into account, and merged into a
 .. note::
 
    In order to sample shape key animations controlled by drivers using bone transformations,
-   they must be on a mesh object which is a child of the bones' armature.
+   they must be on a mesh object which is a direct child of the bones' armature.
 
 
 Custom Properties

--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -382,6 +382,11 @@ option is selected (on by default). All glTF animations are imported as NLA Stri
 If option is disabled, Blender NLA strip actions will be ignored.
 Only active action of each objects will be taken into account, and merged into a single glTF animation.
 
+.. note::
+
+   In order for shape key animations controlled by drivers using bone transformations to be sampled,
+   they must be on a mesh object which is a child of the bones' armature.
+
 
 Custom Properties
 -----------------

--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -384,7 +384,7 @@ Only active action of each objects will be taken into account, and merged into a
 
 .. note::
 
-   In order for shape key animations controlled by drivers using bone transformations to be sampled,
+   In order to sample shape key animations controlled by drivers using bone transformations,
    they must be on a mesh object which is a child of the bones' armature.
 
 


### PR DESCRIPTION
I ran into a workflow difficulty in #1178. It's conceivable that other people may as well.

I don't think I saw this information anywhere else in the documentation or UI, but I may have missed something.

I also don't actually know how this behaviour is implemented, so I described only the specific case I encountered (and which is probably the most likely to be encountered). Is it special-cased for only `Armature`>`Bone`>`Transform`>`Driver` shape key animations, is it a consequence of more general behaviour around sampling of animations in object hierarchies, or is it something in between? 