### PR TITLE
Replace factory reset with select-all and delete.

### DIFF
--- a/tests/roundtrip_gltf.py
+++ b/tests/roundtrip_gltf.py
@@ -25,7 +25,9 @@ try:
 
     filepath = argv[0]
 
-    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
     bpy.ops.import_scene.gltf(filepath=argv[0])
 
     extension = '.gltf'


### PR DESCRIPTION
For developers with custom system scripts folders, as described in the DEBUGGING.md document, the factory reset was killing off
the glTF addon itself.

This replaces it with a simple select-all and delete, so the roundtrip tests don't get polluted by the default cube, light, and camera, but any custom folder settings will survive.

This shouldn't have any real effect on CircleCI, but will be of use to developers running tests locally.