### PR TITLE
Export: more descriptive exception when from_union fails

### DIFF
--- a/addons/io_scene_gltf2/io/com/gltf2_io.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io.py
@@ -53,7 +53,7 @@ def from_union(fs, x):
         for tbi in tb_info:
             filename, line, func, text = tbi
             gltf2_io_debug.print_console('ERROR', 'An error occurred on line {} in statement {}'.format(line, text))
-    assert False
+    raise TypeError(x)
 
 
 def from_dict(f, x):


### PR DESCRIPTION
Replaces `assert False` with `raise TypeError(x)` so the argument `x` will show up in the trace.

The stack trace to this assert is not currently very useful in diagnosing errors, see eg. most recently #1175. Hopefully this will help.