### PR TITLE
Permit missing texture.source

### DIFF
--- a/addons/io_scene_gltf2/io/com/gltf2_io.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io.py
@@ -1117,7 +1117,7 @@ class Texture:
         extras = obj.get("extras")
         name = from_union([from_str, from_none], obj.get("name"))
         sampler = from_union([from_int, from_none], obj.get("sampler"))
-        source = from_int(obj.get("source"))
+        source = from_union([from_int, from_none], obj.get("source"))
         return Texture(extensions, extras, name, sampler, source)
 
     def to_dict(self):
@@ -1127,7 +1127,7 @@ class Texture:
         result["extras"] = from_extra(self.extras)
         result["name"] = from_union([from_str, from_none], self.name)
         result["sampler"] = from_union([from_int, from_none], self.sampler)
-        result["source"] = from_int(self.source)  # most viewers can't handle missing sources
+        result["source"] = from_union([from_int, from_none], self.source)
         return result
 
 


### PR DESCRIPTION
The texture.source property is not required, but the importer barfs if it's missing. gltf2_blender_texture [handles](https://github.com/KhronosGroup/glTF-Blender-IO/blob/fdce5bcf687f3d0dd9b0ec5a4e74faf9f267745c/addons/io_scene_gltf2/blender/imp/gltf2_blender_texture.py#L46) the None case, it's just that the gltf2_io classes won't parse it correctly in from_dict. This fixes it.

I also changed to_dict to permit None here. There was a comment: `# most viewers can't handle missing sources` (ironic, since that included us). But the gltf2_io class is not the right place to enforce this. It should be done in gather_texture, which it [is](https://github.com/KhronosGroup/glTF-Blender-IO/blob/fdce5bcf687f3d0dd9b0ec5a4e74faf9f267745c/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture.py#L49-L51).