### PR TITLE
Import: unlit: don't force opaque materials to HASHED blend mode

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_unlit.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_unlit.py
@@ -34,9 +34,6 @@ def unlit(mh):
     mh.node_tree.links.new(mix_node.inputs['Fac'], lightpath_node.outputs['Is Camera Ray'])
     mh.node_tree.links.new(mix_node.inputs[1], transparent_node.outputs[0])
     mh.node_tree.links.new(mix_node.inputs[2], emission_node.outputs[0])
-    # Using transparency requires alpha blending for Eevee
-    if mh.is_opaque():
-        mh.mat.blend_method = 'HASHED' # TODO check best result in eevee
 
     _emission_socket, alpha_socket = make_output_nodes(
         mh,


### PR DESCRIPTION
Contrary to the comment here, I couldn't find any effect of switching to HASHED.

![out](https://user-images.githubusercontent.com/11024420/91652276-2ad8db80-ea5b-11ea-8e33-67c64f0b1422.png)

@julienduroure Do you know if this is good for something?