### PR TITLE
⚡️ Drastically improve performance when creating bufferViews by using…

### DIFF
--- a/addons/io_scene_gltf2/io/exp/gltf2_io_buffer.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_buffer.py
@@ -22,21 +22,23 @@ class Buffer:
     """Class representing binary data for use in a glTF file as 'buffer' property."""
 
     def __init__(self, buffer_index=0):
-        self.__data = b""
+        self.__data = bytearray(b"")
         self.__buffer_index = buffer_index
 
     def add_and_get_view(self, binary_data: gltf2_io_binary_data.BinaryData) -> gltf2_io.BufferView:
         """Add binary data to the buffer. Return a glTF BufferView."""
         offset = len(self.__data)
-        self.__data += binary_data.data
+        self.__data.extend(binary_data.data)
+
+        length = binary_data.byte_length
 
         # offsets should be a multiple of 4 --> therefore add padding if necessary
-        padding = (4 - (binary_data.byte_length % 4)) % 4
-        self.__data += b"\x00" * padding
+        padding = (4 - (length % 4)) % 4
+        self.__data.extend(b"\x00" * padding)
 
         buffer_view = gltf2_io.BufferView(
             buffer=self.__buffer_index,
-            byte_length=binary_data.byte_length,
+            byte_length=length,
             byte_offset=offset,
             byte_stride=None,
             extensions=None,


### PR DESCRIPTION
… bytearrays

I am exporting big scenes (several hundred objects - resulting glb is 800MB+) and I finally found time to investigate why performance was so bad in my case.

Here is a simple change that boosts performance in my case.

I couldn't quite believe how much performance was gained.

Before:

`INFO: Finished glTF 2.0 export in 3073.9336087703705 s`

After:

`Finished glTF 2.0 export in 59.18472361564636 s`

Resulting file has same sha1 and is fully working :S

I guess this should help others with big scenes as well.