### PR TITLE
export material: new option to keep placeholders

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -217,12 +217,11 @@ class ExportGLTF2_Base:
     export_materials: EnumProperty(
         name='Materials',
         items=(('EXPORT', 'Export',
-                'Export materials '),
-                ('PLACEHOLDER', 'Placeholder',
-                'Do not export materials, but keep placeholder primitives '),
-                ('NONE', 'No export',
-                'Do not export materials '),
-               ),
+        'Export all materials used by included objects'),
+        ('PLACEHOLDER', 'Placeholder',
+        'Do not export materials, but write multiple primitive groups per mesh, keeping material slot information'),
+        ('NONE', 'No export',
+        'Do not export materials, and combine mesh primitive groups, losing material slot information'),
         description=(
             'Export materials '
         ),

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -221,10 +221,8 @@ class ExportGLTF2_Base:
         ('PLACEHOLDER', 'Placeholder',
         'Do not export materials, but write multiple primitive groups per mesh, keeping material slot information'),
         ('NONE', 'No export',
-        'Do not export materials, and combine mesh primitive groups, losing material slot information'),
-        description=(
-            'Export materials '
-        ),
+        'Do not export materials, and combine mesh primitive groups, losing material slot information')),
+        description='Export materials ',
         default='EXPORT'
     )
 

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -214,10 +214,19 @@ class ExportGLTF2_Base:
         default=False
     )
 
-    export_materials: BoolProperty(
+    export_materials: EnumProperty(
         name='Materials',
-        description='Export materials',
-        default=True
+        items=(('EXPORT', 'Export',
+                'Export materials '),
+                ('PLACEHOLDER', 'Placeholder',
+                'Do not export materials, but keep placeholder primitives '),
+                ('NONE', 'No export',
+                'Do not export materials '),
+               ),
+        description=(
+            'Export materials '
+        ),
+        default='EXPORT'
     )
 
     export_colors: BoolProperty(
@@ -672,7 +681,7 @@ class GLTF_PT_export_geometry(bpy.types.Panel):
         layout.prop(operator, 'export_colors')
         layout.prop(operator, 'export_materials')
         col = layout.column()
-        col.active = operator.export_materials
+        col.active = operator.export_materials == "EXPORT"
         col.prop(operator, 'export_image_format')
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -179,7 +179,7 @@ def extract_primitives(glTF, blender_mesh, library, blender_object, blender_vert
 
     prim_indices = {}  # maps material index to TRIANGLES-style indices into dots
 
-    if not use_materials:
+    if use_materials == "NONE": # Only for None. For placeholder and export, keep primitives
         # Put all vertices into one primitive
         prim_indices[-1] = loop_indices
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
@@ -54,15 +54,17 @@ def gather_primitives(
         material_idx = internal_primitive['material']
         double_sided = False
         material = None
-        try:
-            blender_material = bpy.data.materials[material_names[material_idx]]
-            double_sided = not blender_material.use_backface_culling
-            material = gltf2_blender_gather_materials.gather_material(blender_material,
-                                                                  double_sided,
-                                                                  export_settings)
-        except IndexError:
-            # no material at that index
-            pass
+
+        if export_settings['gltf_materials'] == "EXPORT":
+            try:
+                blender_material = bpy.data.materials[material_names[material_idx]]
+                double_sided = not blender_material.use_backface_culling
+                material = gltf2_blender_gather_materials.gather_material(blender_material,
+                                                                      double_sided,
+                                                                      export_settings)
+            except IndexError:
+                # no material at that index
+                pass
 
 
         primitive = gltf2_io.MeshPrimitive(


### PR DESCRIPTION
Fix #1205 

This PR change "export material" option from boolean (export / not export) to an enum: 
* export
* not export
* placeholder

Not export merges all primitives (as it is done on current master)
Placeholder keep primitives, but does not create a material. This is working for empty slots or filled slots