### PR TITLE
Export: replace zero normals with UP

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -348,6 +348,12 @@ def __get_normals(blender_mesh, key_blocks, armature, blender_object, export_set
             ns[:] = __apply_mat_to_all(normal_transform, ns)
             __normalize_vecs(ns)
 
+    for ns in [normals, *morph_normals]:
+        # Replace zero normals with the unit UP vector.
+        # Seems to happen sometimes with degenerate tris?
+        is_zero = ~ns.any(axis=1)
+        ns[is_zero, 2] = 1
+
     # glTF stores deltas in morph targets
     for ns in morph_normals:
         ns -= normals


### PR DESCRIPTION
Fixes #1138.

Zero normals are turned into the up vector. Since this seems to happen only on degenerate tris, it shouldn't have any visible effect, but it makes the glTF validate. 

I tried to make a test case, but wasn't able to. I couldn't figure out what causes zero normals. Just being degenerate is not enough, I assume you need some condition on the topology too. Also the file from #372 is working in master with no zero normals right now.

So the only file I know of with this problem is the one from #1138. It now passes validation.