### PR TITLE
Import: import grayscale emissiveFactor as Emission Strength

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -16,7 +16,7 @@ bl_info = {
     'name': 'glTF 2.0 format',
     'author': 'Julien Duroure, Scurest, Norbert Nopper, Urs Hanselmann, Moritz Becher, Benjamin Schmithüsen, Jim Eckerlein, and many external contributors',
     "version": (1, 4, 31),
-    'blender': (2, 90, 0),
+    'blender': (2, 91, 0),
     'location': 'File > Import-Export',
     'description': 'Import-Export as glTF 2.0',
     'warning': '',

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -62,6 +62,7 @@ def pbr_metallic_roughness(mh: MaterialHelper):
         mh,
         location=locs['emission'],
         color_socket=pbr_node.inputs['Emission'],
+        strength_socket=pbr_node.inputs['Emission Strength'],
     )
 
     base_color(
@@ -167,7 +168,7 @@ def calc_locations(mh):
 
 
 # [Texture] => [Emissive Factor] =>
-def emission(mh: MaterialHelper, location, color_socket):
+def emission(mh: MaterialHelper, location, color_socket, strength_socket=None):
     x, y = location
     emissive_factor = mh.pymat.emissive_factor or [0, 0, 0]
 
@@ -178,20 +179,26 @@ def emission(mh: MaterialHelper, location, color_socket):
         color_socket.default_value = emissive_factor + [1]
         return
 
-    # Mix emissive factor
-    if emissive_factor != [1, 1, 1]:
-        node = mh.node_tree.nodes.new('ShaderNodeMixRGB')
-        node.label = 'Emissive Factor'
-        node.location = x - 140, y
-        node.blend_type = 'MULTIPLY'
-        # Outputs
-        mh.node_tree.links.new(color_socket, node.outputs[0])
-        # Inputs
-        node.inputs['Fac'].default_value = 1.0
-        color_socket = node.inputs['Color1']
-        node.inputs['Color2'].default_value = emissive_factor + [1]
+    # Put grayscale emissive factors into the Emission Strength
+    e0, e1, e2 = emissive_factor
+    if strength_socket and e0 == e1 == e2:
+        strength_socket.default_value = e0
 
-        x -= 200
+    # Otherwise, use a multiply node for it
+    else:
+        if emissive_factor != [1, 1, 1]:
+            node = mh.node_tree.nodes.new('ShaderNodeMixRGB')
+            node.label = 'Emissive Factor'
+            node.location = x - 140, y
+            node.blend_type = 'MULTIPLY'
+            # Outputs
+            mh.node_tree.links.new(color_socket, node.outputs[0])
+            # Inputs
+            node.inputs['Fac'].default_value = 1.0
+            color_socket = node.inputs['Color1']
+            node.inputs['Color2'].default_value = emissive_factor + [1]
+
+            x -= 200
 
     texture(
         mh,


### PR DESCRIPTION
For the importer side of #1216.

When there is an emissiveTexture and the emissiveFactor is grayscale (R==G==B), put the emissiveFactor into the strength socket. This doesn't actually matter to the glTF exporter, but it will help exporters that use node_shader_utils, and it makes the graph cleaner.

When the emissiveFactor is not grayscale, it still goes in a multiply node.

I also bumped the addon's required Blender version since the importer now requires the latest version of Blender. (You might object, "Yesterday's build was also (2,91,0), and it didn't have an Emission Strength socket". So I checked what OBJ and FBX did, and they didn't bump it at all, so....)