### PR TITLE
Import/Export: fixes for material_index/material slots

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -314,7 +314,8 @@ def __gather_mesh(blender_object, library, export_settings):
                 vertex_groups = None # Not needed if no armature, avoid a cache miss
                 modifiers = None
 
-    material_names = tuple([ms.material.name for ms in blender_object.material_slots if ms.material is not None])
+    materials = tuple(ms.material for ms in blender_object.material_slots)
+    material_names = tuple(None if mat is None else mat.name for mat in materials)
 
     # retrieve armature
     # Because mesh data will be transforms to skeleton space,

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
@@ -55,14 +55,17 @@ def gather_primitives(
         material = None
 
         if export_settings['gltf_materials'] == "EXPORT":
-            try:
-                blender_material = bpy.data.materials[material_names[material_idx]]
-                material = gltf2_blender_gather_materials.gather_material(blender_material,
-                                                                      export_settings)
-            except IndexError:
-                # no material at that index
-                pass
-
+            blender_material = None
+            if material_names:
+                i = material_idx if material_idx < len(material_names) else -1
+                material_name = material_names[i]
+                if material_name is not None:
+                    blender_material = bpy.data.materials[material_name]
+            if blender_material is not None:
+                material = gltf2_blender_gather_materials.gather_material(
+                    blender_material,
+                    export_settings,
+                )
 
         primitive = gltf2_io.MeshPrimitive(
             attributes=internal_primitive['attributes'],


### PR DESCRIPTION
Fixes #1224.

Exporter:

* any material slots at or after an empty material slot would be screwed up (they are skipped [here](https://github.com/KhronosGroup/glTF-Blender-IO/blob/5d976d3642b5ce885719a29976b83f8d6562713b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py#L317), which screws up the indices (and caching)). This changes material_names to have a None for empty slots. Anything assigned to an empty slots will now be exported with `material: None`.
* OOB material_indices exported as `material: None`. This changes to use the last slot (if it exists), which is what Blender does.

Importer: 

* if no primitive in a mesh has materials, the `# Assign materials` block is now skipped, which gives every poly a material_index of 0, and no material slots.
* Otherwise, an empty material slot will be created and used for prims that have `material: None`.

IOW we only import with an empty material slot when necessary.

-----

In addition to #1224, here's another example of a bug with empty slots:

![good](https://user-images.githubusercontent.com/11024420/94297076-88145f80-ff29-11ea-9170-78683bacfb8f.png)

In master, export->reimport results in

![bad](https://user-images.githubusercontent.com/11024420/94297127-9c585c80-ff29-11ea-983a-c2264e6f6b6c.png)

It's fixed on this branch.