### PR TITLE
Import: use bpy.utils.escape_identifier to escape names for action paths

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_node.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import bpy
 from mathutils import Vector
 
@@ -90,7 +89,10 @@ class BlenderNodeAnim():
         if vnode.type == VNode.Bone:
             # Need to animate the pose bone when the node is a bone.
             group_name = vnode.blender_bone_name
-            blender_path = "pose.bones[%s].%s" % (json.dumps(vnode.blender_bone_name), blender_path)
+            blender_path = 'pose.bones["%s"].%s' % (
+                bpy.utils.escape_identifier(vnode.blender_bone_name),
+                blender_path
+            )
 
             # We have the final TRS of the bone in values. We need to give
             # the TRS of the pose bone though, which is relative to the edit

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_weight.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_animation_weight.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import bpy
 
 from ...io.imp.gltf2_io_binary import BinaryData
@@ -75,7 +74,7 @@ class BlenderWeightAnim():
             if pymesh.shapekey_names[sk] is not None: # Do not animate shapekeys not created
                 coords[1::2] = (values[offset + stride * i + sk][0] for i in range(len(keys)))
                 kb_name = pymesh.shapekey_names[sk]
-                data_path = "key_blocks[" + json.dumps(kb_name) + "].value"
+                data_path = 'key_blocks["%s"].value' % bpy.utils.escape_identifier(kb_name)
 
                 make_fcurve(
                     action,


### PR DESCRIPTION
Use [bpy.utils.escape_identifier](https://docs.blender.org/api/current/bpy.utils.html#bpy.utils.escape_identifier) instead of json.dumps for escaping names in action paths. I found this function and realized this is the right way to do this.

For reference, here is an example of this function being used in Blender: https://github.com/dfelinto/blender/blob/87ebc4ef4f2029a8f4fb21ea433c4ca189b243d5/release/scripts/startup/bl_operators/wm.py#L1318

This fixes a bug when bones/shape keys have "weird" names. For example, a bone named `🌍` will not animate correctly in master because

````py
>>> 'pose.bones[%s]' % json.dumps('🌍')
'pose.bones["\\ud83c\\udf0d"]'
>>> 'pose.bones["%s"]' % bpy.utils.escape_identifier('🌍')
'pose.bones["🌍"]'
````
