### PR TITLE
Import: better error messages when loading files

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -994,26 +994,28 @@ class ImportGLTF2(Operator, ImportHelper):
 
     def unit_import(self, filename, import_settings):
         import time
-        from .io.imp.gltf2_io_gltf import glTFImporter
+        from .io.imp.gltf2_io_gltf import glTFImporter, ImportError
         from .blender.imp.gltf2_blender_gltf import BlenderGlTF
 
-        gltf_importer = glTFImporter(filename, import_settings)
-        success, txt = gltf_importer.read()
-        if not success:
-            self.report({'ERROR'}, txt)
-            return {'CANCELLED'}
-        success, txt = gltf_importer.checks()
-        if not success:
-            self.report({'ERROR'}, txt)
-            return {'CANCELLED'}
-        print("Data are loaded, start creating Blender stuff")
-        start_time = time.time()
-        BlenderGlTF.create(gltf_importer)
-        elapsed_s = "{:.2f}s".format(time.time() - start_time)
-        print("glTF import finished in " + elapsed_s)
-        gltf_importer.log.removeHandler(gltf_importer.log_handler)
+        try:
+            gltf_importer = glTFImporter(filename, import_settings)
+            gltf_importer.read()
+            gltf_importer.checks()
 
-        return {'FINISHED'}
+            print("Data are loaded, start creating Blender stuff")
+
+            start_time = time.time()
+            BlenderGlTF.create(gltf_importer)
+            elapsed_s = "{:.2f}s".format(time.time() - start_time)
+            print("glTF import finished in " + elapsed_s)
+
+            gltf_importer.log.removeHandler(gltf_importer.log_handler)
+
+            return {'FINISHED'}
+
+        except ImportError as e:
+            self.report({'ERROR'}, e.args[0])
+            return {'CANCELLED'}
 
     def set_debug_log(self):
         import logging

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -997,21 +997,21 @@ class ImportGLTF2(Operator, ImportHelper):
         from .io.imp.gltf2_io_gltf import glTFImporter
         from .blender.imp.gltf2_blender_gltf import BlenderGlTF
 
-        self.gltf_importer = glTFImporter(filename, import_settings)
-        success, txt = self.gltf_importer.read()
+        gltf_importer = glTFImporter(filename, import_settings)
+        success, txt = gltf_importer.read()
         if not success:
             self.report({'ERROR'}, txt)
             return {'CANCELLED'}
-        success, txt = self.gltf_importer.checks()
+        success, txt = gltf_importer.checks()
         if not success:
             self.report({'ERROR'}, txt)
             return {'CANCELLED'}
         print("Data are loaded, start creating Blender stuff")
         start_time = time.time()
-        BlenderGlTF.create(self.gltf_importer)
+        BlenderGlTF.create(gltf_importer)
         elapsed_s = "{:.2f}s".format(time.time() - start_time)
         print("glTF import finished in " + elapsed_s)
-        self.gltf_importer.log.removeHandler(self.gltf_importer.log_handler)
+        gltf_importer.log.removeHandler(gltf_importer.log_handler)
 
         return {'FINISHED'}
 

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
@@ -92,18 +92,14 @@ class glTFImporter():
 
     def load_glb(self, content):
         """Load binary glb."""
-        header = struct.unpack_from('<4sII', content)
-        self.format = header[0]
-        self.version = header[1]
-        self.file_size = header[2]
-
-        if self.format != b'glTF':
+        magic = content[:4]
+        if magic != b'glTF':
             raise ImportError("This file is not a glTF/glb file")
 
-        if self.version != 2:
-            raise ImportError("GLB version must be 2; got %d" % self.version)
-
-        if self.file_size != len(content):
+        version, file_size = struct.unpack_from('<II', content, offset=4)
+        if version != 2:
+            raise ImportError("GLB version must be 2; got %d" % version)
+        if file_size != len(content):
             raise ImportError("Bad GLB: file size doesn't match")
 
         glb_buffer = None

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
@@ -101,7 +101,7 @@ class glTFImporter():
             raise ImportError("This file is not a glTF/glb file")
 
         if self.version != 2:
-            raise ImportError("GLB version %d unsupported" % self.version)
+            raise ImportError("GLB version must be 2; got %d" % self.version)
 
         if self.file_size != len(content):
             raise ImportError("Bad GLB: file size doesn't match")

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
@@ -152,7 +152,12 @@ class glTFImporter():
 
         glTFImporter.check_version(gltf)
 
-        self.data = gltf_from_dict(gltf)
+        try:
+            self.data = gltf_from_dict(gltf)
+        except AssertionError:
+            import traceback
+            traceback.print_exc()
+            raise ImportError("Couldn't parse glTF. Check that the file is valid")
 
     def load_buffer(self, buffer_idx):
         """Load buffer."""


### PR DESCRIPTION
Fixes #1237.

Three main changes are:

* Refactor to communicate errors with an exception instead of `success, txt` return codes, which is nicer. Raising an ImportError will now make the importer report an error with that little error box.
* Do version checks on the JSON before converting to it gltf_io classes, since the format might change between versions. This is what fixes #1237. Importing a version 1.0 .gltf now results in:

    ![err1](https://user-images.githubusercontent.com/11024420/96297740-f4c5cb80-0fb6-11eb-8170-7488f0e5a680.png)
* If gltf_from_dict fails, print a friendlier error message that suggests checking if the file is valid. The full traceback is still printed to stdout. Cf #1199

    ![err2](https://user-images.githubusercontent.com/11024420/96297986-55550880-0fb7-11eb-840c-76fb25a458c2.png)

I also cleaned up some and massaged a few other error messages, ex.

![err5](https://user-images.githubusercontent.com/11024420/96298469-1a9fa000-0fb8-11eb-85b6-126ad44cd536.png)

See commit messages for more details.