### PR TITLE
Take care of active output material node

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_unlit.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_unlit.py
@@ -38,7 +38,7 @@ def detect_shadeless_material(blender_material, export_settings):
     info = {}
 
     for node in blender_material.node_tree.nodes:
-        if node.type == 'OUTPUT_MATERIAL':
+        if node.type == 'OUTPUT_MATERIAL' and node.is_active_output:
             socket = node.inputs[0]
             break
     else:

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -105,9 +105,10 @@ def check_if_is_linked_to_active_output(shader_socket):
         if isinstance(link.to_node, bpy.types.ShaderNodeOutputMaterial) and link.to_node.is_active_output is True:
             return True
 
-        ret = check_if_is_linked_to_active_output(link.to_node.outputs[0])
-        if ret is True:
-            return True
+        if len(link.to_node.outputs) > 0: # ignore non active output, not having output sockets
+            ret = check_if_is_linked_to_active_output(link.to_node.outputs[0]) # recursive until find an output material node
+            if ret is True:
+                return True
 
     return False
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -60,6 +60,7 @@ def get_socket(blender_material: bpy.types.Material, name: str):
             type = bpy.types.ShaderNodeEmission
             name = "Color"
             nodes = [n for n in blender_material.node_tree.nodes if isinstance(n, type) and not n.mute]
+            nodes = [node for node in nodes if check_if_is_linked_to_active_output(node.outputs[0])]
             inputs = sum([[input for input in node.inputs if input.name == name] for node in nodes], [])
             if inputs:
                 return inputs[0]
@@ -72,6 +73,7 @@ def get_socket(blender_material: bpy.types.Material, name: str):
         else:
             type = bpy.types.ShaderNodeBsdfPrincipled
         nodes = [n for n in blender_material.node_tree.nodes if isinstance(n, type) and not n.mute]
+        nodes = [node for node in nodes if check_if_is_linked_to_active_output(node.outputs[0])]
         inputs = sum([[input for input in node.inputs if input.name == name] for node in nodes], [])
         if inputs:
             return inputs[0]
@@ -98,6 +100,12 @@ def get_socket_old(blender_material: bpy.types.Material, name: str):
 
     return None
 
+def check_if_is_linked_to_active_output(shader_socket):
+    for link in shader_socket.links:
+        if isinstance(link.to_node, bpy.types.ShaderNodeOutputMaterial) and link.to_node.is_active_output is True:
+            return True
+
+    return False
 
 def find_shader_image_from_shader_socket(shader_socket, max_hops=10):
     """Find any ShaderNodeTexImage in the path from the socket."""

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -105,6 +105,10 @@ def check_if_is_linked_to_active_output(shader_socket):
         if isinstance(link.to_node, bpy.types.ShaderNodeOutputMaterial) and link.to_node.is_active_output is True:
             return True
 
+        ret = check_if_is_linked_to_active_output(link.to_node.outputs[0])
+        if ret is True:
+            return True
+
     return False
 
 def find_shader_image_from_shader_socket(shader_socket, max_hops=10):


### PR DESCRIPTION
Fix #1248 Fix #1213
Take care of active output material node

Material node tree can have multiple output node.
Only 1 can be active.

This PR:
* Check that nodes are linked to any output material node
* and that node is the active one

Not sure how this will work with background rendering, when there is no user to click on an output node to activate it