### PR TITLE
Feature: Draco Decoder

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -200,6 +200,14 @@ class ExportGLTF2_Base:
         max=30
     )
 
+    export_draco_color_quantization: IntProperty(
+        name='Color quantization bits',
+        description='Quantization bits for color values (0 = no quantization)',
+        default=10,
+        min=0,
+        max=30
+    )
+
     export_draco_generic_quantization: IntProperty(
         name='Generic quantization bits',
         description='Quantization bits for generic coordinate values like weights or joints (0 = no quantization)',
@@ -471,6 +479,7 @@ class ExportGLTF2_Base:
             export_settings['gltf_draco_position_quantization'] = self.export_draco_position_quantization
             export_settings['gltf_draco_normal_quantization'] = self.export_draco_normal_quantization
             export_settings['gltf_draco_texcoord_quantization'] = self.export_draco_texcoord_quantization
+            export_settings['gltf_draco_color_quantization'] = self.export_draco_color_quantization
             export_settings['gltf_draco_generic_quantization'] = self.export_draco_generic_quantization
         else:
             export_settings['gltf_draco_mesh_compression'] = False
@@ -719,7 +728,8 @@ class GLTF_PT_export_geometry_compression(bpy.types.Panel):
         col = layout.column(align=True)
         col.prop(operator, 'export_draco_position_quantization', text="Quantize Position")
         col.prop(operator, 'export_draco_normal_quantization', text="Normal")
-        col.prop(operator, 'export_draco_texcoord_quantization', text="Tex Coords")
+        col.prop(operator, 'export_draco_texcoord_quantization', text="Tex Coord")
+        col.prop(operator, 'export_draco_color_quantization', text="Color")
         col.prop(operator, 'export_draco_generic_quantization', text="Generic")
 
 

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -89,7 +89,7 @@ class ExportGLTF2_Base:
     # TODO: refactor to avoid boilerplate
 
     def __init__(self):
-        from io_scene_gltf2.io.exp import gltf2_io_draco_compression_extension
+        from io_scene_gltf2.io.com import gltf2_io_draco_compression_extension
         self.is_draco_available = gltf2_io_draco_compression_extension.dll_exists()
 
     bl_options = {'PRESET'}
@@ -690,7 +690,7 @@ class GLTF_PT_export_geometry_compression(bpy.types.Panel):
     bl_options = {'DEFAULT_CLOSED'}
 
     def __init__(self):
-        from io_scene_gltf2.io.exp import gltf2_io_draco_compression_extension
+        from io_scene_gltf2.io.com import gltf2_io_draco_compression_extension
         self.is_draco_available = gltf2_io_draco_compression_extension.dll_exists(quiet=True)
 
     @classmethod

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
@@ -76,7 +76,7 @@ def __gather_gltf(exporter, export_settings):
     active_scene_idx, scenes, animations = plan['active_scene_idx'], plan['scenes'], plan['animations']
 
     if export_settings['gltf_draco_mesh_compression']:
-        gltf2_io_draco_compression_extension.compress_scene_primitives(scenes, export_settings)
+        gltf2_io_draco_compression_extension.encode_scene_primitives(scenes, export_settings)
         exporter.add_draco_extension()
 
     for idx, scene in enumerate(scenes):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -137,7 +137,7 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
         vert_index_base = len(vert_locs)
 
         if 'KHR_draco_mesh_compression' in prim.extensions:
-            print_console('INFO', 'Draco Decoder: Found compress primitive in ' + pymesh.name)
+            print_console('INFO', 'Draco Decoder: Found compressed primitive in ' + pymesh.name)
             decode_primitive(gltf, prim)
 
         if prim.indices is not None:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -137,7 +137,7 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
         vert_index_base = len(vert_locs)
 
         if prim.extensions is not None and 'KHR_draco_mesh_compression' in prim.extensions:
-            print_console('INFO', 'Draco Decoder: Found compressed primitive in ' + pymesh.name)
+            print_console('INFO', 'Draco Decoder: Decode primitive {}'.format(pymesh.name or '[unnamed]'))
             decode_primitive(gltf, prim)
 
         if prim.indices is not None:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -19,6 +19,8 @@ import numpy as np
 from ...io.imp.gltf2_io_binary import BinaryData
 from ..com.gltf2_blender_extras import set_extras
 from .gltf2_blender_material import BlenderMaterial
+from ...io.com.gltf2_io_debug import print_console
+from .gltf2_io_draco_compression_extension import decode_primitive
 
 
 class BlenderMesh():
@@ -133,6 +135,10 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
             continue
 
         vert_index_base = len(vert_locs)
+
+        if 'KHR_draco_mesh_compression' in prim.extensions:
+            print_console('INFO', 'Draco Decoder: Found compress primitive in ' + pymesh.name)
+            decode_primitive(gltf, prim)
 
         if prim.indices is not None:
             indices = BinaryData.decode_accessor(gltf, prim.indices)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -136,7 +136,7 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
 
         vert_index_base = len(vert_locs)
 
-        if 'KHR_draco_mesh_compression' in prim.extensions:
+        if prim.extensions is not None and 'KHR_draco_mesh_compression' in prim.extensions:
             print_console('INFO', 'Draco Decoder: Found compressed primitive in ' + pymesh.name)
             decode_primitive(gltf, prim)
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
@@ -41,6 +41,12 @@ def decode_primitive(gltf, prim):
     dll.decoderReadAttribute.restype = c_bool
     dll.decoderReadAttribute.argtypes = [c_void_p, c_uint32, c_size_t, c_char_p]
 
+    dll.decoderGetVertexCount.restype = c_uint32
+    dll.decoderGetVertexCount.argtypes = [c_void_p]
+
+    dll.decoderGetIndexCount.restype = c_uint32
+    dll.decoderGetIndexCount.argtypes = [c_void_p]
+
     dll.decoderAttributeIsNormalized.restype = c_bool
     dll.decoderAttributeIsNormalized.argtypes = [c_void_p, c_uint32]
 
@@ -77,6 +83,9 @@ def decode_primitive(gltf, prim):
     
     # Read indices.
     index_accessor = gltf.data.accessors[prim.indices]
+    if dll.decoderGetIndexCount(decoder) != index_accessor.count:
+        print_console('ERROR', 'Draco Decoder: Index count of accessor and decoded index count does not match. Skipping primitive.')
+        return
     if not dll.decoderReadIndices(decoder, index_accessor.component_type):
         print_console('ERROR', 'Draco Decoder: Could not decode indices of primitive {}. Skipping primitive.'.format(prim.name))
         return
@@ -105,6 +114,9 @@ def decode_primitive(gltf, prim):
             return
         
         accessor = gltf.data.accessors[prim.attributes[attr]]
+        if dll.decoderGetVertexCount(decoder) != accessor.count:
+            print_console('ERROR', 'Draco Decoder: Vertex count of accessor and decoded vertex count does not match for attribute {}. Skipping primitive.'.format(attr))
+            return
         if not dll.decoderReadAttribute(decoder, dracoId, accessor.component_type, accessor.type.encode()):
             print_console('ERROR', 'Draco Decoder: Could not decode attribute {} of primitive {}. Skipping primitive.'.format(attr, prim.name))
             return

--- a/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
@@ -86,8 +86,8 @@ def decode_primitive(gltf, prim):
     # Read indices.
     index_accessor = gltf.data.accessors[prim.indices]
     if dll.decoderGetIndexCount(decoder) != index_accessor.count:
-        print_console('ERROR', 'Draco Decoder: Index count of accessor and decoded index count does not match. Skipping primitive {}.'.format(name))
-        return
+        print_console('WARNING', 'Draco Decoder: Index count of accessor and decoded index count does not match. Updating accessor.')
+        index_accessor.count = dll.decoderGetIndexCount(decoder)
     if not dll.decoderReadIndices(decoder, index_accessor.component_type):
         print_console('ERROR', 'Draco Decoder: Unable to decode indices. Skipping primitive {}.'.format(name))
         return
@@ -117,8 +117,8 @@ def decode_primitive(gltf, prim):
         
         accessor = gltf.data.accessors[prim.attributes[attr]]
         if dll.decoderGetVertexCount(decoder) != accessor.count:
-            print_console('ERROR', 'Draco Decoder: Vertex count of accessor and decoded vertex count does not match for attribute {}. Skipping primitive {}.'.format(attr, name))
-            return
+            print_console('WARNING', 'Draco Decoder: Vertex count of accessor and decoded vertex count does not match for attribute {}. Updating accessor.'.format(attr, name))
+            accessor.count = dll.decoderGetVertexCount(decoder)
         if not dll.decoderReadAttribute(decoder, dracoId, accessor.component_type, accessor.type.encode()):
             print_console('ERROR', 'Draco Decoder: Could not decode attribute {}. Skipping primitive {}.'.format(attr, name))
             return

--- a/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
@@ -87,7 +87,7 @@ def decode_primitive(gltf, prim):
     
     indices_byte_length = dll.decoderGetIndicesByteLength(decoder)
     indices_data_pointer = dll.decoderGetIndicesData(decoder)
-    decoded_data = memoryview((c_char * indices_byte_length).from_address(indices_data_pointer))[0:indices_byte_length]
+    decoded_data = bytes((c_char * indices_byte_length).from_address(indices_data_pointer))
 
     # Generate a new buffer holding the decoded indices.
     gltf.buffers[base_buffer_idx] = decoded_data
@@ -115,7 +115,7 @@ def decode_primitive(gltf, prim):
         
         byte_length = dll.decoderGetAttributeByteLength(decoder, dracoId)
         data_pointer = dll.decoderGetAttributeData(decoder, dracoId)
-        decoded_data = memoryview((c_char * byte_length).from_address(data_pointer))[0:byte_length]
+        decoded_data = bytes((c_char * byte_length).from_address(data_pointer))
 
         # Generate a new buffer holding the decoded vertex data.
         buffer_idx = base_buffer_idx + 1 + attr_idx

--- a/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
@@ -1,0 +1,89 @@
+# Copyright 2018-2019 The glTF-Blender-IO authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import bpy
+import sys
+from ctypes import *
+from pathlib import Path
+import struct
+
+from io_scene_gltf2.io.imp.gltf2_io_binary import BinaryData
+from ...io.com.gltf2_io_debug import print_console
+from io_scene_gltf2.io.com.gltf2_io_draco_compression_extension import dll_path
+
+
+def decode_primitive(gltf, prim):
+    """
+    Handles draco compression.
+    Moves decoded data into new buffers and buffer views held by the accessors of the given primitive.
+    """
+
+    # Load DLL and setup function signatures.
+    dll = cdll.LoadLibrary(str(dll_path().resolve()))
+
+    dll.decoderCreate.restype = c_void_p
+    dll.decoderCreate.argtypes = []
+
+    dll.decoderRelease.restype = None
+    dll.decoderRelease.argtypes = [c_void_p]
+
+    dll.decoderDecode.restype = c_bool
+    dll.decoderDecode.argtypes = [c_void_p, c_void_p, c_size_t]
+
+    dll.decoderReadAttribute.restype = c_bool
+    dll.decoderReadAttribute.argtypes = [c_void_p, c_uint32, c_size_t, c_char_p]
+
+    dll.decoderAttributeIsNormalized.restype = c_bool
+    dll.decoderAttributeIsNormalized.argtypes = [c_void_p, c_uint32]
+
+    dll.decoderGetAttributeByteLength.restype = c_size_t
+    dll.decoderGetAttributeByteLength.argtypes = [c_void_p, c_uint32]
+
+    dll.decoderGetAttributeData.restype = c_void_p
+    dll.decoderGetAttributeData.argtypes = [c_void_p, c_uint32]
+
+    dll.decoderReadIndices.restype = c_bool
+    dll.decoderReadIndices.argtypes = [c_void_p, c_size_t]
+
+    dll.decoderGetIndicesByteLength.restype = c_size_t
+    dll.decoderGetIndicesByteLength.argtypes = [c_void_p]
+
+    dll.decoderGetIndicesData.restype = c_void_p
+    dll.decoderGetIndicesData.argtypes = [c_void_p]
+    
+    decoder = dll.decoderCreate()
+    extension = prim.extensions['KHR_draco_mesh_compression']
+
+    # Create Draco decoder.
+    draco_buffer = BinaryData.get_buffer_view(gltf, extension['bufferView'])
+    if not dll.decoderDecode(decoder, draco_buffer.obj, draco_buffer.nbytes):
+        print_console('ERROR', 'Draco Decoder: Could not decode primitive {}. Skipping primitive.'.format(prim.name))
+    
+    # Read each attribute.
+    for attr in extension['attributes']:
+        dracoId = extension['attributes'][attr]
+        if attr not in prim.attributes:
+            print_console('ERROR', 'Draco Decoder: Draco attribute {} not in primitive attributes'.format(attr))
+            return
+        
+        accessor = gltf.data.accessors[prim.attributes[attr]]
+        if not dll.decoderReadAttribute(decoder, dracoId, accessor.component_type, accessor.type.encode()):
+            print_console('ERROR', 'Draco Decoder: Could not decode attribute {} of primitive {}. Skipping primitive.'.format(attr, prim.name))
+        
+        byte_length = dll.decoderGetAttributeByteLength(decoder, dracoId)
+        data = dll.decoderGetAttributeData(decoder, dracoId)
+
+        buffer_idx = 0
+
+    dll.decoderRelease(decoder)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bpy
-import sys
 from ctypes import *
-from pathlib import Path
-import struct
 
 from io_scene_gltf2.io.com.gltf2_io import BufferView
 from io_scene_gltf2.io.imp.gltf2_io_binary import BinaryData

--- a/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
@@ -51,8 +51,8 @@ def decode_primitive(gltf, prim):
     dll.decoderGetAttributeByteLength.restype = c_size_t
     dll.decoderGetAttributeByteLength.argtypes = [c_void_p, c_uint32]
 
-    dll.decoderGetAttributeData.restype = c_void_p
-    dll.decoderGetAttributeData.argtypes = [c_void_p, c_uint32]
+    dll.decoderCopyAttribute.restype = None
+    dll.decoderCopyAttribute.argtypes = [c_void_p, c_uint32, c_void_p]
 
     dll.decoderReadIndices.restype = c_bool
     dll.decoderReadIndices.argtypes = [c_void_p, c_size_t]
@@ -60,8 +60,8 @@ def decode_primitive(gltf, prim):
     dll.decoderGetIndicesByteLength.restype = c_size_t
     dll.decoderGetIndicesByteLength.argtypes = [c_void_p]
 
-    dll.decoderGetIndicesData.restype = c_void_p
-    dll.decoderGetIndicesData.argtypes = [c_void_p]
+    dll.decoderCopyIndices.restype = None
+    dll.decoderCopyIndices.argtypes = [c_void_p, c_void_p]
     
     decoder = dll.decoderCreate()
     extension = prim.extensions['KHR_draco_mesh_compression']
@@ -86,8 +86,8 @@ def decode_primitive(gltf, prim):
         return
     
     indices_byte_length = dll.decoderGetIndicesByteLength(decoder)
-    indices_data_pointer = dll.decoderGetIndicesData(decoder)
-    decoded_data = bytes((c_char * indices_byte_length).from_address(indices_data_pointer))
+    decoded_data = bytes(indices_byte_length)
+    dll.decoderCopyIndices(decoder, decoded_data)
 
     # Generate a new buffer holding the decoded indices.
     gltf.buffers[base_buffer_idx] = decoded_data
@@ -114,8 +114,8 @@ def decode_primitive(gltf, prim):
             return
         
         byte_length = dll.decoderGetAttributeByteLength(decoder, dracoId)
-        data_pointer = dll.decoderGetAttributeData(decoder, dracoId)
-        decoded_data = bytes((c_char * byte_length).from_address(data_pointer))
+        decoded_data = bytes(byte_length)
+        dll.decoderCopyAttribute(decoder, dracoId, decoded_data)
 
         # Generate a new buffer holding the decoded vertex data.
         buffer_idx = base_buffer_idx + 1 + attr_idx

--- a/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_io_draco_compression_extension.py
@@ -63,9 +63,9 @@ def decode_primitive(gltf, prim):
     extension = prim.extensions['KHR_draco_mesh_compression']
 
     # Create Draco decoder.
-    draco_buffer = BinaryData.get_buffer_view(gltf, extension['bufferView'])
-    if not dll.decoderDecode(decoder, draco_buffer.obj, draco_buffer.nbytes):
-        print_console('ERROR', 'Draco Decoder: Could not decode primitive {}. Skipping primitive.'.format(prim.name))
+    draco_buffer = bytes(BinaryData.get_buffer_view(gltf, extension['bufferView']))
+    if not dll.decoderDecode(decoder, draco_buffer, len(draco_buffer)):
+        print_console('ERROR', 'Draco Decoder: Could not decode primitive {}. Skipping primitive.'.format(prim))
         return
 
     # Choose a buffer index which does not yet exist, skipping over existing glTF buffers yet to be loaded

--- a/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
@@ -38,7 +38,7 @@ def dll_path() -> Path:
     # }
 
     # path = paths.get(sys.platform)
-    path = Path('/Users/work/ux3d/draco_blender/build-xcode/bin/2.80/python/lib/python3.7/Debug/libglTFBlenderIO-Draco.dylib')
+    path = Path('/Users/work/ux3d/draco_blender/build/bin/2.80/python/lib/python3.7/Debug/libglTF-Blender-IO_DracoMeshCompression.dylib')
     return path if path is not None else ''
 
 

--- a/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
@@ -1,0 +1,54 @@
+# Copyright 2018-2019 The glTF-Blender-IO authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import bpy
+import sys
+from ctypes import c_void_p, c_uint32, c_uint64, c_bool, c_char_p, cdll
+from pathlib import Path
+import struct
+
+from io_scene_gltf2.io.exp.gltf2_io_binary_data import BinaryData
+from ...io.com.gltf2_io_debug import print_console
+
+
+def dll_path() -> Path:
+    """
+    Get the DLL path depending on the underlying platform.
+    :return: DLL path.
+    """
+    # lib_name = 'extern_draco'
+    # blender_root = Path(bpy.app.binary_path).parent
+    # python_lib = Path("{v[0]}.{v[1]}/python/lib".format(v=bpy.app.version))
+    # python_version = "python{v[0]}.{v[1]}".format(v=sys.version_info)
+    # paths = {
+    #     'win32': blender_root/python_lib/'site-packages'/'{}.dll'.format(lib_name),
+    #     'linux': blender_root/python_lib/python_version/'site-packages'/'lib{}.so'.format(lib_name),
+    #     'darwin': blender_root.parent/'Resources'/python_lib/python_version/'site-packages'/'lib{}.dylib'.format(lib_name)
+    # }
+
+    # path = paths.get(sys.platform)
+    path = Path('/Users/work/ux3d/draco_blender/build-xcode/bin/2.80/python/lib/python3.7/Debug/libglTFBlenderIO-Draco.dylib')
+    return path if path is not None else ''
+
+
+def dll_exists(quiet=False) -> bool:
+    """
+    Checks whether the DLL path exists.
+    :return: True if the DLL exists.
+    """
+    exists = dll_path().exists()
+    if quiet is False:
+        print("'{}' ".format(dll_path().absolute()) + ("exists, draco mesh compression is available" if exists else
+                                                       "does not exist, draco mesh compression not available"))
+    return exists

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -123,7 +123,7 @@ def __dispose_memory(node):
 def __encode_node(node, dll, export_settings):
     """Encodes a single node."""
     if not (node.mesh is None):
-        print_console('INFO', 'Draco encoder: Encoding mesh "%s".' % node.name)
+        print_console('INFO', 'Draco encoder: Encoding mesh {}.'.format(node.name))
         for primitive in node.mesh.primitives:
             __encode_primitive(primitive, dll, export_settings)
 
@@ -166,8 +166,8 @@ def __encode_primitive(primitive, dll, export_settings):
     weights = [attributes[attr] for attr in attributes if attr.startswith('WEIGHTS_')]
     joints = [attributes[attr] for attr in attributes if attr.startswith('JOINTS_')]
 
-    print_console('INFO', 'Draco encoder: %s normals, %d uvs, %d weights, %d joints' %
-        ('without' if normals is None else 'with', len(uvs), len(weights), len(joints)))
+    print_console('INFO', 'Draco encoder: {} normals, {} uvs, {} weights, {} joints'
+        .format('without' if normals is None else 'with', len(uvs), len(weights), len(joints)))
 
     # Begin mesh.
     encoder = dll.encoderCreate()
@@ -182,7 +182,7 @@ def __encode_primitive(primitive, dll, export_settings):
     normal_id = None
     if normals is not None:
         if normals.count != count:
-            print_console('INFO', 'Draco encoder: Mismatching normal count. Skipping.')
+            print_console('INFO', 'Draco encoder: Mismatching normal count. Skipping primitive.')
             dll.encoderRelease(encoder)
             return
         normal_id = dll.encoderAddNormals(encoder, normals.count, normals.buffer_view.data)
@@ -190,7 +190,7 @@ def __encode_primitive(primitive, dll, export_settings):
     uv_ids = []
     for uv in uvs:
         if uv.count != count:
-            print_console('INFO', 'Draco encoder: Mismatching uv count. Skipping.')
+            print_console('INFO', 'Draco encoder: Mismatching uv count. Skipping primitive.')
             dll.encoderRelease(encoder)
             return
         uv_ids.append(dll.encoderAddUVs(encoder, uv.count, uv.buffer_view.data))
@@ -198,7 +198,7 @@ def __encode_primitive(primitive, dll, export_settings):
     weight_ids = []
     for weight in weights:
         if weight.count != count:
-            print_console('INFO', 'Draco encoder: Mismatching weight count. Skipping.')
+            print_console('INFO', 'Draco encoder: Mismatching weight count. Skipping primitive.')
             dll.encoderRelease(encoder)
             return
         weight_ids.append(dll.encoderAddWeights(encoder, weight.count, weight.buffer_view.data))
@@ -206,7 +206,7 @@ def __encode_primitive(primitive, dll, export_settings):
     joint_ids = []
     for joint in joints:
         if joint.count != count:
-            print_console('INFO', 'Draco encoder: Mismatching joint count. Skipping.')
+            print_console('INFO', 'Draco encoder: Mismatching joint count. Skipping primitive.')
             dll.encoderRelease(encoder)
             return
         joint_ids.append(dll.encoderAddJoints(encoder, joint.count, joint.buffer_view.data))

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -27,17 +27,18 @@ def dll_path() -> Path:
     Get the DLL path depending on the underlying platform.
     :return: DLL path.
     """
-    lib_name = 'extern_draco'
-    blender_root = Path(bpy.app.binary_path).parent
-    python_lib = Path("{v[0]}.{v[1]}/python/lib".format(v=bpy.app.version))
-    python_version = "python{v[0]}.{v[1]}".format(v=sys.version_info)
-    paths = {
-        'win32': blender_root/python_lib/'site-packages'/'{}.dll'.format(lib_name),
-        'linux': blender_root/python_lib/python_version/'site-packages'/'lib{}.so'.format(lib_name),
-        'darwin': blender_root.parent/'Resources'/python_lib/python_version/'site-packages'/'lib{}.dylib'.format(lib_name)
-    }
+    # lib_name = 'extern_draco'
+    # blender_root = Path(bpy.app.binary_path).parent
+    # python_lib = Path("{v[0]}.{v[1]}/python/lib".format(v=bpy.app.version))
+    # python_version = "python{v[0]}.{v[1]}".format(v=sys.version_info)
+    # paths = {
+    #     'win32': blender_root/python_lib/'site-packages'/'{}.dll'.format(lib_name),
+    #     'linux': blender_root/python_lib/python_version/'site-packages'/'lib{}.so'.format(lib_name),
+    #     'darwin': blender_root.parent/'Resources'/python_lib/python_version/'site-packages'/'lib{}.dylib'.format(lib_name)
+    # }
 
-    path = paths.get(sys.platform)
+    # path = paths.get(sys.platform)
+    path = Path('/Users/work/ux3d/draco_blender/build-xcode/bin/2.80/python/lib/python3.7/Debug/libglTFBlenderIO-Draco.dylib')
     return path if path is not None else ''
 
 

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -50,6 +50,12 @@ def encode_scene_primitives(scenes, export_settings):
     dll.encoderEncode.restype = c_bool
     dll.encoderEncode.argtypes = [c_void_p, c_uint8]
 
+    dll.encoderGetEncodedVertexCount.restype = c_uint32
+    dll.encoderGetEncodedVertexCount.argtypes = [c_void_p]
+
+    dll.encoderGetEncodedIndexCount.restype = c_uint32
+    dll.encoderGetEncodedIndexCount.argtypes = [c_void_p]
+
     dll.encoderGetByteLength.restype = c_uint64
     dll.encoderGetByteLength.argtypes = [c_void_p]
 
@@ -126,5 +132,11 @@ def __encode_primitive(primitive, dll, export_settings):
 
     # Set to triangle list mode.
     primitive.mode = 4
+
+    # Update accessors to match encoded data.
+    indices.count = dll.encoderGetEncodedIndexCount(encoder)
+    encoded_vertices = dll.encoderGetEncodedVertexCount(encoder)
+    for attr_name in attributes:
+        attributes[attr_name].count = encoded_vertices
 
     dll.encoderRelease(encoder)

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -220,7 +220,7 @@ def __encode_primitive(primitive, dll, export_settings):
         export_settings['gltf_draco_generic_quantization'])
     
     # After all point and connectivity data has been written to the encoder, it can finally be encoded.
-    if dll.encoderEncode(encoder, primitive.targets is not None):
+    if dll.encoderEncode(encoder, primitive.targets is not None and len(primitive.targets) > 0):
 
         # Encoding was successful.
         # Move compressed data into a bytes object,

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -182,47 +182,49 @@ def __encode_primitive(primitive, dll, export_settings):
         export_settings['gltf_draco_texcoord_quantization'],
         export_settings['gltf_draco_generic_quantization'])
     
-    if dll.encoderEncode(encoder, primitive.targets is not None and len(primitive.targets) > 0):
-        byte_length = dll.encoderGetByteLength(encoder)
-        encoded_data = bytes(byte_length)
-        dll.encoderCopy(encoder, encoded_data)
+    if not dll.encoderEncode(encoder, primitive.targets is not None and len(primitive.targets) > 0):
+        print_console('ERROR', 'Could not encode primitive. Skipping primitive.')
 
-        extension = {
-            'bufferView': BinaryData(encoded_data),
-            'attributes': {
-                'POSITION': position_id
-            }
+    byte_length = dll.encoderGetByteLength(encoder)
+    encoded_data = bytes(byte_length)
+    dll.encoderCopy(encoder, encoded_data)
+
+    extension = {
+        'bufferView': BinaryData(encoded_data),
+        'attributes': {
+            'POSITION': position_id
         }
+    }
 
-        if normals is not None:
-            extension['attributes']['NORMAL'] = normal_id
+    if normals is not None:
+        extension['attributes']['NORMAL'] = normal_id
 
-        for (k, id) in enumerate(uv_ids):
-            extension['attributes']['TEXCOORD_' + str(k)] = id
+    for (k, id) in enumerate(uv_ids):
+        extension['attributes']['TEXCOORD_' + str(k)] = id
 
-        for (k, id) in enumerate(weight_ids):
-            extension['attributes']['WEIGHTS_' + str(k)] = id
+    for (k, id) in enumerate(weight_ids):
+        extension['attributes']['WEIGHTS_' + str(k)] = id
 
-        for (k, id) in enumerate(joint_ids):
-            extension['attributes']['JOINTS_' + str(k)] = id
+    for (k, id) in enumerate(joint_ids):
+        extension['attributes']['JOINTS_' + str(k)] = id
 
-        if primitive.extensions is None:
-            primitive.extensions = {}
-        
-        primitive.extensions['KHR_draco_mesh_compression'] = extension
+    if primitive.extensions is None:
+        primitive.extensions = {}
+    
+    primitive.extensions['KHR_draco_mesh_compression'] = extension
 
-        # Remove buffer views from the accessors of the attributes which compressed.
-        positions.buffer_view = None
-        if normals is not None:
-            normals.buffer_view = None
-        for uv in uvs:
-            uv.buffer_view = None
-        for weight in weights:
-            weight.buffer_view = None
-        for joint in joints:
-            joint.buffer_view = None
+    # Remove buffer views from the accessors of the attributes which compressed.
+    positions.buffer_view = None
+    if normals is not None:
+        normals.buffer_view = None
+    for uv in uvs:
+        uv.buffer_view = None
+    for weight in weights:
+        weight.buffer_view = None
+    for joint in joints:
+        joint.buffer_view = None
 
-        # Set to triangle list mode.
-        primitive.mode = 4
+    # Set to triangle list mode.
+    primitive.mode = 4
 
     dll.encoderRelease(encoder)

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -20,38 +20,7 @@ import struct
 
 from io_scene_gltf2.io.exp.gltf2_io_binary_data import BinaryData
 from ...io.com.gltf2_io_debug import print_console
-
-
-def dll_path() -> Path:
-    """
-    Get the DLL path depending on the underlying platform.
-    :return: DLL path.
-    """
-    # lib_name = 'extern_draco'
-    # blender_root = Path(bpy.app.binary_path).parent
-    # python_lib = Path("{v[0]}.{v[1]}/python/lib".format(v=bpy.app.version))
-    # python_version = "python{v[0]}.{v[1]}".format(v=sys.version_info)
-    # paths = {
-    #     'win32': blender_root/python_lib/'site-packages'/'{}.dll'.format(lib_name),
-    #     'linux': blender_root/python_lib/python_version/'site-packages'/'lib{}.so'.format(lib_name),
-    #     'darwin': blender_root.parent/'Resources'/python_lib/python_version/'site-packages'/'lib{}.dylib'.format(lib_name)
-    # }
-
-    # path = paths.get(sys.platform)
-    path = Path('/Users/work/ux3d/draco_blender/build-xcode/bin/2.80/python/lib/python3.7/Debug/libglTFBlenderIO-Draco.dylib')
-    return path if path is not None else ''
-
-
-def dll_exists(quiet=False) -> bool:
-    """
-    Checks whether the DLL path exists.
-    :return: True if the DLL exists.
-    """
-    exists = dll_path().exists()
-    if quiet is False:
-        print("'{}' ".format(dll_path().absolute()) + ("exists, draco mesh compression is available" if exists else
-                                                       "does not exist, draco mesh compression not available"))
-    return exists
+from io_scene_gltf2.io.com.gltf2_io_draco_compression_extension import dll_path
 
 
 def encode_scene_primitives(scenes, export_settings):

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -28,10 +28,7 @@ def encode_scene_primitives(scenes, export_settings):
     """
 
     # Load DLL and setup function signatures.
-    # Nearly all functions take the encoder as the first argument.
     dll = cdll.LoadLibrary(str(dll_path().resolve()))
-
-    # Initialization:
 
     dll.encoderCreate.restype = c_void_p
     dll.encoderCreate.argtypes = []
@@ -39,30 +36,17 @@ def encode_scene_primitives(scenes, export_settings):
     dll.encoderRelease.restype = None
     dll.encoderRelease.argtypes = [c_void_p]
 
-    # Configuration:
-
     dll.encoderSetCompressionLevel.restype = None
     dll.encoderSetCompressionLevel.argtypes = [c_void_p, c_uint32]
 
     dll.encoderSetQuantizationBits.restype = None
     dll.encoderSetQuantizationBits.argtypes = [c_void_p, c_uint32, c_uint32, c_uint32, c_uint32]
 
-    # Data transfer:
-
     dll.encoderSetFaces.restype = None
-    dll.encoderSetFaces.argtypes = [
-        c_void_p, # Encoder
-        c_uint32, # Index count
-        c_uint32, # Index byte length
-        c_char_p  # Indices
-    ]
+    dll.encoderSetFaces.argtypes = [c_void_p, c_uint32, c_uint32, c_void_p]
 
-    add_attribute_fn_restype = c_uint32 # Draco id
-    add_attribute_fn_argtypes = [
-        c_void_p, # Encoder
-        c_uint32, # Attribute count
-        c_char_p  # Values
-    ]
+    add_attribute_fn_restype = c_uint32
+    add_attribute_fn_argtypes = [c_void_p, c_uint32, c_void_p]
 
     dll.encoderAddPositions.restype = add_attribute_fn_restype
     dll.encoderAddPositions.argtypes = add_attribute_fn_argtypes
@@ -79,8 +63,6 @@ def encode_scene_primitives(scenes, export_settings):
     dll.encoderAddJoints.restype = add_attribute_fn_restype
     dll.encoderAddJoints.argtypes = add_attribute_fn_argtypes
 
-    # Encoding:
-
     dll.encoderEncode.restype = c_bool
     dll.encoderEncode.argtypes = [c_void_p, c_uint8]
 
@@ -88,16 +70,13 @@ def encode_scene_primitives(scenes, export_settings):
     dll.encoderGetByteLength.argtypes = [c_void_p]
 
     dll.encoderCopy.restype = None
-    dll.encoderCopy.argtypes = [c_void_p, c_char_p]
+    dll.encoderCopy.argtypes = [c_void_p, c_void_p]
 
-    # Traverse nodes.
     for scene in scenes:
         for node in scene.nodes:
             __traverse_node(node, lambda node: __encode_node(node, dll, export_settings))
 
-    # Cleanup memory.
-    # May be shared amongst nodes because of non-unique primitive parents, so memory
-    # release happens delayed.
+    # Memory might be shared amongst nodes because of non-unique primitive parents, so release happens delayed.
     for scene in scenes:
         for node in scene.nodes:
             __traverse_node(node, __dispose_memory)
@@ -106,11 +85,7 @@ def __dispose_memory(node):
     """Remove buffers from attribute, since the data now resides inside the encoded Draco buffer."""
     if not (node.mesh is None):
         for primitive in node.mesh.primitives:
-
-            # Drop indices.
             primitive.indices.buffer_view = None
-
-            # Drop attributes.
             attributes = primitive.attributes
             if 'NORMAL' in attributes:
                 attributes['NORMAL'].buffer_view = None
@@ -133,11 +108,9 @@ def __traverse_node(node, f):
 
 
 def __encode_primitive(primitive, dll, export_settings):
-
     attributes = primitive.attributes
     indices = primitive.indices
 
-    # Maps component types to their byte length.
     component_type_byte_length = {
         'Byte': 1,
         'UnsignedByte': 1,
@@ -146,15 +119,13 @@ def __encode_primitive(primitive, dll, export_settings):
         'UnsignedInt': 4,
     }
 
-    # Positions are the only attribute type required to be present.
     if 'POSITION' not in attributes:
         print_console('WARNING', 'Draco encoder: Primitive without positions encountered. Skipping.')
         return
 
     positions = attributes['POSITION']
 
-    # Skip nodes without a position buffer.
-    # This happens with Blender instances, i.e. multiple nodes sharing the same mesh.
+    # Skip nodes without a position buffer, e.g. a primitive from a Blender shared instance.
     if attributes['POSITION'].buffer_view is None:
         return
 
@@ -166,19 +137,13 @@ def __encode_primitive(primitive, dll, export_settings):
     print_console('INFO', 'Draco encoder: {} normals, {} uvs, {} weights, {} joints'
         .format('without' if normals is None else 'with', len(uvs), len(weights), len(joints)))
 
-    # Begin mesh.
     encoder = dll.encoderCreate()
 
-    # Each attribute must have the same count of elements.
-    count = positions.count
-
-    # Add attributes to mesh encoder, remembering each attribute's Draco id.
-
-    position_id = dll.encoderAddPositions(encoder, count, positions.buffer_view.data)
+    position_id = dll.encoderAddPositions(encoder, positions.count, positions.buffer_view.data)
 
     normal_id = None
     if normals is not None:
-        if normals.count != count:
+        if normals.count != positions.count:
             print_console('INFO', 'Draco encoder: Mismatching normal count. Skipping primitive.')
             dll.encoderRelease(encoder)
             return
@@ -186,7 +151,7 @@ def __encode_primitive(primitive, dll, export_settings):
 
     uv_ids = []
     for uv in uvs:
-        if uv.count != count:
+        if uv.count != positions.count:
             print_console('INFO', 'Draco encoder: Mismatching uv count. Skipping primitive.')
             dll.encoderRelease(encoder)
             return
@@ -194,7 +159,7 @@ def __encode_primitive(primitive, dll, export_settings):
 
     weight_ids = []
     for weight in weights:
-        if weight.count != count:
+        if weight.count != positions.count:
             print_console('INFO', 'Draco encoder: Mismatching weight count. Skipping primitive.')
             dll.encoderRelease(encoder)
             return
@@ -202,16 +167,14 @@ def __encode_primitive(primitive, dll, export_settings):
 
     joint_ids = []
     for joint in joints:
-        if joint.count != count:
+        if joint.count != positions.count:
             print_console('INFO', 'Draco encoder: Mismatching joint count. Skipping primitive.')
             dll.encoderRelease(encoder)
             return
         joint_ids.append(dll.encoderAddJoints(encoder, joint.count, joint.buffer_view.data))
 
-    # Add face indices to mesh encoder.
     dll.encoderSetFaces(encoder, indices.count, component_type_byte_length[indices.component_type.name], indices.buffer_view.data)
 
-    # Set compression parameters.
     dll.encoderSetCompressionLevel(encoder, export_settings['gltf_draco_mesh_compression_level'])
     dll.encoderSetQuantizationBits(encoder,
         export_settings['gltf_draco_position_quantization'],
@@ -219,32 +182,13 @@ def __encode_primitive(primitive, dll, export_settings):
         export_settings['gltf_draco_texcoord_quantization'],
         export_settings['gltf_draco_generic_quantization'])
     
-    # After all point and connectivity data has been written to the encoder, it can finally be encoded.
     if dll.encoderEncode(encoder, primitive.targets is not None and len(primitive.targets) > 0):
-
-        # Encoding was successful.
-        # Move compressed data into a bytes object,
-        # which is referenced by a 'gltf2_io_binary_data.BinaryData':
-        #
-        # "KHR_draco_mesh_compression": {
-        #     ....
-        #     "buffer_view": Compressed data inside a 'gltf2_io_binary_data.BinaryData'.
-        # }
-
-        # Query size necessary to hold all the compressed data.
-        compression_size = dll.encoderGetByteLength(encoder)
-
-        # Allocate byte buffer and write compressed data to it.
-        compressed_data = bytes(compression_size)
-        dll.encoderCopy(encoder, compressed_data)
-
-        if primitive.extensions is None:
-            primitive.extensions = {}
-
-        # Write Draco extension into primitive, including attribute ids:
+        byte_length = dll.encoderGetByteLength(encoder)
+        encoded_data = bytes(byte_length)
+        dll.encoderCopy(encoder, encoded_data)
 
         extension = {
-            'bufferView': BinaryData(compressed_data),
+            'bufferView': BinaryData(encoded_data),
             'attributes': {
                 'POSITION': position_id
             }
@@ -262,28 +206,23 @@ def __encode_primitive(primitive, dll, export_settings):
         for (k, id) in enumerate(joint_ids):
             extension['attributes']['JOINTS_' + str(k)] = id
 
+        if primitive.extensions is None:
+            primitive.extensions = {}
+        
         primitive.extensions['KHR_draco_mesh_compression'] = extension
 
-        # Remove buffer views from the accessors of the attributes which compressed:
-
+        # Remove buffer views from the accessors of the attributes which compressed.
         positions.buffer_view = None
-
         if normals is not None:
             normals.buffer_view = None
-
         for uv in uvs:
             uv.buffer_view = None
-
         for weight in weights:
             weight.buffer_view = None
-
         for joint in joints:
             joint.buffer_view = None
 
         # Set to triangle list mode.
         primitive.mode = 4
 
-    # Afterwards, the encoder can be released.
     dll.encoderRelease(encoder)
-
-    return

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -39,7 +39,7 @@ def encode_scene_primitives(scenes, export_settings):
     dll.encoderSetCompressionLevel.argtypes = [c_void_p, c_uint32]
 
     dll.encoderSetQuantizationBits.restype = None
-    dll.encoderSetQuantizationBits.argtypes = [c_void_p, c_uint32, c_uint32, c_uint32, c_uint32]
+    dll.encoderSetQuantizationBits.argtypes = [c_void_p, c_uint32, c_uint32, c_uint32, c_uint32, c_uint32]
     
     dll.encoderSetIndices.restype = None
     dll.encoderSetIndices.argtypes = [c_void_p, c_size_t, c_uint32, c_void_p]
@@ -114,6 +114,7 @@ def __encode_primitive(primitive, dll, export_settings):
         export_settings['gltf_draco_position_quantization'],
         export_settings['gltf_draco_normal_quantization'],
         export_settings['gltf_draco_texcoord_quantization'],
+        export_settings['gltf_draco_color_quantization'],
         export_settings['gltf_draco_generic_quantization'])
     
     if not dll.encoderEncode(encoder, primitive.targets is not None and len(primitive.targets) > 0):

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -89,20 +89,12 @@ def __encode_primitive(primitive, dll, export_settings):
     if attributes['POSITION'].buffer_view is None:
         return
 
-    normals = attributes['NORMAL'] if 'NORMAL' in attributes else None
-    uvs = [attributes[attr] for attr in attributes if attr.startswith('TEXCOORD_')]
-    weights = [attributes[attr] for attr in attributes if attr.startswith('WEIGHTS_')]
-    joints = [attributes[attr] for attr in attributes if attr.startswith('JOINTS_')]
-
     encoder = dll.encoderCreate(positions.count)
 
     draco_ids = {}
     for attr_name in attributes:
         attr = attributes[attr_name]
         draco_id = dll.encoderSetAttribute(encoder, attr_name.encode(), attr.component_type, attr.type.encode(), attr.buffer_view.data)
-        if draco_id == -1:
-            print_console('ERROR', 'Could not encode attribute {}. Skipping primitive.'.format(attr_name))
-            return
         draco_ids[attr_name] = draco_id
         attr.buffer_view = None
 

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bpy
-import sys
-from ctypes import c_void_p, c_uint8, c_uint32, c_uint64, c_bool, c_char_p, cdll
+from ctypes import *
 from pathlib import Path
-import struct
 
 from io_scene_gltf2.io.exp.gltf2_io_binary_data import BinaryData
 from ...io.com.gltf2_io_debug import print_console

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_draco_compression_extension.py
@@ -14,7 +14,7 @@
 
 import bpy
 import sys
-from ctypes import c_void_p, c_uint32, c_uint64, c_bool, c_char_p, cdll
+from ctypes import c_void_p, c_uint8, c_uint32, c_uint64, c_bool, c_char_p, cdll
 from pathlib import Path
 import struct
 
@@ -85,10 +85,7 @@ def encode_scene_primitives(scenes, export_settings):
     # Encoding:
 
     dll.encoderEncode.restype = c_bool
-    dll.encoderEncode.argtypes = [c_void_p]
-
-    dll.encoderEncodeMorphed.restype = c_bool
-    dll.encoderEncodeMorphed.argtypes = [c_void_p]
+    dll.encoderEncode.argtypes = [c_void_p, c_uint8]
 
     dll.encoderGetByteLength.restype = c_uint64
     dll.encoderGetByteLength.argtypes = [c_void_p]
@@ -225,10 +222,8 @@ def __encode_primitive(primitive, dll, export_settings):
         export_settings['gltf_draco_texcoord_quantization'],
         export_settings['gltf_draco_generic_quantization'])
     
-    encodeFunction = dll.encoderEncode if not primitive.targets else dll.encoderEncodeMorphed
-
     # After all point and connectivity data has been written to the encoder, it can finally be encoded.
-    if encodeFunction(encoder):
+    if dll.encoderEncode(encoder, primitive.targets is not None):
 
         # Encoding was successful.
         # Move compressed data into a bytes object,

--- a/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
+++ b/addons/io_scene_gltf2/io/imp/gltf2_io_gltf.py
@@ -54,6 +54,7 @@ class glTFImporter():
             'KHR_texture_transform',
             'KHR_materials_clearcoat',
             'KHR_mesh_quantization',
+            'KHR_draco_mesh_compression'
         ]
 
     @staticmethod


### PR DESCRIPTION
Adds the ability to import a Draco compressed glTF file using the [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression) extension.
Updates the Draco exporter to handle any arbitrary mesh attribute including vertex colors.

The updated [Blender Draco bridge](https://github.com/ux3d/Blender_ExternDraco) is required to be installed in order to use the new encoder/decoder.
