### PR TITLE
Fixing calculated transform for linked collections with non-zero offsets

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -423,8 +423,17 @@ def __gather_trans_rot_scale(blender_object, export_settings):
     sca = __convert_swizzle_scale(sca, export_settings)
 
     if blender_object.instance_type == 'COLLECTION' and blender_object.instance_collection:
-        trans -= __convert_swizzle_location(
+        offset = -gltf2_blender_extract.convert_swizzle_location(
             blender_object.instance_collection.instance_offset, export_settings)
+
+        s = Matrix.Diagonal(sca).to_4x4()
+        r = rot.to_matrix().to_4x4() 
+        t = Matrix.Translation(trans).to_4x4()
+        o = Matrix.Translation(offset).to_4x4()
+        m = t @ r @ s @ o
+
+        trans = m.translation
+        
     translation, rotation, scale = (None, None, None)
     trans[0], trans[1], trans[2] = gltf2_blender_math.round_if_near(trans[0], 0.0), gltf2_blender_math.round_if_near(trans[1], 0.0), \
                                    gltf2_blender_math.round_if_near(trans[2], 0.0)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -423,7 +423,7 @@ def __gather_trans_rot_scale(blender_object, export_settings):
     sca = __convert_swizzle_scale(sca, export_settings)
 
     if blender_object.instance_type == 'COLLECTION' and blender_object.instance_collection:
-        offset = -gltf2_blender_extract.convert_swizzle_location(
+        offset = -__convert_swizzle_location(
             blender_object.instance_collection.instance_offset, export_settings)
 
         s = Matrix.Diagonal(sca).to_4x4()


### PR DESCRIPTION
If a scene has an object which is linked to an object in another file and the original object is in a collection where the collection has a non-zero offset, then the transform for the object in the scene will be incorrectly calculated if it has a non-zero rotation or scale.

See issue:
https://github.com/KhronosGroup/glTF-Blender-IO/issues/1280