### PR TITLE
Import: create placeholder images for files that can't be loaded (fix #1296)

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_image.py
@@ -39,15 +39,14 @@ class BlenderImage():
             return
 
         tmp_dir = None
+        is_placeholder = False
         try:
             if img.uri is not None and not img.uri.startswith('data:'):
                 # Image stored in a file
                 img_from_file = True
                 path = join(dirname(gltf.filename), _uri_to_path(img.uri))
                 img_name = img_name or basename(path)
-                if not isfile(path):
-                    gltf.log.error("Missing file (index " + str(img_idx) + "): " + img.uri)
-                    return
+
             else:
                 # Image stored as data => create a tempfile, pack, and delete file
                 img_from_file = False
@@ -63,10 +62,19 @@ class BlenderImage():
                     f.write(img_data)
 
             num_images = len(bpy.data.images)
-            blender_image = bpy.data.images.load(os.path.abspath(path), check_existing=img_from_file)
+
+            try:
+                blender_image = bpy.data.images.load(os.path.abspath(path), check_existing=img_from_file)
+            except RuntimeError:
+                gltf.log.error("Missing image file (index %d): %s" % (img_idx, path))
+                blender_image = _placeholder_image(img_name, os.path.abspath(path))
+                is_placeholder = True
+
             if len(bpy.data.images) != num_images:  # If created a new image
                 blender_image.name = img_name
-                if gltf.import_settings['import_pack_images'] or not img_from_file:
+
+                needs_pack = gltf.import_settings['import_pack_images'] or not img_from_file
+                if not is_placeholder and needs_pack:
                     blender_image.pack()
 
             img.blender_image_name = blender_image.name
@@ -74,6 +82,13 @@ class BlenderImage():
         finally:
             if tmp_dir is not None:
                 tmp_dir.cleanup()
+
+def _placeholder_image(name, path):
+    image = bpy.data.images.new(name, 128, 128)
+    # allow the path to be resolved later
+    image.filepath = path
+    image.source = 'FILE'
+    return image
 
 def _uri_to_path(uri):
     uri = urllib.parse.unquote(uri)


### PR DESCRIPTION
Fixes #1296.

CesiumMan with its image missing in master:

![master](https://user-images.githubusercontent.com/11024420/102504922-05420300-4047-11eb-8021-61440d3fddda.png)

And in this branch; a placeholder image is created pointing at where the image should be:

![this branch](https://user-images.githubusercontent.com/11024420/102504959-0ecb6b00-4047-11eb-81f8-ff60c0fb6c1c.png)

The missing texture will be reported through `File > External Data > Report Missing Files`. You can check what the missing file should be and put the image file there after the import to make it work.

Placeholders are created only for images from a file (ie. not from bufferView/data URIs).