### PR TITLE
🐛 correctly resolve uvset when nodepath is rerouted

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -151,6 +151,12 @@ def __gather_tex_coord(primary_socket, export_settings):
 
     input_node = blender_shader_node.inputs['Vector'].links[0].from_node
 
+    while isinstance(input_node, bpy.types.NodeReroute):
+        # reroute node is not connected. not sure if this can happen
+        if len(input_node.inputs[0].links) == 0:
+            return 0
+        input_node = input_node.inputs[0].links[0].from_node
+
     if isinstance(input_node, bpy.types.ShaderNodeMapping):
 
         if len(input_node.inputs['Vector'].links) == 0:


### PR DESCRIPTION
I have a reroutenode in place on the road to my uvset...unfortunately blender will just return 0 (which is wrong because I have a light UV map at position 0) and I get super distorted models out of blender....

this bugfix handles reroute nodes in between...


