### PR TITLE
Import: bugfix: use Separate R node for clearcoat textures

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_clearcoat.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_clearcoat.py
@@ -16,7 +16,7 @@ from ...io.com.gltf2_io import TextureInfo, MaterialNormalTextureInfoClass
 from .gltf2_blender_texture import texture
 
 
-# [Texture] => [Clearcoat Factor] =>
+# [Texture] => [Separate R] => [Clearcoat Factor] =>
 def clearcoat(mh, location, clearcoat_socket):
     x, y = location
     try:
@@ -49,9 +49,15 @@ def clearcoat(mh, location, clearcoat_socket):
 
         x -= 200
 
-    # Clearcoat is in the R component; we don't need to separate it out
-    # since hooking a color socket up to a value socket automatically gets
-    # the R
+    # Separate RGB
+    node = mh.node_tree.nodes.new('ShaderNodeSeparateRGB')
+    node.location = x - 150, y - 75
+    # Outputs
+    mh.node_tree.links.new(clearcoat_socket, node.outputs['R'])
+    # Inputs
+    clearcoat_socket = node.inputs[0]
+
+    x -= 200
 
     texture(
         mh,


### PR DESCRIPTION
This is a bugfix for #1061.  
cc @donmccurdy 

The comment here says the Separate RGB node when wiring up the Clearcoat texture can be skipped because the R component is used when a Color node is connected to a Value node. The reason I believed this is because the exporter acts as if this were true, but what _Blender_ actually does is

> [the color data is converted to its gray scale equivalent](https://docs.blender.org/manual/en/2.91/interface/controls/nodes/parts.html?highlight=gray+scale#conversion)

So this just adds the missing Separate RGB node. Because, like I said, the exporter uses R in this case, there is no change in roundtripping behaviour.