### PR TITLE
Import: make NLA track order match glTF animation order

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -50,7 +50,9 @@ class BlenderScene():
     def create_animations(gltf):
         """Create animations."""
         if gltf.data.animations:
-            for anim_idx, _anim in enumerate(gltf.data.animations):
+            # NLA tracks are added bottom to top, so create animations in
+            # reverse so the first winds up on top
+            for anim_idx in reversed(range(len(gltf.data.animations))):
                 BlenderAnimation.anim(gltf, anim_idx)
 
             # Restore first animation


### PR DESCRIPTION
This is a minor enhancement.

If you look at the tracks in the NLA editor after import, they are reversed from the order in the original glTF file. This PR makes them go, reading from top to bottom, in the same order as the file.

Because the API doesn't seem to allow adding a track to the _bottom_ of the track list, the easiest way to do this is just to create the animations in reverse.

Example with Fox sample model:

![out](https://user-images.githubusercontent.com/11024420/104817964-49f9bf00-57ea-11eb-9fab-10f9dbbba6fc.png)
