### PR TITLE
Draco: Increase maximal compression limit

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -196,7 +196,7 @@ class ExportGLTF2_Base:
         description='Compression level (0 = most speed, 6 = most compression, higher values currently not supported)',
         default=6,
         min=0,
-        max=6
+        max=10
     )
 
     export_draco_position_quantization: IntProperty(


### PR DESCRIPTION
Increases the available Draco compression levels from [0, 6] to [0, 10].
10 is the currently maximal compression level offered by the Draco API.

A sample [.blend file](https://github.com/KhronosGroup/glTF-Blender-IO/files/6035002/Archive.zip) has been compressed with all available compression levels, showing that a higher compression level does not necessarily guarantee a smaller file size. The uncompressed GLB is 4800 KB.

<img width="403" alt="image" src="https://user-images.githubusercontent.com/46439951/108982470-20a43c80-768e-11eb-984b-fb400687a65d.png">


This PR depends on the Draco bridging library shipped with Blender 2.92, though it does not require it to be updated.

