### PR TITLE
Basic export of KHR_materials_sheen factors.

### DIFF
--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -60,6 +60,7 @@ with the following channels of information:
 Some additional material properties or types of materials can be expressed using glTF extensions:
 
 - Clearcoat, Clearcoat Roughness, Clearcoat Normal (uses ``KHR_materials_clearcoat``)
+- Sheen (uses ``KHR_materials_sheen``; textures not yet supported)
 - Transmission (uses ``KHR_materials_transmission``)
 - "Shadeless" materials (uses ``KHR_materials_unlit``)
 
@@ -420,6 +421,7 @@ are supported directly by this add-on:
 - ``KHR_draco_mesh_compression``
 - ``KHR_lights_punctual``
 - ``KHR_materials_clearcoat``
+- ``KHR_materials_sheen``
 - ``KHR_materials_transmission``
 - ``KHR_materials_unlit``
 - ``KHR_texture_transform``


### PR DESCRIPTION
Sheen in Blender's Principled BSDF node doesn't exactly match `KHR_materials_sheen`: glTF defines a sheen color. Blender defines a sheen factor (0-1), and defines color in a "tint" that can be lerped between white and the base color. Blender does not offer sheen roughness, but sheen appears to inherit the roughness of the material itself.

This is a basic export implementation for `KHR_materials_sheen`, supporting only factors and not textures. If the approach seems reasonable I am happy to add tests, but I don't think I have bandwidth to extend this and also bake textures. The example below uses a "hot pink" base color, and full-strength white sheen. The effect appears stronger in BabylonJS than in Blender, but I don't know why and don't yet have other implementations to compare against.

| Blender | BabylonJS |
|---|---|
| ![Screen Shot 2021-03-02 at 7 50 27 PM](https://user-images.githubusercontent.com/1848368/109750156-c543e400-7b90-11eb-81b4-51c4df06b937.png) | ![Screen Shot 2021-03-02 at 7 50 05 PM](https://user-images.githubusercontent.com/1848368/109750160-c70da780-7b90-11eb-85eb-c46de6764cd4.png) |

[SheenTest.glb.zip](https://github.com/KhronosGroup/glTF-Blender-IO/files/6073486/SheenTest.glb.zip)