### PR TITLE
Fix #1382 fix crash when mesh is not created, without crash

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -15,8 +15,8 @@
 bl_info = {
     'name': 'glTF 2.0 format',
     'author': 'Julien Duroure, Scurest, Norbert Nopper, Urs Hanselmann, Moritz Becher, Benjamin Schmithüsen, Jim Eckerlein, and many external contributors',
-    "version": (1, 6, 9),
-    'blender': (2, 91, 0),
+    "version": (1, 7, 0),
+    'blender': (2, 93, 0),
     'location': 'File > Import-Export',
     'description': 'Import-Export as glTF 2.0',
     'warning': '',

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -352,15 +352,14 @@ def __gather_mesh_from_nonmesh(blender_object, library, export_settings):
                 blender_mesh_owner = blender_object.evaluated_get(depsgraph)
                 blender_mesh = blender_mesh_owner.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
                 # TODO: do we need preserve_all_data_layers?
-                # In some cases (for example curve with single vertice), no blender_mesh is created (without crash)
-                if blender_mesh is None:
-                    return None
 
             else:
                 blender_mesh_owner = blender_object
                 blender_mesh = blender_mesh_owner.to_mesh()
-                if blender_mesh is None: #Just in case (see above some not created mesh without crash)
-                    return None
+                
+            # In some cases (for example curve with single vertice), no blender_mesh is created (without crash)
+            if blender_mesh is None:
+                return None
 
         except Exception:
             return None

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -352,10 +352,15 @@ def __gather_mesh_from_nonmesh(blender_object, library, export_settings):
                 blender_mesh_owner = blender_object.evaluated_get(depsgraph)
                 blender_mesh = blender_mesh_owner.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
                 # TODO: do we need preserve_all_data_layers?
+                # In some cases (for example curve with single vertice), no blender_mesh is created (without crash)
+                if blender_mesh is None:
+                    return None
 
             else:
                 blender_mesh_owner = blender_object
                 blender_mesh = blender_mesh_owner.to_mesh()
+                if blender_mesh is None: #Just in case (see above some not created mesh without crash)
+                    return None
 
         except Exception:
             return None


### PR DESCRIPTION
When creating a mesh from non mesh (curve for example), it sometime do not create any meshes, but without crashes (for example curve with a single vertice).