### PR TITLE
CI: update for builder.blender.org changes, Blender 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Find latest Blender build
       id: blender_version
       run: |
-        BLENDER_URL="https://builder.blender.org$(curl -s https://builder.blender.org/download/ | \
-          grep -oe '[^\"]*blender-'$BLENDER_MAJOR'\.'$BLENDER_MINOR'[^\"]*linux64[^\"]*' | \
+        BLENDER_URL="$(curl -s https://builder.blender.org/download/daily/ | \
+          grep -oe 'http[^\"]*blender-'$BLENDER_MAJOR'\.'$BLENDER_MINOR'[^\"]*linux[^\"]*\.tar\.xz' | \
           tail -n1)"
         echo "Found current build for Blender $BLENDER_MAJOR.$BLENDER_MINOR: $BLENDER_URL"
         echo "::set-output name=blender-url::$BLENDER_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
         curl -SL "${{ steps.blender_version.outputs.blender-url }}" | \
           tar -Jx -C /opt/blender --strip-components=1
 
+    # See https://developer.blender.org/T88387
+    - name: Install PulseAudio
+      run: sudo apt-get install pulseaudio
+
     - name: Set up workspace
       run: |
         sudo ln -s /opt/blender/blender /usr/local/bin/blender

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,15 @@ jobs:
     - name: Find latest Blender build
       id: blender_version
       run: |
+        echo "Looking for Blender $BLENDER_MAJOR.$BLENDER_MINOR"
         BLENDER_URL="$(curl -s https://builder.blender.org/download/daily/ | \
           grep -oe 'http[^\"]*blender-'$BLENDER_MAJOR'\.'$BLENDER_MINOR'[^\"]*linux[^\"]*\.tar\.xz' | \
           tail -n1)"
-        echo "Found current build for Blender $BLENDER_MAJOR.$BLENDER_MINOR: $BLENDER_URL"
+        if [ -z "$BLENDER_URL" ]; then
+          echo "Not found! Download URL may have changed; CI may need update."
+          exit 1
+        fi
+        echo "Found: $BLENDER_URL"
         echo "::set-output name=blender-url::$BLENDER_URL"
 
     # Loads a cached build of Blender if available. If not available, this step


### PR DESCRIPTION
builder.blender.org changed again, which triggered #1320.

This should fix #1320 and update for the new URL format and 3.0.