### PR TITLE
Import: fix issue involving flipped bone Z dir (#1396)

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -145,8 +145,8 @@ class BlenderNode():
             arma_mat = vnode.editbone_arma_mat
             editbone.head = arma_mat @ Vector((0, 0, 0))
             editbone.tail = arma_mat @ Vector((0, 1, 0))
-            editbone.align_roll(arma_mat @ Vector((0, 0, 1)) - editbone.head)
             editbone.length = vnode.bone_length
+            editbone.align_roll(arma_mat @ Vector((0, 0, 1)) - editbone.head)
 
             if isinstance(id, int):
                 pynode = gltf.data.nodes[id]


### PR DESCRIPTION
Fixes #1396.

Blender issue is confirmed, but don't think we need to around for a fix. This just avoids the issue by setting the bone Z axis after the length. This fixes the file from https://devtalk.blender.org/t/gltf-export-issue-upd-import-issue/18970.

This is also a good candidate for 2.93, either before the release next week, or after since its an LTS.