### PR TITLE
CI: be less wasteful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    strategy:
-      matrix:
-       include:
-         - filter: "blender_export"
-         - filter: "blender_roundtrip"
-
-    env:
-      FILTER: ${{ matrix.filter }}
-
     steps:
 
     - uses: actions/checkout@v2
@@ -86,11 +77,11 @@ jobs:
     - name: Run tests
       run: |
         cd tests
-        OUT_PREFIX=$GITHUB_WORKSPACE/tests/out yarn test-bail --reporter-options reportDir=out/mochawesome -g $FILTER
+        OUT_PREFIX=$GITHUB_WORKSPACE/tests/out yarn test-bail --reporter-options reportDir=out/mochawesome
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: test-output-${{ matrix.filter }}
+        name: test-output
         path: tests/out/mochawesome
         if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
   CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-
     # Finds latest Blender build, and outputs the hosted build's download URL.
     - name: Find latest Blender build
       id: blender_version


### PR DESCRIPTION
A push to the (eg) vtree export branch downloads Blender [four times in CI](https://github.com/KhronosGroup/glTF-Blender-IO/runs/2687067559) (two event triggers X two jobs). This fixes it so it only downloads once.

* Run only on pushes to _master_ (still runs on PRs to all branches). Currently two workflows are started if a maintainer pushes to a PRed branch in this repo, one for the push and one for the PR. (This only affects maintainers since the rest of us push to branches in forks.) See https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012.
* Do all tests in one job, instead of two, as suggested by @emackey in https://github.com/KhronosGroup/glTF-Blender-IO/pull/1274#issuecomment-735243033. This adds about 60s wall clock time.

This also removes setup-node in favor of using the version of node/yarn that comes preinstalled on the CI machine, which is good enough for us.