### PR TITLE
Keep original texture files

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -173,6 +173,12 @@ class ExportGLTF2_Base:
         default='',
     )
 
+    export_keep_originals: BoolProperty(
+        name='Keep original',
+        description='Keep original textures files if possible',
+        default=False,
+    )
+
     export_texcoords: BoolProperty(
         name='UVs',
         description='Export UVs (texture coordinates) with meshes',
@@ -517,6 +523,7 @@ class ExportGLTF2_Base:
             export_settings['gltf_filedirectory'],
             self.export_texture_dir,
         )
+        export_settings['gltf_keep_original_textures'] = self.export_keep_originals
 
         export_settings['gltf_format'] = self.export_format
         export_settings['gltf_image_format'] = self.export_image_format
@@ -654,6 +661,7 @@ class GLTF_PT_export_main(bpy.types.Panel):
         layout.prop(operator, 'export_format')
         if operator.export_format == 'GLTF_SEPARATE':
             layout.prop(operator, 'export_texture_dir', icon='FILE_FOLDER')
+            layout.prop(operator, 'export_keep_originals')
         layout.prop(operator, 'export_copyright')
         layout.prop(operator, 'will_save_settings')
 

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -175,9 +175,9 @@ class ExportGLTF2_Base:
 
     export_keep_originals: BoolProperty(
         name='Keep original',
-        description=('Keep original textures files if possible. ',
+        description=('Keep original textures files if possible. '
                      'WARNING: if you use more than one texture, '
-                     'where pbr standard requires only one, only one texture will be used.',
+                     'where pbr standard requires only one, only one texture will be used.'
                      'This can lead to unexpected results'
         ),
         default=False,

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -175,7 +175,11 @@ class ExportGLTF2_Base:
 
     export_keep_originals: BoolProperty(
         name='Keep original',
-        description='Keep original textures files if possible',
+        description=('Keep original textures files if possible. ',
+                     'WARNING: if you use more than one texture, '
+                     'where pbr standard requires only one, only one texture will be used.',
+                     'This can lead to unexpected results'
+        ),
         default=False,
     )
 

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -660,8 +660,10 @@ class GLTF_PT_export_main(bpy.types.Panel):
 
         layout.prop(operator, 'export_format')
         if operator.export_format == 'GLTF_SEPARATE':
-            layout.prop(operator, 'export_texture_dir', icon='FILE_FOLDER')
             layout.prop(operator, 'export_keep_originals')
+            if operator.export_keep_originals is False:
+                layout.prop(operator, 'export_texture_dir', icon='FILE_FOLDER')
+
         layout.prop(operator, 'export_copyright')
         layout.prop(operator, 'will_save_settings')
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -198,7 +198,6 @@ def __get_image_data(sockets, export_settings) -> ExportImage:
         # Assume that user know what he does, and that channels/images are already combined correctly for pbr
         if export_settings['gltf_keep_original_textures']:
             composed_image = ExportImage.from_original(result.shader_node.image)
-            print("-->", result.shader_node.image.name)
 
         else:
             # rudimentarily try follow the node tree to find the correct image data.

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -46,7 +46,7 @@ def gather_image(
         uri = __gather_uri(image_data, mime_type, name, export_settings)
     else:
         # Retrieve URI relative to exported glTF files
-            uri = __gather_original_uri(image_data.original.filepath, export_settings)
+        uri = __gather_original_uri(image_data.original.filepath, export_settings)
 
     buffer_view = __gather_buffer_view(image_data, mime_type, name, export_settings)
 
@@ -65,7 +65,7 @@ def gather_image(
     return image
 
 def __gather_original_uri(original_uri, export_settings):
-    
+
     def _path_to_uri(path):
         import urllib
         path = os.path.normpath(path)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_image.py
@@ -196,6 +196,10 @@ def __get_image_data(sockets, export_settings) -> ExportImage:
             continue
 
         # Assume that user know what he does, and that channels/images are already combined correctly for pbr
+        # If not, we are going to keep only the first texture found
+        # Example : If user set up 2 or 3 different textures for Metallic / Roughness / Occlusion
+        # Only 1 will be used at export
+        # This Warning is displayed in UI of this option
         if export_settings['gltf_keep_original_textures']:
             composed_image = ExportImage.from_original(result.shader_node.image)
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -64,8 +64,11 @@ class ExportImage:
     intelligent decisions about how to encode the image.
     """
 
-    def __init__(self):
+    def __init__(self, original=None):
         self.fills = {}
+
+        # In case of keeping original texture images
+        self.original = original
 
     @staticmethod
     def from_blender_image(image: bpy.types.Image):
@@ -73,6 +76,10 @@ class ExportImage:
         for chan in range(image.channels):
             export_image.fill_image(image, dst_chan=chan, src_chan=chan)
         return export_image
+
+    @staticmethod
+    def from_original(image: bpy.types.Image):
+        return ExportImage(image)
 
     def fill_image(self, image: bpy.types.Image, dst_chan: Channel, src_chan: Channel):
         self.fills[dst_chan] = FillImage(image, src_chan)
@@ -84,7 +91,10 @@ class ExportImage:
         return chan in self.fills
 
     def empty(self) -> bool:
-        return not self.fills
+        if self.original is None:
+            return not self.fills
+        else:
+            return False
 
     def blender_image(self) -> Optional[bpy.types.Image]:
         """If there's an existing Blender image we can use,


### PR DESCRIPTION
Add a new option, when exporting as 'gltf separate', to keep original texture images if possible.

Proof of concept.
Works only for simple cases yet

Using this example :
[test_keep_texture.zip](https://github.com/KhronosGroup/glTF-Blender-IO/files/6604867/test_keep_texture.zip)

Do not work for occlusion/roughnessMetalic
Works for base color, emissive, normal