### PR TITLE
(WIP) More flexible image export handling for extensions.

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -208,7 +208,7 @@ class ExportImage:
                     with open(src_path, 'rb') as f:
                         data = f.read()
         # Check magic number is right
-        if data and self.check_magic(data):
+        if data and self.__check_magic(data):
             return data
 
         # Copy to a temp image and save.

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_image_data.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_image_data.py
@@ -19,6 +19,13 @@ class ImageData:
     # FUTURE_WORK: as a method to allow the node graph to be better supported, we could model some of
     # the node graph elements with numpy functions
 
+    extension_for_mime = {
+        "image/jpeg": ".jpg",
+        "image/png": ".png",
+        "image/x-exr": ".exr",
+        "image/vnd.radiance": ".hdr"
+    }
+
     def __init__(self, data: bytes, mime_type: str, name: str):
         self._data = data
         self._mime_type = mime_type
@@ -46,9 +53,7 @@ class ImageData:
 
     @property
     def file_extension(self):
-        if self._mime_type == "image/jpeg":
-            return ".jpg"
-        return ".png"
+        return ImageData.extension_for_mime.get(self.mime_type)
 
     @property
     def byte_length(self):

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_image_data.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_image_data.py
@@ -53,7 +53,7 @@ class ImageData:
 
     @property
     def file_extension(self):
-        return ImageData.extension_for_mime.get(self.mime_type)
+        return ImageData.extension_for_mime.get(self._mime_type)
 
     @property
     def byte_length(self):


### PR DESCRIPTION
There are now several GLTF extensions for alternate image formats like `KHR_texture_basisu` and  `EXT_texture_webp`. It would be nice to add support for these to to other addons built against this extension without them having to duplicate the node traversal and channel combination/remapping logic already implemented in `ExportImage`.

This is a quick attempt at abstracting things just enough to allow that. I am not particularly happy with this solution but I think its a useful starting point for discussion.

Using this in the Hubs Blender Exporter to support .hdr (which blender already natively understands) files on lightmaps like this:
https://github.com/MozillaReality/hubs-blender-exporter/blob/76579e38ad2b3ad6768eef7b1acf575b2fe4302d/gather_properties.py#L181-L193
https://github.com/MozillaReality/hubs-blender-exporter/blob/76579e38ad2b3ad6768eef7b1acf575b2fe4302d/gather_properties.py#L215

For formats Blender does not already natively support you could instead completely override `encode(mime)`:
```python
ImageData.extension_for_mime["image/ktx2"] = ".ktx"
class BasisExportImage(ExportImage):
    def preferred_mime_type(self) -> str:
        return "image/ktx2"

    def encode(self, mime_type: Optional[str]) -> bytes:
        # use self.fills to generate a ktx2 image
        return bytes()
```
Again this feels a bit messy and its stretching the `ExportImage` abstraction quite a bit, but hopefully serves to show what an addon might want to be able to do. It would likely be a better solution to pull out the bits of `gather_image` and `ExportImage` that are generically useful and have the addon call those instead, skipping `gather_image` entirely, but I wanted to start with a more direct approach just to see the minimal set of changes needed.

---

Some related issues I ran into while looking into this: #1234 #1308