### PR TITLE
Add merge_animation_extensions_hook

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather.py
@@ -116,6 +116,10 @@ def __gather_animations(blender_scene, export_settings):
 
             to_delete_idx.append(anim_idx)
 
+            # Merging extensions
+            # Provide a hook to handle extension merging since there is no way to know author intent
+            export_user_extensions('merge_animation_extensions_hook', export_settings, animations[anim_idx], animations[base_animation_idx])
+
             # Merging extras
             # Warning, some values can be overwritten if present in multiple merged animations
             if animations[anim_idx].extras is not None:

--- a/example-addons/example_gltf_extension/readme.md
+++ b/example-addons/example_gltf_extension/readme.md
@@ -32,4 +32,5 @@ gather_scene_hook(self, gltf2_scene, blender_scene, export_settings)
 gather_skin_hook(self, gltf2_skin, blender_object, export_settings)
 gather_texture_hook(self, gltf2_texture, blender_shader_sockets, export_settings)
 gather_texture_info_hook(self, gltf2_texture_info, blender_shader_sockets, export_settings)
+merge_animation_extensions_hook(self, gltf2_animation_source, gltf2_animation_destination, export_settings)
 ```


### PR DESCRIPTION
This adds a new hook called `merge_animation_extensions_hook` to allow add-ons to handle the merging of animation extension data when multiple animations use the same name.

Resolves #1419
