### PR TITLE
Don't export glTF2ExportSettings into GLTF extras

### DIFF
--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_extras.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_extras.py
@@ -18,7 +18,7 @@ from .gltf2_blender_json import is_json_convertible
 
 
 # Custom properties, which are in most cases present and should not be imported/exported.
-BLACK_LIST = ['cycles', 'cycles_visibility', 'cycles_curves', '_RNA_UI']
+BLACK_LIST = ['cycles', 'cycles_visibility', 'cycles_curves', '_RNA_UI', 'glTF2ExportSettings']
 
 
 def generate_extras(blender_element):


### PR DESCRIPTION
Not sure if this was an oversight or intentional; feel free to close if the latter.