### PR TITLE
Extended information string in case no binary provided

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -332,10 +332,7 @@ def __gather_output(channels: typing.Tuple[bpy.types.FCurve],
     else:
         object_path = None
 
-    if driver_obj is not None:
-        is_armature_animation = False
-    else:
-        is_armature_animation = bake_bone is not None or (blender_object_if_armature is not None and object_path != "")
+    is_armature_animation = bake_bone is not None or (blender_object_if_armature is not None and object_path != "")
 
     if is_armature_animation:
         if bake_bone is None:


### PR DESCRIPTION
In case binary file is not included in Blender3D installation it would be nice for user to know the fastest way to solve the problem without visiting source files.

My case is that Blender3D uses OS Python libraries and adding ```blender_root / python_lib / python_version / 'site_packages'``` folder to my installation breaks Python or some of it's dependencies. Adding BLENDER_EXTERN_DRACO_LIBRARY_PATH with binary file is the fastest way to solve a problem.