### PR TITLE
Don't mangle custom properties on export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
@@ -104,6 +104,9 @@ def __fix_json(obj):
     if isinstance(obj, dict):
         fixed = {}
         for key, value in obj.items():
+            if key == 'extras' and value is not None:
+                fixed[key] = value
+                continue
             if not __should_include_json_value(key, value):
                 continue
             fixed[key] = __fix_json(value)


### PR DESCRIPTION
Modifies the json export process to leave extras as-is. This is the product of a long debugging session trying to work out why my custom property with a value of `{}` was being silently erased.