### PR TITLE
Fix #1432 : remove some channel animation if is not animated

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_channels.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_channels.py
@@ -126,7 +126,17 @@ def gather_animation_channels(blender_action: bpy.types.Action,
             if len(channel_group_sorted) == 0:
                 # Only errors on channels, ignoring
                 continue
-            channel = __gather_animation_channel(channel_group_sorted, blender_object, export_settings, None, None, bake_range_start, bake_range_end, blender_action.name, None, False)
+            channel = __gather_animation_channel(
+                        channel_group_sorted,
+                        blender_object,
+                        export_settings,
+                        None,
+                        None,
+                        bake_range_start,
+                        bake_range_end,
+                        blender_action.name,
+                        None,
+                        False)
             if channel is not None:
                 channels.append(channel)
 
@@ -198,14 +208,14 @@ def __gather_animation_channel(channels: typing.Tuple[bpy.types.FCurve],
                                bake_range_end,
                                action_name: str,
                                driver_obj,
-                               bone_channel_is_animated: bool
+                               node_channel_is_animated: bool
                                ) -> typing.Union[gltf2_io.AnimationChannel, None]:
     if not __filter_animation_channel(channels, blender_object, export_settings):
         return None
 
     __target= __gather_target(channels, blender_object, export_settings, bake_bone, bake_channel, driver_obj)
     if __target.path is not None:
-        sampler = __gather_sampler(channels, blender_object, export_settings, bake_bone, bake_channel, bake_range_start, bake_range_end, action_name, driver_obj, bone_channel_is_animated)
+        sampler = __gather_sampler(channels, blender_object, export_settings, bake_bone, bake_channel, bake_range_start, bake_range_end, action_name, driver_obj, node_channel_is_animated)
 
         if sampler is None:
             # After check, no need to animate this node for this channel
@@ -266,7 +276,7 @@ def __gather_sampler(channels: typing.Tuple[bpy.types.FCurve],
                      bake_range_end,
                      action_name,
                      driver_obj,
-                     bone_channel_is_animated: bool
+                     node_channel_is_animated: bool
                      ) -> gltf2_io.AnimationSampler:
     return gltf2_blender_gather_animation_samplers.gather_animation_sampler(
         channels,
@@ -277,7 +287,7 @@ def __gather_sampler(channels: typing.Tuple[bpy.types.FCurve],
         bake_range_end,
         action_name,
         driver_obj,
-        bone_channel_is_animated,
+        node_channel_is_animated,
         export_settings
     )
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_channels.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_channels.py
@@ -69,6 +69,11 @@ def gather_animation_channels(blender_action: bpy.types.Action,
             bones_to_be_animated, _, _ = gltf2_blender_gather_skins.get_bone_tree(None, blender_object)
             bones_to_be_animated = [blender_object.pose.bones[b.name] for b in bones_to_be_animated]
 
+        list_of_animated_bone_channels = []
+        for channel_group in __get_channel_groups(blender_action, blender_object, export_settings):
+            channel_group_sorted = __get_channel_group_sorted(channel_group, blender_object)
+            list_of_animated_bone_channels.extend([(gltf2_blender_get.get_object_from_datapath(blender_object, get_target_object_path(i.data_path)).name, get_target_property_name(i.data_path)) for i in channel_group])
+
         for bone in bones_to_be_animated:
             for p in ["location", "rotation_quaternion", "scale"]:
                 channel = __gather_animation_channel(
@@ -80,8 +85,10 @@ def gather_animation_channels(blender_action: bpy.types.Action,
                     bake_range_start,
                     bake_range_end,
                     blender_action.name,
-                    None)
-                channels.append(channel)
+                    None,
+                    (bone.name, p) in list_of_animated_bone_channels)
+                if channel is not None:
+                    channels.append(channel)
 
 
         # Retrieve animation on armature object itself, if any
@@ -91,7 +98,7 @@ def gather_animation_channels(blender_action: bpy.types.Action,
             if len(channel_group) == 0:
                 # Only errors on channels, ignoring
                 continue
-            channel = __gather_animation_channel(channel_group, blender_object, export_settings, None, None, bake_range_start, bake_range_end, blender_action.name, None)
+            channel = __gather_animation_channel(channel_group, blender_object, export_settings, None, None, bake_range_start, bake_range_end, blender_action.name, None, False)
             if channel is not None:
                 channels.append(channel)
 
@@ -109,7 +116,8 @@ def gather_animation_channels(blender_action: bpy.types.Action,
                 bake_range_start,
                 bake_range_end,
                 blender_action.name,
-                obj)
+                obj,
+                False)
             channels.append(channel)
 
     else:
@@ -118,7 +126,7 @@ def gather_animation_channels(blender_action: bpy.types.Action,
             if len(channel_group_sorted) == 0:
                 # Only errors on channels, ignoring
                 continue
-            channel = __gather_animation_channel(channel_group_sorted, blender_object, export_settings, None, None, bake_range_start, bake_range_end, blender_action.name, None)
+            channel = __gather_animation_channel(channel_group_sorted, blender_object, export_settings, None, None, bake_range_start, bake_range_end, blender_action.name, None, False)
             if channel is not None:
                 channels.append(channel)
 
@@ -189,17 +197,25 @@ def __gather_animation_channel(channels: typing.Tuple[bpy.types.FCurve],
                                bake_range_start,
                                bake_range_end,
                                action_name: str,
-                               driver_obj
+                               driver_obj,
+                               bone_channel_is_animated: bool
                                ) -> typing.Union[gltf2_io.AnimationChannel, None]:
     if not __filter_animation_channel(channels, blender_object, export_settings):
         return None
 
     __target= __gather_target(channels, blender_object, export_settings, bake_bone, bake_channel, driver_obj)
     if __target.path is not None:
+        sampler = __gather_sampler(channels, blender_object, export_settings, bake_bone, bake_channel, bake_range_start, bake_range_end, action_name, driver_obj, bone_channel_is_animated)
+
+        if sampler is None:
+            # After check, no need to animate this node for this channel
+            return None
+
+
         animation_channel = gltf2_io.AnimationChannel(
             extensions=__gather_extensions(channels, blender_object, export_settings, bake_bone),
             extras=__gather_extras(channels, blender_object, export_settings, bake_bone),
-            sampler=__gather_sampler(channels, blender_object, export_settings, bake_bone, bake_channel, bake_range_start, bake_range_end, action_name, driver_obj),
+            sampler=sampler,
             target=__target
         )
 
@@ -249,7 +265,8 @@ def __gather_sampler(channels: typing.Tuple[bpy.types.FCurve],
                      bake_range_start,
                      bake_range_end,
                      action_name,
-                     driver_obj
+                     driver_obj,
+                     bone_channel_is_animated: bool
                      ) -> gltf2_io.AnimationSampler:
     return gltf2_blender_gather_animation_samplers.gather_animation_sampler(
         channels,
@@ -260,6 +277,7 @@ def __gather_sampler(channels: typing.Tuple[bpy.types.FCurve],
         bake_range_end,
         action_name,
         driver_obj,
+        bone_channel_is_animated,
         export_settings
     )
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -317,7 +317,7 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
     # We can ignore this keyframes
     # if there are some fcurve, we can keep only 2 keyframes, first and last
     if blender_object_if_armature is not None:
-        std = np.std(np.std([[k.value[i] for i in range(len(keyframes[0].value))] for k in keyframes], axis=0))
+        std = np.ptp(np.ptp([[k.value[i] for i in range(len(keyframes[0].value))] for k in keyframes], axis=0))
 
         if node_channel_is_animated is True: # fcurve on this bone for this property
              # Keep animation, but keep only 2 keyframes if data are not changing

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -22,6 +22,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_get
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_drivers import get_sk_drivers, get_sk_driver_values
 from . import gltf2_blender_export_keys
 from io_scene_gltf2.io.com import gltf2_io_debug
+import numpy as np
 
 
 class Keyframe:
@@ -193,6 +194,7 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
                      bake_range_end,
                      action_name: str,
                      driver_obj,
+                     bone_channel_is_animated: bool,
                      export_settings
                      ) -> typing.List[Keyframe]:
     """Convert the blender action groups' fcurves to keyframes for use in glTF."""
@@ -308,6 +310,20 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
                 complete_key_tangents(key, non_keyed_values)
 
             keyframes.append(key)
+
+    # For armature only
+    # Check if all values are the same
+    # In that case, if there is no real keyframe on this channel for this given bone,
+    # We can ignore this keyframes
+    if blender_object_if_armature is not None:
+        # First check that this particular bone is not animated directly
+        if bone_channel_is_animated is True:
+             # Keep animation, even if no data are changing
+             return keyframes
+
+        std = np.std(np.std([[k.value[i] for i in range(len(keyframes[0].value))] for k in keyframes], axis=0))
+        if std < 0.0001:
+            return None
 
     return keyframes
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -316,14 +316,14 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
     # In that case, if there is no real keyframe on this channel for this given bone,
     # We can ignore this keyframes
     if blender_object_if_armature is not None:
-        # First check that this particular bone is not animated directly
-        if bone_channel_is_animated is True:
-             # Keep animation, even if no data are changing
-             return keyframes
-
         std = np.std(np.std([[k.value[i] for i in range(len(keyframes[0].value))] for k in keyframes], axis=0))
-        if std < 0.0001:
-            return None
+
+        if bone_channel_is_animated is True: # fcurve on this bone for this property
+             # Keep animation, but keep only 2 keyframes if data are not changing
+             return [keyframes[0], keyframes[-1]] if std < 0.0001 and len(keyframes) >= 2 else keyframes
+        else: # bone is not animated (no fcurve)
+            # Not keeping if not changing property
+            return None if std < 0.0001 else keyframes
 
     return keyframes
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -194,7 +194,7 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
                      bake_range_end,
                      action_name: str,
                      driver_obj,
-                     bone_channel_is_animated: bool,
+                     node_channel_is_animated: bool,
                      export_settings
                      ) -> typing.List[Keyframe]:
     """Convert the blender action groups' fcurves to keyframes for use in glTF."""
@@ -315,10 +315,11 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
     # Check if all values are the same
     # In that case, if there is no real keyframe on this channel for this given bone,
     # We can ignore this keyframes
+    # if there are some fcurve, we can keep only 2 keyframes, first and last
     if blender_object_if_armature is not None:
         std = np.std(np.std([[k.value[i] for i in range(len(keyframes[0].value))] for k in keyframes], axis=0))
 
-        if bone_channel_is_animated is True: # fcurve on this bone for this property
+        if node_channel_is_animated is True: # fcurve on this bone for this property
              # Keep animation, but keep only 2 keyframes if data are not changing
              return [keyframes[0], keyframes[-1]] if std < 0.0001 and len(keyframes) >= 2 else keyframes
         else: # bone is not animated (no fcurve)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -39,7 +39,7 @@ def gather_animation_sampler(channels: typing.Tuple[bpy.types.FCurve],
                              bake_range_end,
                              action_name: str,
                              driver_obj,
-                             bone_channel_is_animated: bool,
+                             node_channel_is_animated: bool,
                              export_settings
                              ) -> gltf2_io.AnimationSampler:
 
@@ -63,7 +63,7 @@ def gather_animation_sampler(channels: typing.Tuple[bpy.types.FCurve],
         matrix_parent_inverse = mathutils.Matrix.Identity(4).freeze()
 
     input = __gather_input(channels, blender_object_if_armature, non_keyed_values,
-                         bake_bone, bake_channel, bake_range_start, bake_range_end, action_name, driver_obj, bone_channel_is_animated, export_settings)
+                         bake_bone, bake_channel, bake_range_start, bake_range_end, action_name, driver_obj, node_channel_is_animated, export_settings)
 
     if input is None:
         # After check, no need to animate this node for this channel
@@ -84,7 +84,7 @@ def gather_animation_sampler(channels: typing.Tuple[bpy.types.FCurve],
                                bake_range_end,
                                action_name,
                                driver_obj,
-                               bone_channel_is_animated,
+                               node_channel_is_animated,
                                export_settings)
     )
 
@@ -237,7 +237,7 @@ def __gather_input(channels: typing.Tuple[bpy.types.FCurve],
                    bake_range_end,
                    action_name,
                    driver_obj,
-                   bone_channel_is_animated: bool,
+                   node_channel_is_animated: bool,
                    export_settings
                    ) -> gltf2_io.Accessor:
     """Gather the key time codes."""
@@ -250,7 +250,7 @@ def __gather_input(channels: typing.Tuple[bpy.types.FCurve],
                                                                                   bake_range_end,
                                                                                   action_name,
                                                                                   driver_obj,
-                                                                                  bone_channel_is_animated,
+                                                                                  node_channel_is_animated,
                                                                                   export_settings)
     if keyframes is None:
         # After check, no need to animation this node
@@ -319,7 +319,7 @@ def __gather_output(channels: typing.Tuple[bpy.types.FCurve],
                     bake_range_end,
                     action_name,
                     driver_obj,
-                    bone_channel_is_animated: bool,
+                    node_channel_is_animated: bool,
                     export_settings
                     ) -> gltf2_io.Accessor:
     """Gather the data of the keyframes."""
@@ -332,7 +332,7 @@ def __gather_output(channels: typing.Tuple[bpy.types.FCurve],
                                                                                   bake_range_end,
                                                                                   action_name,
                                                                                   driver_obj,
-                                                                                  bone_channel_is_animated,
+                                                                                  node_channel_is_animated,
                                                                                   export_settings)
     if bake_bone is not None:
         target_datapath = "pose.bones['" + bake_bone + "']." + bake_channel


### PR DESCRIPTION
Check is done after sampler
If channel is not directly animated and data are not animated, do not 
create animation for this node property