### PR TITLE
feat: more import user extension hooks

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_light.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_light.py
@@ -16,6 +16,7 @@ import bpy
 from math import pi
 
 from ..com.gltf2_blender_extras import set_extras
+from io_scene_gltf2.io.imp.gltf2_io_user_extensions import import_user_extensions
 
 
 class BlenderLight():
@@ -27,6 +28,9 @@ class BlenderLight():
     def create(gltf, light_id):
         """Light creation."""
         pylight = gltf.data.extensions['KHR_lights_punctual']['lights'][light_id]
+
+        import_user_extensions('gather_import_light_before_hook', gltf, pylight, light_id)
+
         if pylight['type'] == "directional":
             light = BlenderLight.create_directional(gltf, light_id)
         elif pylight['type'] == "point":
@@ -43,6 +47,8 @@ class BlenderLight():
         # TODO range
 
         set_extras(light, pylight.get('extras'))
+
+        import_user_extensions('gather_import_light_after_hook', gltf, pylight, light_id, light)
 
         return light
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_material.py
@@ -18,6 +18,7 @@ from ..com.gltf2_blender_extras import set_extras
 from .gltf2_blender_pbrMetallicRoughness import MaterialHelper, pbr_metallic_roughness
 from .gltf2_blender_KHR_materials_pbrSpecularGlossiness import pbr_specular_glossiness
 from .gltf2_blender_KHR_materials_unlit import unlit
+from io_scene_gltf2.io.imp.gltf2_io_user_extensions import import_user_extensions
 
 
 class BlenderMaterial():
@@ -29,6 +30,8 @@ class BlenderMaterial():
     def create(gltf, material_idx, vertex_color):
         """Material creation."""
         pymaterial = gltf.data.materials[material_idx]
+
+        import_user_extensions('gather_import_material_before_hook', gltf, pymaterial, material_idx, vertex_color)
 
         name = pymaterial.name
         if name is None:
@@ -55,6 +58,8 @@ class BlenderMaterial():
             pbr_specular_glossiness(mh)
         else:
             pbr_metallic_roughness(mh)
+
+        import_user_extensions('gather_import_material_after_hook', gltf, pymaterial, material_idx, vertex_color, mat)
 
     @staticmethod
     def set_double_sided(pymaterial, mat):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -21,6 +21,7 @@ from ..com.gltf2_blender_extras import set_extras
 from .gltf2_blender_material import BlenderMaterial
 from ...io.com.gltf2_io_debug import print_console
 from .gltf2_io_draco_compression_extension import decode_primitive
+from io_scene_gltf2.io.imp.gltf2_io_user_extensions import import_user_extensions
 
 
 class BlenderMesh():
@@ -41,6 +42,9 @@ COLOR_MAX = 8
 
 def create_mesh(gltf, mesh_idx, skin_idx):
     pymesh = gltf.data.meshes[mesh_idx]
+
+    import_user_extensions('gather_import_mesh_before_hook', gltf, pymesh, mesh_idx, skin_idx)
+
     name = pymesh.name or 'Mesh_%d' % mesh_idx
     mesh = bpy.data.meshes.new(name)
 
@@ -55,6 +59,8 @@ def create_mesh(gltf, mesh_idx, skin_idx):
     finally:
         if tmp_ob:
             bpy.data.objects.remove(tmp_ob)
+
+    import_user_extensions('gather_import_mesh_before_hook', gltf, pymesh, mesh_idx, skin_idx, mesh)
 
     return mesh
 

--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -427,7 +427,7 @@ Third-party glTF Extensions
 
 It is possible for Python developers to add Blender support for additional glTF extensions by writing their
 own third-party add-on, without modifying this glTF add-on. For more information, `see the example on GitHub
-<https://github.com/KhronosGroup/glTF-Blender-IO/tree/master/example-addons/example_gltf_exporter_extension>`__ and if needed,
+<https://github.com/KhronosGroup/glTF-Blender-IO/tree/master/example-addons>`__ and if needed,
 `register an extension prefix <https://github.com/KhronosGroup/glTF/blob/master/extensions/Prefixes.md>`__.
 
 

--- a/example-addons/example_gltf_importer_extension/__init__.py
+++ b/example-addons/example_gltf_importer_extension/__init__.py
@@ -41,6 +41,3 @@ def register():
 def unregister():
     bpy.utils.unregister_class(ExampleImporterExtensionProperties)
     del bpy.types.Scene.ExampleImporterExtensionProperties
-
-
-# TODO: SET EXTENSIONS REQUIRED

--- a/example-addons/example_gltf_importer_extension/__init__.py
+++ b/example-addons/example_gltf_importer_extension/__init__.py
@@ -41,3 +41,6 @@ def register():
 def unregister():
     bpy.utils.unregister_class(ExampleImporterExtensionProperties)
     del bpy.types.Scene.ExampleImporterExtensionProperties
+
+
+# TODO: SET EXTENSIONS REQUIRED

--- a/example-addons/example_gltf_importer_extension/readme.md
+++ b/example-addons/example_gltf_importer_extension/readme.md
@@ -18,4 +18,8 @@ gather_import_scene_after_nodes_hook(self, gltf_scene, blender_scene)
 gather_import_scene_after_animation_hook(self, gltf_scene, blender_scene)
 gather_import_material_before_hook(self, gltf, pymaterial, material_idx, vertex_color)
 gather_import_material_after_hook(self, gltf, pymaterial, material_idx, vertex_color, blender_mat)
+gather_import_light_before_hook(self, gltf, pylight, light_id)
+gather_import_light_after_hook(self, gltf, pylight, light_id, blender_light)
+gather_import_mesh_before_hook(self, gltf, pymesh, mesh_idx, skin_idx)
+gather_import_mesh_after_hook(self, gltf, pymesh, mesh_idx, skin_idx, blender_mesh)
 ```

--- a/example-addons/example_gltf_importer_extension/readme.md
+++ b/example-addons/example_gltf_importer_extension/readme.md
@@ -16,4 +16,6 @@ gather_import_node_after_hook(self, vnode, gltf_node, blender_object)
 gather_import_scene_before_hook(self, gltf_scene, blender_scene)
 gather_import_scene_after_nodes_hook(self, gltf_scene, blender_scene)
 gather_import_scene_after_animation_hook(self, gltf_scene, blender_scene)
+gather_import_material_before_hook(self, gltf, pymaterial, material_idx, vertex_color)
+gather_import_material_after_hook(self, gltf, pymaterial, material_idx, vertex_color, blender_mat)
 ```


### PR DESCRIPTION
This is a draft PR.

Added hooks:
- `gather_import_material_before_hook(self, gltf, pymaterial, material_idx, vertex_color)`
- `gather_import_material_after_hook(self, gltf, pymaterial, material_idx, vertex_color, blender_mat)`
- `gather_import_light_before_hook(self, gltf, pylight, light_id)`
- `gather_import_light_after_hook(self, gltf, pylight, light_id, blender_light)`
- `gather_import_mesh_before_hook(self, gltf, pymesh, mesh_idx, skin_idx)`
- `gather_import_mesh_after_hook(self, gltf, pymesh, mesh_idx, skin_idx, blender_mesh)`

Things left to do:

- [ ] Other hooks (undecided currently)
- [ ] Register `extensionsRequired`
- [ ] Cleanup code
- [ ] Expand example code