### PR TITLE
Fix invalid index mesh name

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -187,7 +187,7 @@ class BlenderNode():
         if not (0 <= pynode.mesh < len(gltf.data.meshes)):
             # Avoid traceback for invalid gltf file: invalid reference to meshes array
             # So return an empty blender object)
-            return bpy.data.objects.new(vnode.name or mesh.name, None)
+            return bpy.data.objects.new(vnode.name or "Invalid Mesh Index", None)
         pymesh = gltf.data.meshes[pynode.mesh]
 
         # Key to cache the Blender mesh by.


### PR DESCRIPTION
Should not happen with valid files, but for invalid files without any "name" property, set an arbitrary name