### PR TITLE
feat: export node groups

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -82,8 +82,9 @@ def get_socket(blender_material: bpy.types.Material, name: str):
             for node in blender_material.node_tree.nodes:
                 if hasattr(node, "node_tree"):
                     if inputs[0].node in list(node.node_tree.nodes):
-                        if inputs[0].name in dict(node.inputs):
-                            return node.inputs[inputs[0].name]
+                        if inputs[0].links:
+                            if inputs[0].links[0].from_socket.name in dict(node.inputs):
+                                return node.inputs[inputs[0].links[0].from_socket.name]
 
             return inputs[0]
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -78,6 +78,13 @@ def get_socket(blender_material: bpy.types.Material, name: str):
         nodes = [node for node in nodes if check_if_is_linked_to_active_output(node.outputs[0], blender_material)]
         inputs = sum([[input for input in node.inputs if input.name == name] for node in nodes], [])
         if inputs:
+            # Check node group inputs
+            for node in blender_material.node_tree.nodes:
+                if hasattr(node, "node_tree"):
+                    if inputs[0].node in list(node.node_tree.nodes):
+                        if inputs[0].name in dict(node.inputs):
+                            return node.inputs[inputs[0].name]
+
             return inputs[0]
 
     return None

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -93,7 +93,7 @@ def get_socket_old(blender_material: bpy.types.Material, name: str):
     """
     gltf_node_group_name = get_gltf_node_name().lower()
     if blender_material.node_tree and blender_material.use_nodes:
-        nodes = [n for n in get_blender_material_nodes(blender_material.node_tree) if \
+        nodes = [n for n in blender_material.node_tree.nodes if \
             isinstance(n, bpy.types.ShaderNodeGroup) and \
             (n.node_tree.name.startswith('glTF Metallic Roughness') or n.node_tree.name.lower() == gltf_node_group_name)]
         inputs = sum([[input for input in node.inputs if input.name == name] for node in nodes], [])


### PR DESCRIPTION
Fixes #1141

This PR adds the ability for the exporter to search inside custom shader node groups. This is very useful for those who chose to use custom node groups