### PR TITLE
Option to not export textures

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -15,7 +15,7 @@
 bl_info = {
     'name': 'glTF 2.0 format',
     'author': 'Julien Duroure, Scurest, Norbert Nopper, Urs Hanselmann, Moritz Becher, Benjamin Schmithüsen, Jim Eckerlein, and many external contributors',
-    "version": (1, 8, 12),
+    "version": (1, 8, 13),
     'blender': (3, 1, 0),
     'location': 'File > Import-Export',
     'description': 'Import-Export as glTF 2.0',

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -114,7 +114,10 @@ def __gather_emissive_factor(blender_material, export_settings):
     if emissive_socket is None:
         emissive_socket = gltf2_blender_get.get_socket_old(blender_material, "EmissiveFactor")
     if isinstance(emissive_socket, bpy.types.NodeSocket):
-        factor = gltf2_blender_get.get_factor_from_socket(emissive_socket, kind='RGB')
+        if export_settings['gltf_image_format'] != "NONE":
+            factor = gltf2_blender_get.get_factor_from_socket(emissive_socket, kind='RGB')
+        else:
+            factor = gltf2_blender_get.get_const_from_default_value_socket(emissive_socket, kind='RGB')
 
         if factor is None and emissive_socket.is_linked:
             # In glTF, the default emissiveFactor is all zeros, so if an emission texture is connected,

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
@@ -53,7 +53,10 @@ def __gather_base_color_factor(blender_material, export_settings):
 
     alpha_socket = gltf2_blender_get.get_socket(blender_material, "Alpha")
     if isinstance(alpha_socket, bpy.types.NodeSocket):
-        alpha = gltf2_blender_get.get_factor_from_socket(alpha_socket, kind='VALUE')
+        if export_settings['gltf_image_format'] != "NONE": 
+            alpha = gltf2_blender_get.get_factor_from_socket(alpha_socket, kind='VALUE')
+        else:
+            alpha = gltf2_blender_get.get_const_from_default_value_socket(alpha_socket, kind='VALUE')
 
     base_color_socket = gltf2_blender_get.get_socket(blender_material, "Base Color")
     if base_color_socket is None:
@@ -61,7 +64,10 @@ def __gather_base_color_factor(blender_material, export_settings):
     if base_color_socket is None:
         base_color_socket = gltf2_blender_get.get_socket_old(blender_material, "BaseColorFactor")
     if isinstance(base_color_socket, bpy.types.NodeSocket):
-        rgb = gltf2_blender_get.get_factor_from_socket(base_color_socket, kind='RGB')
+        if export_settings['gltf_image_format'] != "NONE":
+            rgb = gltf2_blender_get.get_factor_from_socket(base_color_socket, kind='RGB')
+        else:
+            rgb = gltf2_blender_get.get_const_from_default_value_socket(base_color_socket, kind='RGB')
 
     if rgb is None: rgb = [1.0, 1.0, 1.0]
     if alpha is None: alpha = 1.0

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture.py
@@ -57,7 +57,7 @@ def gather_texture(
 
 
 def __filter_texture(blender_shader_sockets, export_settings):
-    # Use doesn't want to export textures
+    # User doesn't want to export textures
     if export_settings['gltf_image_format'] == "NONE":
         return None
     return True

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture.py
@@ -35,8 +35,6 @@ def gather_texture(
     :param export_settings: configuration of the export
     :return: a glTF 2.0 texture with sampler and source embedded (will be converted to references by the exporter)
     """
-    if export_settings['gltf_image_format'] == "NONE":
-        return None
 
     if not __filter_texture(blender_shader_sockets, export_settings):
         return None
@@ -59,6 +57,9 @@ def gather_texture(
 
 
 def __filter_texture(blender_shader_sockets, export_settings):
+    # Use doesn't want to export textures
+    if export_settings['gltf_image_format'] == "NONE":
+        return None
     return True
 
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_get.py
@@ -250,6 +250,15 @@ def get_factor_from_socket(socket, kind):
 
     return None
 
+def get_const_from_default_value_socket(socket, kind):
+    if kind == 'RGB':
+        if socket.type != 'RGBA': return None
+        return list(socket.default_value)[:3]
+    if kind == 'VALUE':
+        if socket.type != 'VALUE': return None
+        return socket.default_value
+    return None
+
 
 def get_const_from_socket(socket, kind):
     if not socket.is_linked:


### PR DESCRIPTION
Add some enhancement to jtnicholl PR

- moving check to filter
- add default socket values if texture is not exported