### PR TITLE
animation export settings toggle to force export all animation tracks without optimization

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -388,6 +388,15 @@ class ExportGLTF2_Base:
         default=False
     )
 
+    export_all_tracks: BoolProperty(
+        name='Export all tracks',
+        description=(
+            "Export all animation tracks without optimization for filesize."
+            "Can help with one frame long and static animations"
+        ),
+        default=False
+    )
+
     export_current_frame: BoolProperty(
         name='Use Current Frame',
         description='Export the scene in the current animation frame',
@@ -580,11 +589,13 @@ class ExportGLTF2_Base:
             else:
                 export_settings['gltf_def_bones'] = False
             export_settings['gltf_nla_strips'] = self.export_nla_strips
+            export_settings['gltf_all_tracks'] = self.export_all_tracks
         else:
             export_settings['gltf_frame_range'] = False
             export_settings['gltf_move_keyframes'] = False
             export_settings['gltf_force_sampling'] = False
             export_settings['gltf_def_bones'] = False
+            export_settings['gltf_all_tracks'] = False
         export_settings['gltf_skins'] = self.export_skins
         if self.export_skins:
             export_settings['gltf_all_vertex_influences'] = self.export_all_influences
@@ -872,6 +883,7 @@ class GLTF_PT_export_animation_export(bpy.types.Panel):
         layout.prop(operator, 'export_frame_step')
         layout.prop(operator, 'export_force_sampling')
         layout.prop(operator, 'export_nla_strips')
+        layout.prop(operator, 'export_all_tracks')
 
         row = layout.row()
         row.active = operator.export_force_sampling

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_export_keys.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_export_keys.py
@@ -57,6 +57,7 @@ EMBED_IMAGES = 'gltf_embed_images'
 BINARY = 'gltf_binary'
 EMBED_BUFFERS = 'gltf_embed_buffers'
 USE_NO_COLOR = 'gltf_use_no_color'
+ALL_TRACKS = 'gltf_all_tracks'
 
 METALLIC_ROUGHNESS_IMAGE = "metallic_roughness_image"
 GROUP_INDEX = 'group_index'

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -317,6 +317,9 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
 
             keyframes.append(key)
 
+    if export_settings[gltf2_blender_export_keys.ALL_TRACKS]:
+        return keyframes
+
     # For armature only
     # Check if all values are the same
     # In that case, if there is no real keyframe on this channel for this given bone,


### PR DESCRIPTION
https://github.com/KhronosGroup/glTF-Blender-IO/issues/1559
tested it with blender 3.0 where it works