### PR TITLE
fix: support for generated images that change dimensions

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_image.py
@@ -245,6 +245,7 @@ def _make_temp_image_copy(guard: TmpImageGuard, src_image: bpy.types.Image):
     tmp_image = guard.image
 
     tmp_image.update()
+    tmp_image.scale(*src_image.size)
 
     if src_image.is_dirty:
         # Unsaved changes aren't copied by .copy(), so do them ourselves


### PR DESCRIPTION
This small change adds support to export  glTF 2.0 (.glb/gltf) when using generated images that can change their default dimensions. A more detailed description of the issue this solves can be found at: https://github.com/KhronosGroup/glTF-Blender-IO/issues/1564
