### PR TITLE
Fix #1465 - add UI for glTF settings node creation

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -1168,6 +1168,24 @@ class ImportGLTF2(Operator, ImportHelper):
             self.loglevel = logging.NOTSET
 
 
+def update_gltf_settings_node_ui(self, context):
+    import io_scene_gltf2.blender.com.gltf2_blender_ui as blender_ui
+    if bpy.context.preferences.addons['io_scene_gltf2'].preferences.settings_node_ui is True:
+        bpy.utils.register_class(blender_ui.NODE_PT_GLTF_PANEL)
+    else:
+        blender_ui.unregister()
+
+class GLTF_AddonPreferences(bpy.types.AddonPreferences):
+    bl_idname = __package__
+
+    settings_node_ui : bpy.props.BoolProperty(default= False, update=update_gltf_settings_node_ui)
+
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.prop(self, "settings_node_ui", text="Settings node interface")
+
 def menu_func_import(self, context):
     self.layout.operator(ImportGLTF2.bl_idname, text='glTF 2.0 (.glb/.gltf)')
 
@@ -1185,14 +1203,18 @@ classes = (
     GLTF_PT_export_animation_skinning,
     GLTF_PT_export_user_extensions,
     ImportGLTF2,
-    GLTF_PT_import_user_extensions
+    GLTF_PT_import_user_extensions,
+    GLTF_AddonPreferences
 )
 
 
 def register():
+    import io_scene_gltf2.blender.com.gltf2_blender_ui as blender_ui
     for c in classes:
         bpy.utils.register_class(c)
     # bpy.utils.register_module(__name__)
+
+    blender_ui.register()
 
     # add to the export / import menu
     bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
@@ -1200,6 +1222,7 @@ def register():
 
 
 def unregister():
+    import io_scene_gltf2.blender.com.gltf2_blender_ui as blender_ui
     for c in classes:
         bpy.utils.unregister_class(c)
     for f in exporter_extension_panel_unregister_functors:
@@ -1209,6 +1232,8 @@ def unregister():
     for f in importer_extension_panel_unregister_functors:
         f()
     importer_extension_panel_unregister_functors.clear()
+
+    blender_ui.unregister()
 
     # bpy.utils.unregister_module(__name__)
 

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -1173,14 +1173,14 @@ class GLTF_AddonPreferences(bpy.types.AddonPreferences):
 
     settings_node_ui : bpy.props.BoolProperty(
             default= False, 
-            description="Displays glTF 2.0 node in Shader Editor (Menu Add > Ouput)"
+            description="Displays glTF Settings node in Shader Editor (Menu Add > Ouput)"
             )
 
 
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        row.prop(self, "settings_node_ui", text="Shader Editor")
+        row.prop(self, "settings_node_ui", text="Shader Editor Add-ons")
 
 def menu_func_import(self, context):
     self.layout.operator(ImportGLTF2.bl_idname, text='glTF 2.0 (.glb/.gltf)')

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -1168,23 +1168,19 @@ class ImportGLTF2(Operator, ImportHelper):
             self.loglevel = logging.NOTSET
 
 
-def update_gltf_settings_node_ui(self, context):
-    import io_scene_gltf2.blender.com.gltf2_blender_ui as blender_ui
-    if bpy.context.preferences.addons['io_scene_gltf2'].preferences.settings_node_ui is True:
-        bpy.utils.register_class(blender_ui.NODE_PT_GLTF_PANEL)
-    else:
-        blender_ui.unregister()
-
 class GLTF_AddonPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
 
-    settings_node_ui : bpy.props.BoolProperty(default= False, update=update_gltf_settings_node_ui)
+    settings_node_ui : bpy.props.BoolProperty(
+            default= False, 
+            description="Displays glTF 2.0 node in Shader Editor (Menu Add > Ouput)"
+            )
 
 
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        row.prop(self, "settings_node_ui", text="Settings node interface")
+        row.prop(self, "settings_node_ui", text="Shader Editor")
 
 def menu_func_import(self, context):
     self.layout.operator(ImportGLTF2.bl_idname, text='glTF 2.0 (.glb/.gltf)')

--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_material_helpers.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_material_helpers.py
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import bpy
 
 def get_gltf_node_name():
     return "glTF Settings"
+
+def create_settings_group(name):
+    gltf_node_group = bpy.data.node_groups.new(name, 'ShaderNodeTree')
+    gltf_node_group.inputs.new("NodeSocketFloat", "Occlusion")
+    gltf_node_group.nodes.new('NodeGroupOutput')
+    gltf_node_group_input = gltf_node_group.nodes.new('NodeGroupInput')
+    gltf_node_group_input.location = -200, 0
+    return gltf_node_group

--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_ui.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_ui.py
@@ -36,7 +36,7 @@ class NODE_PT_GLTF_PANEL(bpy.types.Panel):
 
 class NODE_OT_GLTF_AO(bpy.types.Operator):
     bl_idname = "node.gltf_settings_node_operator"
-    bl_label  = "Add glTF 2.0 AO node"
+    bl_label  = "Add Settings glTF node"
 
 
     @classmethod

--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_ui.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_ui.py
@@ -1,0 +1,66 @@
+# Copyright 2018-2022 The glTF-Blender-IO authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import bpy
+from ..com.gltf2_blender_material_helpers import get_gltf_node_name, create_settings_group
+
+def create_gltf_ao_group(operator, group_name):
+
+    # create a new group
+    gltf_ao_group = bpy.data.node_groups.new(group_name, "ShaderNodeTree")
+    
+    return gltf_ao_group
+
+class NODE_PT_GLTF_PANEL(bpy.types.Panel):
+    bl_label = "glTF 2.0"
+    bl_idname = "NODE_PT_GLTF_PANEL"
+    bl_space_type = "NODE_EDITOR"
+    bl_region_type = "UI"
+    bl_category = "glTF 2.0"
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.operator("node.gltf_settings_node_operator")
+
+class NODE_OT_GLTF_AO(bpy.types.Operator):
+    bl_idname = "node.gltf_settings_node_operator"
+    bl_label  = "Add glTF 2.0 AO node"
+
+
+    @classmethod
+    def poll(cls, context):
+        space = context.space_data
+        return space.type == "NODE_EDITOR" \
+            and context.object and context.object.active_material \
+            and context.object.active_material.use_nodes is True
+
+    def execute(self, context):
+        gltf_settings_node_name = get_gltf_node_name()
+        if gltf_settings_node_name in bpy.data.node_groups:
+            my_group = bpy.data.node_groups[get_gltf_node_name()]
+        else:
+            my_group = create_settings_group(gltf_settings_node_name)
+        node_tree = context.object.active_material.node_tree
+        new_node = node_tree.nodes.new("ShaderNodeGroup")
+        new_node.node_tree = bpy.data.node_groups[my_group.name]
+        return {"FINISHED"}
+
+def register():
+    bpy.utils.register_class(NODE_OT_GLTF_AO)
+    if bpy.context.preferences.addons['io_scene_gltf2'].preferences.settings_node_ui is True:
+        bpy.utils.register_class(NODE_PT_GLTF_PANEL)
+
+def unregister():
+    bpy.utils.unregister_class(NODE_PT_GLTF_PANEL)

--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_ui.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_ui.py
@@ -22,21 +22,9 @@ def create_gltf_ao_group(operator, group_name):
     
     return gltf_ao_group
 
-class NODE_PT_GLTF_PANEL(bpy.types.Panel):
-    bl_label = "glTF 2.0"
-    bl_idname = "NODE_PT_GLTF_PANEL"
-    bl_space_type = "NODE_EDITOR"
-    bl_region_type = "UI"
-    bl_category = "glTF 2.0"
-
-    def draw(self, context):
-        layout = self.layout
-        row = layout.row()
-        row.operator("node.gltf_settings_node_operator")
-
-class NODE_OT_GLTF_AO(bpy.types.Operator):
+class NODE_OT_GLTF_SETTINGS(bpy.types.Operator):
     bl_idname = "node.gltf_settings_node_operator"
-    bl_label  = "Add Settings glTF node"
+    bl_label  = "glTF Settings"
 
 
     @classmethod
@@ -44,7 +32,8 @@ class NODE_OT_GLTF_AO(bpy.types.Operator):
         space = context.space_data
         return space.type == "NODE_EDITOR" \
             and context.object and context.object.active_material \
-            and context.object.active_material.use_nodes is True
+            and context.object.active_material.use_nodes is True \
+            and bpy.context.preferences.addons['io_scene_gltf2'].preferences.settings_node_ui is True
 
     def execute(self, context):
         gltf_settings_node_name = get_gltf_node_name()
@@ -57,10 +46,15 @@ class NODE_OT_GLTF_AO(bpy.types.Operator):
         new_node.node_tree = bpy.data.node_groups[my_group.name]
         return {"FINISHED"}
 
-def register():
-    bpy.utils.register_class(NODE_OT_GLTF_AO)
+
+def add_gltf_settings_to_menu(self, context) :
     if bpy.context.preferences.addons['io_scene_gltf2'].preferences.settings_node_ui is True:
-        bpy.utils.register_class(NODE_PT_GLTF_PANEL)
+        self.layout.operator("node.gltf_settings_node_operator")
+
+
+def register():
+    bpy.utils.register_class(NODE_OT_GLTF_SETTINGS)
+    bpy.types.NODE_MT_category_SH_NEW_OUTPUT.append(add_gltf_settings_to_menu)
 
 def unregister():
-    bpy.utils.unregister_class(NODE_PT_GLTF_PANEL)
+    bpy.utils.unregister_class(NODE_OT_GLTF_SETTINGS)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -14,7 +14,7 @@
 
 import bpy
 from ...io.com.gltf2_io import TextureInfo, MaterialPBRMetallicRoughness
-from ..com.gltf2_blender_material_helpers import get_gltf_node_name
+from ..com.gltf2_blender_material_helpers import get_gltf_node_name, create_settings_group
 from .gltf2_blender_texture import texture
 from .gltf2_blender_KHR_materials_clearcoat import \
     clearcoat, clearcoat_roughness, clearcoat_normal
@@ -563,16 +563,12 @@ def make_settings_node(mh):
     node.node_tree = get_settings_group()
     return node
 
-
 def get_settings_group():
     gltf_node_group_name = get_gltf_node_name()
     if gltf_node_group_name in bpy.data.node_groups:
         gltf_node_group = bpy.data.node_groups[gltf_node_group_name]
     else:
         # Create a new node group
-        gltf_node_group = bpy.data.node_groups.new(gltf_node_group_name, 'ShaderNodeTree')
-        gltf_node_group.inputs.new("NodeSocketFloat", "Occlusion")
-        gltf_node_group.nodes.new('NodeGroupOutput')
-        gltf_node_group_input = gltf_node_group.nodes.new('NodeGroupInput')
-        gltf_node_group_input.location = -200, 0
+        gltf_node_group = create_settings_group(gltf_node_group_name)
+        
     return gltf_node_group


### PR DESCRIPTION
Option need to be actived in addon preferences, avoiding adding UI for people that don't want to use glTF export