### PR TITLE
Fix #1578 - add filter hook

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
@@ -16,6 +16,7 @@ import bpy
 import uuid
 
 from . import gltf2_blender_export_keys
+from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 from mathutils import Quaternion, Matrix
 
 class VExportNode:
@@ -266,6 +267,7 @@ class VExportTree:
 
     def filter(self):
         self.filter_tag()
+        export_user_extensions('gather_tree_filter_tag_hook', self.export_settings, self)
         self.filter_perform()
 
 

--- a/example-addons/example_gltf_exporter_extension/readme.md
+++ b/example-addons/example_gltf_exporter_extension/readme.md
@@ -39,4 +39,5 @@ pre_gather_animation_hook(self, gltf2_animation, blender_action, blender_object,
 gather_actions_hook(self, blender_object, blender_actions, blender_tracks, action_on_type, export_settings)
 pre_gather_actions_hook(self, blender_object, export_settings)
 gather_gltf_hook(self, active_scene_idx, scenes, animations, export_settings)
+gather_tree_filter_tag_hook(self, tree, export_settings)
 ```


### PR DESCRIPTION
Fix #1578 

You can change keep_tag values after the exporter set it, to change data that are exporter.
To be manipulate carefully, this can break everything (you should take care of parenting for example)