### PR TITLE
feat: add setting to restore first animation at import

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -1062,6 +1062,12 @@ class ImportGLTF2(Operator, ImportHelper):
         default=True,
     )
 
+    restore_first_animation: BoolProperty(
+        name='Restore First Animation',
+        description="Restore the actions on the first animation in the glTF",
+        default=True,
+    )
+
     def draw(self, context):
         layout = self.layout
 
@@ -1073,6 +1079,7 @@ class ImportGLTF2(Operator, ImportHelper):
         layout.prop(self, 'import_shading')
         layout.prop(self, 'guess_original_bind_pose')
         layout.prop(self, 'bone_heuristic')
+        layout.prop(self, 'restore_first_animation')
 
     def invoke(self, context, event):
         import sys

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_scene.py
@@ -69,8 +69,9 @@ class BlenderScene():
                 BlenderAnimation.anim(gltf, anim_idx)
 
             # Restore first animation
-            anim_name = gltf.data.animations[0].track_name
-            BlenderAnimation.restore_animation(gltf, anim_name)
+            if gltf.import_settings['restore_first_animation']:
+                anim_name = gltf.data.animations[0].track_name
+                BlenderAnimation.restore_animation(gltf, anim_name)
 
     @staticmethod
     def select_imported_objects(gltf):


### PR DESCRIPTION
This adds an option to the import settings to enable or disable restoring the first animation in the glTF file. In my use case, I do not want the first animation to be restored. I don't quite know the purpose of this, so if it is needed, feel free to close this PR.