### PR TITLE
fix: improve objectcache logic

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -143,7 +143,8 @@ def get_object_matrix(blender_obj_uuid: str,
                       bake_range_end: int,
                       current_frame: int,
                       step: int,
-                      export_settings
+                      export_settings,
+                      only_gather_provided=False
                     ):
 
     data = {}
@@ -155,11 +156,16 @@ def get_object_matrix(blender_obj_uuid: str,
     start_frame = min([v[0] for v in [a.frame_range for a in bpy.data.actions]])
     end_frame = max([v[1] for v in [a.frame_range for a in bpy.data.actions]])
 
+    if only_gather_provided:
+        obj_uuids = [blender_obj_uuid]
+    else:
+        obj_uuids = [uid for (uid, n) in export_settings['vtree'].nodes.items() if n.blender_type not in [VExportNode.BONE]]
+
     frame = start_frame
     while frame <= end_frame:
         bpy.context.scene.frame_set(int(frame))
 
-        for obj_uuid in [uid for (uid, n) in export_settings['vtree'].nodes.items() if n.blender_type not in [VExportNode.BONE]]:
+        for obj_uuid in obj_uuids:
             blender_obj = export_settings['vtree'].nodes[obj_uuid].blender_object
 
             # if this object is not animated, do not skip :

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cache.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cache.py
@@ -98,13 +98,13 @@ def objectcache(func):
 
         # object is not cached yet
         if cache_key_args[0] not in func.__objectcache.keys():
-            result = func(*args)
+            result = func(*args, only_gather_provided=True)
             func.__objectcache = result
             return result[cache_key_args[0]][cache_key_args[1]][cache_key_args[4]]
         # object is in cache, but not this action
         # We need to keep other actions
         elif cache_key_args[1] not in func.__objectcache[cache_key_args[0]].keys():
-            result = func(*args)
+            result = func(*args, only_gather_provided=True)
             func.__objectcache[cache_key_args[0]][cache_key_args[1]] = result[cache_key_args[0]][cache_key_args[1]]
             return result[cache_key_args[0]][cache_key_args[1]][cache_key_args[4]]
         # all is already cached


### PR DESCRIPTION
This PR changes how the `objectcache` logic works. I was running into very slow performance on a scene that had ~1500 nodes each with unique animations. The issue was every time `get_object_matrix` was called, it would get the matrix for every object in the VTree, even though it is completely unnecesary. In the `objectcache`, there was also a case where it would again get the matrix for every object just to only use the info from one entry. 

Previous export time with scene that had 1500 nodes w/ animations: 72 minutes
New export time: 5 minutes