### PR TITLE
🐛 resolve uvmap index using the correct mesh

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -165,12 +165,15 @@ def __gather_texture_transform_and_tex_coord(primary_socket, export_settings):
     use_active_uvmap = True
     if node and node.type == 'UVMAP' and node.uv_map:
         # Try to gather map index.
-        for blender_mesh in bpy.data.meshes:
-            i = blender_mesh.uv_layers.find(node.uv_map)
-            if i >= 0:
-                texcoord_idx = i
-                use_active_uvmap = False
-                break
+        node_tree = node.id_data
+        for mesh in bpy.data.meshes:
+            for material in mesh.materials:
+                if material.node_tree == node_tree:
+                    i = mesh.uv_layers.find(node.uv_map)
+                    if i >= 0:
+                        texcoord_idx = i
+                        use_active_uvmap = False
+                        break
 
     return texture_transform, texcoord_idx or None, use_active_uvmap
 


### PR DESCRIPTION
previously it was just trying to find the uvmap name globally via its name in ANY mesh.

This could result in broken glTF files. For example if there was a mesh having 2 UVMaps named "First UVMap" and "UVMap" and there is a second mesh with just one UVMap "UVMap" then the resulting glTF file would export the textures of the second mesh with a texCoord 1 (which is not present and not exported in this mesh) because the logic was just searching globally.

I am not sure if this is the correct way to fix this but this works for me. I am especially unsure about the id_data thing and if that is really a stable way to do it.