### PR TITLE
Export: Allow custom name for merged animation

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -376,6 +376,14 @@ class ExportGLTF2_Base:
         ),
         default=True
     )
+    
+    export_nla_strips_merged_animation_name: StringProperty(
+        name='Merged Animation Name',
+        description=(
+            "Name of single glTF animation to be exported"
+        ),
+        default='Animation'
+    )    
 
     export_def_bones: BoolProperty(
         name='Export Deformation Bones Only',
@@ -571,6 +579,7 @@ class ExportGLTF2_Base:
             else:
                 export_settings['gltf_def_bones'] = False
             export_settings['gltf_nla_strips'] = self.export_nla_strips
+            export_settings['gltf_nla_strips_merged_animation_name'] = self.export_nla_strips_merged_animation_name
             export_settings['gltf_optimize_animation'] = self.optimize_animation_size
         else:
             export_settings['gltf_frame_range'] = False
@@ -865,6 +874,8 @@ class GLTF_PT_export_animation_export(bpy.types.Panel):
         layout.prop(operator, 'export_frame_step')
         layout.prop(operator, 'export_force_sampling')
         layout.prop(operator, 'export_nla_strips')
+        if operator.export_nla_strips is False:
+            layout.prop(operator, 'export_nla_strips_merged_animation_name')
         layout.prop(operator, 'optimize_animation_size')
 
         row = layout.row()

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather.py
@@ -104,9 +104,12 @@ def __gather_animations(blender_scene, export_settings):
     if export_settings['gltf_nla_strips'] is False:
         # Fake an animation with all animations of the scene
         merged_tracks = {}
-        merged_tracks['Animation'] = []
+        merged_tracks_name = 'Animation'
+        if(len(export_settings['gltf_nla_strips_merged_animation_name']) > 0):
+            merged_tracks_name = export_settings['gltf_nla_strips_merged_animation_name']
+        merged_tracks[merged_tracks_name] = []
         for idx, animation in enumerate(animations):
-            merged_tracks['Animation'].append(idx)
+            merged_tracks[merged_tracks_name].append(idx)
 
 
     to_delete_idx = []


### PR DESCRIPTION
Currently merged NLA strip animations are exported with the hardcoded name of "Animation". This would allow the user to select a custom animation name instead.