### PR TITLE
feat: export facemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Documentation
 | dev     | https://docs.blender.org/manual/en/dev/addons/import_export/scene_gltf2.html  |
 
 Notes:
-* 2.80 - 2.93 are previous stable releases.
-* 2.93 is the current Blender LTS release. Check the `blender-v2.93-release` branch.
 * 3.1 is the current stable release. Check the `blender-v3.1-release` branch.
+* 2.80 - 3.0 are previous stable releases.
+* 2.93 is the current Blender LTS release. Check the `blender-v2.93-release` branch.
 * 3.2 will be the next release. Check the `blender-v3.2-release` branch.
 * master branch of this addon is mirrored in [Blender Addons master](https://developer.blender.org/diffusion/BA/browse/master/io_scene_gltf2/), that will become Blender 3.3.
 

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -292,6 +292,12 @@ class ExportGLTF2_Base:
         default=False,
     )
 
+    export_face_maps: BoolProperty(
+        name='Face Maps',
+        description='Export face maps as a mesh attribute (the names will be exported to the current node\'s extras)',
+        default=True
+    )
+
     export_cameras: BoolProperty(
         name='Cameras',
         description='Export cameras',
@@ -327,6 +333,9 @@ class ExportGLTF2_Base:
         description='Export custom properties as glTF extras',
         default=False
     )
+
+
+
 
     export_yup: BoolProperty(
         name='+Y Up',
@@ -535,6 +544,7 @@ class ExportGLTF2_Base:
         export_settings['gltf_tangents'] = self.export_tangents and self.export_normals
         export_settings['gltf_loose_edges'] = self.use_mesh_edges
         export_settings['gltf_loose_points'] = self.use_mesh_vertices
+        export_settings['gltf_face_maps'] = self.export_face_maps
 
         if self.is_draco_available:
             export_settings['gltf_draco_mesh_compression'] = self.export_draco_mesh_compression_enable
@@ -758,6 +768,9 @@ class GLTF_PT_export_geometry(bpy.types.Panel):
         col = layout.column()
         col.prop(operator, 'use_mesh_edges')
         col.prop(operator, 'use_mesh_vertices')
+
+        col = layout.column()
+        col.prop(operator, 'export_face_maps')
 
         layout.prop(operator, 'export_materials')
         col = layout.column()

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -295,7 +295,7 @@ class ExportGLTF2_Base:
     export_face_maps: BoolProperty(
         name='Face Maps',
         description='Export face maps as a mesh attribute (the names will be exported to the current node\'s extras)',
-        default=True
+        default=False
     )
 
     export_cameras: BoolProperty(

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -334,9 +334,6 @@ class ExportGLTF2_Base:
         default=False
     )
 
-
-
-
     export_yup: BoolProperty(
         name='+Y Up',
         description='Export using glTF convention, +Y up',

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -103,7 +103,6 @@ def extract_primitives(blender_mesh, uuid_for_skined_data, blender_vertex_groups
             # Just store this, to be used later
             armature_uuid = export_settings['vtree'].nodes[uuid_for_skined_data].armature
             export_settings['vtree'].nodes[armature_uuid].need_neutral_bone = True
-    extra_vgroup_weights = __get_extra_vgroups(blender_mesh, modifiers, blender_vertex_groups)
 
     # In Blender there is both per-vert data, like position, and also per-loop
     # (loop=corner-of-poly) data, like normals or UVs. glTF only has per-vert
@@ -295,9 +294,6 @@ def extract_primitives(blender_mesh, uuid_for_skined_data, blender_vertex_groups
             for i, (js, ws) in enumerate(zip(joints, weights)):
                 attributes['JOINTS_%d' % i] = js
                 attributes['WEIGHTS_%d' % i] = ws
-
-        for vgroup_name, weights in extra_vgroup_weights.items():
-            attributes['_VG_' + vgroup_name] = weights[blender_idxs]
 
         if use_facemaps:
             attributes['_FACEMAPS'] = prim_dots['facemaps']
@@ -564,37 +560,6 @@ def __get_colors(blender_mesh, color_i):
     rgb[:] = np.where(not_small, large_result, small_result)
 
     return colors
-
-
-def __get_extra_vgroups(blender_mesh, modifiers, blender_vertex_groups):
-    """Get vertex weights for vgroup that aren't used for skinning."""
-    if not blender_vertex_groups:
-        return {}
-
-    # Find vgroups used for skinning
-    skinning_vgroup_names = set()
-    for m in (modifiers or []):
-        if m.type == 'ARMATURE' and m.use_vertex_groups:
-            if m.object and m.object.type == 'ARMATURE':
-                for bone in m.object.data.bones:
-                    skinning_vgroup_names.add(bone.name)
-
-    if len(skinning_vgroup_names) == len(blender_vertex_groups):
-        return {}
-
-    vgroup_weights = {}
-    for i, vgroup in enumerate(blender_vertex_groups):
-        if vgroup.name in skinning_vgroup_names: continue
-        weights = []
-        for vertex in blender_mesh.vertices:
-            weight = 0.0
-            for vge in vertex.groups:
-                if vge.group == i:
-                    weight = vge.weight
-                    break
-            weights.append(weight)
-        vgroup_weights[vgroup.name] = np.array(weights, dtype=np.float32)
-    return vgroup_weights
 
 
 def __get_bone_data(blender_mesh, skin, blender_vertex_groups):

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -89,7 +89,7 @@ def extract_primitives(blender_mesh, uuid_for_skined_data, blender_vertex_groups
 
     use_materials = export_settings[gltf2_blender_export_keys.MATERIALS]
 
-    # Fetch vert data
+    # Fetch face maps
     use_facemaps = bool(blender_mesh.face_maps)
 
     # Fetch vert positions and bone data (joint,weights)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_extract.py
@@ -137,7 +137,7 @@ def extract_primitives(blender_mesh, uuid_for_skined_data, blender_vertex_groups
                 ('morph%dnz' % morph_i, np.float32),
             ]
     if use_face_maps:
-        dot_fields += [('face_maps', np.int16)]
+        dot_fields += [('face_maps', np.float32)]
 
     dots = np.empty(len(blender_mesh.loops), dtype=np.dtype(dot_fields))
 
@@ -604,7 +604,7 @@ def __get_bone_data(blender_mesh, skin, blender_vertex_groups):
 
 def __get_face_maps(blender_mesh):
     """Gets a face map index for each loop."""
-    poly_face_map = np.empty(len(blender_mesh.polygons), dtype=np.int16)
+    poly_face_map = np.empty(len(blender_mesh.polygons), dtype=np.float32)
     blender_mesh.face_maps[0].data.foreach_get('value', poly_face_map)
 
     # Get polygon_index for each loop in the mesh

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -238,12 +238,12 @@ def __gather_mesh(vnode, blender_object, export_settings):
         skip_filter = False
         # If no skin are exported, no need to have vertex group, this will create a cache miss
         if not export_settings[gltf2_blender_export_keys.SKINS]:
-            #vertex_groups = None
+            vertex_groups = None
             modifiers = None
         else:
             # Check if there is an armature modidier
             if len([mod for mod in blender_object.modifiers if mod.type == "ARMATURE"]) == 0:
-                #vertex_groups = None # Not needed if no armature, avoid a cache miss
+                vertex_groups = None # Not needed if no armature, avoid a cache miss
                 modifiers = None
 
     materials = tuple(ms.material for ms in blender_object.material_slots)

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -176,7 +176,7 @@ def __gather_extras(blender_object, export_settings):
     extras = {}
     if export_settings['gltf_extras']:
         extras = generate_extras(blender_object) or {}
-    if blender_object.face_maps:
+    if export_settings['gltf_face_maps'] and blender_object.face_maps:
         extras['facemaps'] = [face_map.name for face_map in blender_object.face_maps]
     return extras or None
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
@@ -226,7 +226,7 @@ def __gather_face_maps(blender_primitive, export_settings):
             if key == '_FACEMAPS':
                 attributes[key] = array_to_accessor(
                     blender_primitive["attributes"][key],
-                    component_type=gltf2_io_constants.ComponentType.Short,
+                    component_type=gltf2_io_constants.ComponentType.Float,
                     data_type=gltf2_io_constants.DataType.Scalar,
                 )
     return attributes

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
@@ -226,7 +226,7 @@ def __gather_face_maps(blender_primitive, export_settings):
             if key == '_FACEMAPS':
                 attributes[key] = array_to_accessor(
                     blender_primitive["attributes"][key],
-                    component_type=gltf2_io_constants.ComponentType.Float,
+                    component_type=gltf2_io_constants.ComponentType.Short,
                     data_type=gltf2_io_constants.DataType.Scalar,
                 )
     return attributes


### PR DESCRIPTION
This PR adds the feature of exporting face maps as a mesh attribute by enabling "Face Maps" in the "Geometry" options of the exporter.
Face map names are exported to the current node\'s extras "facemaps".

```
"nodes" : [
    {
        "extras" : {
            "facemaps" : [
                "FaceMap"
            ]
        },
        "mesh" : 0,
        "name" : "Cube"
    }
],
"meshes" : [
    {
        "name" : "Cube",
        "primitives" : [
            {
                "attributes" : {
                    "POSITION" : 0,
                    "NORMAL" : 1,
                    "TEXCOORD_0" : 2,
                    "_FACEMAPS" : 3
                },
                "indices" : 4
            }
        ]
    }
],
```

The topic was discussed here: https://github.com/KhronosGroup/glTF-Blender-IO/issues/1232, https://github.com/KhronosGroup/glTF-Blender-IO/pull/1515

Main idea from here: https://github.com/KhronosGroup/glTF-Blender-IO/issues/1232#issuecomment-797840257
The original code can be found here: https://github.com/canadaduane/glTF-Blender-IO/tree/export-facemaps-and-vertex-groups

Is it a good idea to merge it into the master branch?