### PR TITLE
Fixed an issue where indices would not switch to uint above 65535

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives.py
@@ -147,7 +147,7 @@ def __gather_indices(blender_primitive, blender_mesh, modifiers, export_settings
     # https://github.com/KhronosGroup/glTF/pull/1476/files
     # Also, UINT8 mode is not supported:
     # https://github.com/KhronosGroup/glTF/issues/1471
-    max_index = indices.max()
+    max_index = len(indices)
     if max_index < 65535:
         component_type = gltf2_io_constants.ComponentType.UnsignedShort
         indices = indices.astype(np.uint16, copy=False)


### PR DESCRIPTION
[ISSUE](https://github.com/KhronosGroup/glTF-Blender-IO/issues/1671)