### PR TITLE
Fix #1687 - export gather_tree: improved performance ...

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
@@ -106,10 +106,18 @@ class VExportTree:
         bpy.context.window.scene = blender_scene
         depsgraph = bpy.context.evaluated_depsgraph_get()
 
-        for blender_object in [obj.original for obj in depsgraph.scene_eval.objects if obj.parent is None]:
-            self.recursive_node_traverse(blender_object, None, None, Matrix.Identity(4))
+        # Gather parent/children information once, as calling bobj.children is
+        #   very expensive operation : takes O(len(bpy.data.objects)) time.
+        blender_children = dict()
+        for bobj in bpy.data.objects:
+            bparent = bobj.parent
+            blender_children.setdefault(bobj, [])
+            blender_children.setdefault(bparent, []).append(bobj)
 
-    def recursive_node_traverse(self, blender_object, blender_bone, parent_uuid, parent_coll_matrix_world, armature_uuid=None, dupli_world_matrix=None):
+        for blender_object in [obj.original for obj in depsgraph.scene_eval.objects if obj.parent is None]:
+            self.recursive_node_traverse(blender_object, None, None, Matrix.Identity(4), blender_children)
+
+    def recursive_node_traverse(self, blender_object, blender_bone, parent_uuid, parent_coll_matrix_world, blender_children, armature_uuid=None, dupli_world_matrix=None):
         node = VExportNode()
         node.uuid = str(uuid.uuid4())
         node.parent_uuid = parent_uuid
@@ -210,42 +218,42 @@ class VExportTree:
 
         # standard children
         if blender_bone is None and blender_object.is_instancer is False:
-            for child_object in blender_object.children:
+            for child_object in blender_children[blender_object]:
                 if child_object.parent_bone:
                     # Object parented to bones
                     # Will be manage later
                     continue
                 else:
                     # Classic parenting
-                    self.recursive_node_traverse(child_object, None, node.uuid, parent_coll_matrix_world)
+                    self.recursive_node_traverse(child_object, None, node.uuid, parent_coll_matrix_world, blender_children)
 
         # Collections
         if blender_object.instance_type == 'COLLECTION' and blender_object.instance_collection:
             for dupli_object in blender_object.instance_collection.all_objects:
                 if dupli_object.parent is not None:
                     continue
-                self.recursive_node_traverse(dupli_object, None, node.uuid, node.matrix_world)
+                self.recursive_node_traverse(dupli_object, None, node.uuid, node.matrix_world, blender_children)
 
         # Armature : children are bones with no parent
         if blender_object.type == "ARMATURE" and blender_bone is None:
             for b in [b for b in blender_object.pose.bones if b.parent is None]:
-                self.recursive_node_traverse(blender_object, b, node.uuid, parent_coll_matrix_world, node.uuid)
+                self.recursive_node_traverse(blender_object, b, node.uuid, parent_coll_matrix_world, blender_children, node.uuid)
 
         # Bones
         if blender_object.type == "ARMATURE" and blender_bone is not None:
             for b in blender_bone.children:
-                self.recursive_node_traverse(blender_object, b, node.uuid, parent_coll_matrix_world, armature_uuid)
+                self.recursive_node_traverse(blender_object, b, node.uuid, parent_coll_matrix_world, blender_children, armature_uuid)
 
         # Object parented to bone
         if blender_bone is not None:
-            for child_object in [c for c in blender_object.children if c.parent_bone is not None and c.parent_bone == blender_bone.name]:
-                self.recursive_node_traverse(child_object, None, node.uuid, parent_coll_matrix_world)
+            for child_object in [c for c in blender_children[blender_object] if c.parent_bone is not None and c.parent_bone == blender_bone.name]:
+                self.recursive_node_traverse(child_object, None, node.uuid, parent_coll_matrix_world, blender_children)
 
         # Duplis
         if blender_object.is_instancer is True and blender_object.instance_type != 'COLLECTION':
             depsgraph = bpy.context.evaluated_depsgraph_get()
             for (dupl, mat) in [(dup.object.original, dup.matrix_world.copy()) for dup in depsgraph.object_instances if dup.parent and id(dup.parent.original) == id(blender_object)]:
-                self.recursive_node_traverse(dupl, None, node.uuid, parent_coll_matrix_world, dupli_world_matrix=mat)
+                self.recursive_node_traverse(dupl, None, node.uuid, parent_coll_matrix_world, blender_children, dupli_world_matrix=mat)
 
     def get_all_objects(self):
         return [n.uuid for n in self.nodes.values() if n.blender_type != VExportNode.BONE]


### PR DESCRIPTION
... by not calling blender_object.children, which is slow : takes O(len(bpy.data.objects)) operations.

Related to issue https://github.com/KhronosGroup/glTF-Blender-IO/issues/1687

Instead, I build a `dict` containing parent/child relations, which is used during the traversal.

I measured time spent before/after the patch, using b3d 3.3-alpha+master.7f4ee97b9ef9 ; I see improvement from 2.05sec to 0.06sec - about 40x faster in this case.


## before patch
```
16:40:43 | INFO: Draco mesh compression is available, use library at C:\nllbin\blender-3.3.0-alpha+master.7f4ee97b9ef9-windows.amd64-release\3.3\python\lib\site-packages\extern_draco.dll
16:40:43 | INFO: Starting glTF 2.0 export
16:40:45 | INFO: Extracting primitive: Cube.1643
16:40:45 | INFO: Primitives created: 1
16:40:45 | INFO: Finished glTF 2.0 export in 2.051008939743042 s
```

## timing after patch, b3d 3.3-alpha+master.7f4ee97b9ef9
```
16:43:00 | INFO: Draco mesh compression is available, use library at C:\nllbin\blender-3.3.0-alpha+master.7f4ee97b9ef9-windows.amd64-release\3.3\python\lib\site-packages\extern_draco.dll
16:43:00 | INFO: Starting glTF 2.0 export
16:43:00 | INFO: Extracting primitive: Cube.1643
16:43:00 | INFO: Primitives created: 1
16:43:00 | INFO: Finished glTF 2.0 export in 0.06299805641174316 s
```
