### PR TITLE
Export lights using lumens, candelas, correct `GLTF`/`KHR_punctual_lights` units.

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -494,6 +494,12 @@ class ExportGLTF2_Base:
         default=1.0
     )
 
+    export_raw_lights: BoolProperty(
+        name='Raw Intensity',
+        description='Export raw light intensity, without converting to glTF units',
+        default=False
+    )
+
     will_save_settings: BoolProperty(
         name='Remember Export Settings',
         description='Store glTF export settings in the Blender project',
@@ -662,6 +668,7 @@ class ExportGLTF2_Base:
 
         export_settings['gltf_lights'] = self.export_lights
         export_settings['gltf_lights_factor'] = self.export_lights_factor
+        export_settings['gltf_raw_lights'] = self.export_raw_lights
 
         export_settings['gltf_binary'] = bytearray()
         export_settings['gltf_binaryfilename'] = (
@@ -769,6 +776,7 @@ class GLTF_PT_export_include(bpy.types.Panel):
         col.prop(operator, 'export_lights')
         if operator.export_lights:
             col.prop(operator, 'export_lights_factor')
+            col.prop(operator, 'export_raw_lights')
 
 
 class GLTF_PT_export_transform(bpy.types.Panel):

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -925,37 +925,6 @@ class GLTF_PT_export_geometry_lighting(bpy.types.Panel):
 
         layout.prop(operator, 'convert_lighting_mode')
 
-class GLTF_PT_export_geometry_lighting_info(bpy.types.Panel):
-    bl_space_type = 'FILE_BROWSER'
-    bl_region_type = 'TOOL_PROPS'
-    bl_label = "Info"
-    bl_parent_id = "GLTF_PT_export_geometry_lighting"
-    bl_options = {'DEFAULT_CLOSED'}
-
-    @classmethod
-    def poll(cls, context):
-        sfile = context.space_data
-        operator = sfile.active_operator
-        return operator.bl_idname == "EXPORT_SCENE_OT_gltf"
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False  # No animation.
-
-        sfile = context.space_data
-        operator = sfile.active_operator
-
-        for line in (
-            "The GLTF specification requires lighting to be defined in candela, lux, and nits.",
-            "However, some viewers lorem ipsum.",
-            "Dolor sit amet, consectetur adipisci tempor incidunt ut labore et dolore magna aliqua.",
-            "Veniam, quis nostrud exercitation ullamcorpor s commodo consequat. Duis autem vel.",
-            "Eum irrure esse molestiae consequat, vel illum dolore eu fugi et iusto odio dignissim."
-        ):
-            layout.label(text=line)
-
-
 class GLTF_PT_export_geometry_compression(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
     bl_region_type = 'TOOL_PROPS'
@@ -1401,7 +1370,6 @@ classes = (
     GLTF_PT_export_geometry_material,
     GLTF_PT_export_geometry_original_pbr,
     GLTF_PT_export_geometry_lighting,
-    GLTF_PT_export_geometry_lighting_info,
     GLTF_PT_export_geometry_compression,
     GLTF_PT_export_animation,
     GLTF_PT_export_animation_export,

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -115,9 +115,9 @@ class ConvertGLTF2_Base:
     convert_lighting_mode: EnumProperty(
         name='Lighting Mode',
         items=(
-            ('SPEC', 'Standard', 'Use standard glTF lighting units (cd, lx, nt)'),
-            ('COMPAT', 'Compatibility', 'Use unitless PBR lighting'),
-            ('RAW', 'Raw', 'Use Blender lighting strengths directly'),
+            ('SPEC', 'Standard', 'Physically-based glTF lighting units (cd, lx, nt)'),
+            ('COMPAT', 'Unitless', 'Non-physical, unitless lighting. Useful when exposure controls are not available'),
+            ('RAW', 'Raw', 'Blender lighting strengths with no conversion'),
         ),
         description='Optional backwards compatibility for non-standard render engines. Applies to lights',# TODO: and emissive materials',
         default='SPEC'

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -117,7 +117,7 @@ class ConvertGLTF2_Base:
         items=(
             ('SPEC', 'Standard', 'Physically-based glTF lighting units (cd, lx, nt)'),
             ('COMPAT', 'Unitless', 'Non-physical, unitless lighting. Useful when exposure controls are not available'),
-            ('RAW', 'Raw', 'Blender lighting strengths with no conversion'),
+            ('RAW', 'Raw (Deprecated)', 'Blender lighting strengths with no conversion'),
         ),
         description='Optional backwards compatibility for non-standard render engines. Applies to lights',# TODO: and emissive materials',
         default='SPEC'

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -58,6 +58,7 @@ from bpy.props import (StringProperty,
                        BoolProperty,
                        EnumProperty,
                        IntProperty,
+                       FloatProperty,
                        CollectionProperty)
 from bpy.types import Operator
 from bpy_extras.io_utils import ImportHelper, ExportHelper
@@ -487,6 +488,12 @@ class ExportGLTF2_Base:
         default=False
     )
 
+    export_lights_factor: FloatProperty(
+        name='Lights Strength',
+        description='Different platforms scale brightness differently. Setting 1/600 here works well for many engines',
+        default=1.0
+    )
+
     will_save_settings: BoolProperty(
         name='Remember Export Settings',
         description='Store glTF export settings in the Blender project',
@@ -654,6 +661,7 @@ class ExportGLTF2_Base:
             export_settings['gltf_morph_tangent'] = False
 
         export_settings['gltf_lights'] = self.export_lights
+        export_settings['gltf_lights_factor'] = self.export_lights_factor
 
         export_settings['gltf_binary'] = bytearray()
         export_settings['gltf_binaryfilename'] = (
@@ -759,6 +767,8 @@ class GLTF_PT_export_include(bpy.types.Panel):
         col.prop(operator, 'export_extras')
         col.prop(operator, 'export_cameras')
         col.prop(operator, 'export_lights')
+        if operator.export_lights:
+            col.prop(operator, 'export_lights_factor')
 
 
 class GLTF_PT_export_transform(bpy.types.Panel):

--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
@@ -16,6 +16,9 @@ from math import sin, cos
 import numpy as np
 from io_scene_gltf2.io.com import gltf2_io_constants
 
+PBR_WATTS_TO_LUMENS = 683
+# Industry convention, biological peak at 555nm, scientific standard as part of SI candela definition.
+
 def texture_transform_blender_to_gltf(mapping_transform):
     """
     Converts the offset/rotation/scale from a Mapping node applied in Blender's

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
@@ -18,6 +18,7 @@ from typing import Optional, List, Dict, Any
 
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from ..com.gltf2_blender_extras import generate_extras
+from ..com.gltf2_blender_conversion import PBR_WATTS_TO_LUMENS
 
 from io_scene_gltf2.io.com import gltf2_io_lights_punctual
 from io_scene_gltf2.io.com import gltf2_io_debug
@@ -85,7 +86,6 @@ def __gather_intensity(blender_lamp, export_settings) -> Optional[float]:
         return emission_strength
     else:
         # Assume at this point the computed strength is still in the appropriate watt-related SI unit, which if everything up to here was done with physical basis it hopefully should be.
-        WATTS_TO_LUMENS = 683
         if blender_lamp.type == 'SUN': # W/m^2 in Blender to lm/m^2 for GLTF/KHR_lights_punctual.
             emission_luminous = emission_strength
         else:
@@ -94,7 +94,7 @@ def __gather_intensity(blender_lamp, export_settings) -> Optional[float]:
             # Point and spot should both be lm/r^2 in GLTF.
             emission_luminous = emission_strength / (4*math.pi)
         if export_settings['gltf_lighting_mode'] == 'SPEC':
-            emission_luminous *= WATTS_TO_LUMENS
+            emission_luminous *= PBR_WATTS_TO_LUMENS
         elif export_settings['gltf_lighting_mode'] == 'COMPAT':
             pass # Just so we have an exhaustive tree to catch bugged values.
         else:

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
@@ -81,16 +81,19 @@ def __gather_intensity(blender_lamp, export_settings) -> Optional[float]:
             emission_strength = emission_node.inputs["Strength"].default_value
     else:
         emission_strength = blender_lamp.energy
-    # Assume at this point this is still in the appropriate watt-related SI unit, which if everything up to here was done with physical basis it hopefully should be.
-    WATTS_TO_LUMENS = 594
-    # At 580nm, according to WolframAlpha, which is probably as authoritative as a source as I can get for something so variable as physical power to perceptual brightness: https://www.wolframalpha.com/input?i=1+watt+in+lumens
-    if blender_lamp.type == 'SUN': # W/m^2 in Blender to lm/m^2 for GLTF/KHR_lights_punctual.
-        emission_luminous = emission_strength * WATTS_TO_LUMENS
+    if export_settings['gltf_raw_lights']:
+        emission_luminous = emission_strength
     else:
-        # Other than directional, only point and spot lamps are supported by GLTF.
-        # In Blender, points are omnidirectional W, and spots are specified as if they're points.
-        # Point and spot should both be lm/r^2 in GLTF.
-        emission_luminous = emission_strength / (4*math.pi) * WATTS_TO_LUMENS
+        # Assume at this point this is still in the appropriate watt-related SI unit, which if everything up to here was done with physical basis it hopefully should be.
+        WATTS_TO_LUMENS = 594
+        # At 580nm, according to WolframAlpha, which is probably as authoritative as a source as I can get for something so variable as physical power to perceptual brightness: https://www.wolframalpha.com/input?i=1+watt+in+lumens
+        if blender_lamp.type == 'SUN': # W/m^2 in Blender to lm/m^2 for GLTF/KHR_lights_punctual.
+            emission_luminous = emission_strength * WATTS_TO_LUMENS
+        else:
+            # Other than directional, only point and spot lamps are supported by GLTF.
+            # In Blender, points are omnidirectional W, and spots are specified as if they're points.
+            # Point and spot should both be lm/r^2 in GLTF.
+            emission_luminous = emission_strength / (4*math.pi) * WATTS_TO_LUMENS
     return emission_luminous * export_settings['gltf_lights_factor']
     # NOTE: The GLTF spec says light intensity is given in lumens, a unit of *perceptual* luminous flux. Perceptual luminance varies with wavelength. So in order to attempt to actually match the spec, we would have to multiply each RGB component by a different (cone cell) responsivity factor as we convert from watts, a unit of *physical* radiation. However, neither the Three.JS nor the Khronos Group reference GLTF model viewers currently technically implement that part of the spec correctly, and in my personal opinion in this PR a unit of perceptual brightness like "lumens" has no place in a model format designed for physically based workflows anyway (and may not have been intentional). I'll raise this issue on the KhronosGroup GLTF issue tracker: https://github.com/KhronosGroup/glTF/issues/2213
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py
@@ -61,7 +61,7 @@ def __gather_color(blender_lamp, export_settings) -> Optional[List[float]]:
     return list(blender_lamp.color)
 
 
-def __gather_intensity(blender_lamp, _) -> Optional[float]:
+def __gather_intensity(blender_lamp, export_settings) -> Optional[float]:
     emission_node = __get_cycles_emission_node(blender_lamp)
     if emission_node is not None:
         if blender_lamp.type != 'SUN':
@@ -79,9 +79,20 @@ def __gather_intensity(blender_lamp, _) -> Optional[float]:
                 emission_strength = blender_lamp.energy
         else:
             emission_strength = emission_node.inputs["Strength"].default_value
-        return emission_strength
-
-    return blender_lamp.energy
+    else:
+        emission_strength = blender_lamp.energy
+    # Assume at this point this is still in the appropriate watt-related SI unit, which if everything up to here was done with physical basis it hopefully should be.
+    WATTS_TO_LUMENS = 594
+    # At 580nm, according to WolframAlpha, which is probably as authoritative as a source as I can get for something so variable as physical power to perceptual brightness: https://www.wolframalpha.com/input?i=1+watt+in+lumens
+    if blender_lamp.type == 'SUN': # W/m^2 in Blender to lm/m^2 for GLTF/KHR_lights_punctual.
+        emission_luminous = emission_strength * WATTS_TO_LUMENS
+    else:
+        # Other than directional, only point and spot lamps are supported by GLTF.
+        # In Blender, points are omnidirectional W, and spots are specified as if they're points.
+        # Point and spot should both be lm/r^2 in GLTF.
+        emission_luminous = emission_strength / (4*math.pi) * WATTS_TO_LUMENS
+    return emission_luminous * export_settings['gltf_lights_factor']
+    # NOTE: The GLTF spec says light intensity is given in lumens, a unit of *perceptual* luminous flux. Perceptual luminance varies with wavelength. So in order to attempt to actually match the spec, we would have to multiply each RGB component by a different (cone cell) responsivity factor as we convert from watts, a unit of *physical* radiation. However, neither the Three.JS nor the Khronos Group reference GLTF model viewers currently technically implement that part of the spec correctly, and in my personal opinion in this PR a unit of perceptual brightness like "lumens" has no place in a model format designed for physically based workflows anyway (and may not have been intentional). I'll raise this issue on the KhronosGroup GLTF issue tracker: https://github.com/KhronosGroup/glTF/issues/2213
 
 
 def __gather_spot(blender_lamp, export_settings) -> Optional[gltf2_io_lights_punctual.LightSpot]:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_light.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_light.py
@@ -32,7 +32,7 @@ class BlenderLight():
         import_user_extensions('gather_import_light_before_hook', gltf, vnode, pylight)
 
         if pylight['type'] == "directional":
-            light = BlenderLight.create_directional(gltf, light_id)
+            light = BlenderLight.create_directional(gltf, light_id) # ...Why not pass the pylight?
         elif pylight['type'] == "point":
             light = BlenderLight.create_point(gltf, light_id)
         elif pylight['type'] == "spot":

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_light.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_light.py
@@ -17,6 +17,7 @@ from math import pi
 
 from ..com.gltf2_blender_extras import set_extras
 from io_scene_gltf2.io.imp.gltf2_io_user_extensions import import_user_extensions
+from ..com.gltf2_blender_conversion import PBR_WATTS_TO_LUMENS
 
 
 class BlenderLight():
@@ -41,9 +42,6 @@ class BlenderLight():
         if 'color' in pylight.keys():
             light.color = pylight['color']
 
-        if 'intensity' in pylight.keys():
-            light.energy = pylight['intensity']
-
         # TODO range
 
         set_extras(light, pylight.get('extras'))
@@ -55,10 +53,32 @@ class BlenderLight():
         pylight = gltf.data.extensions['KHR_lights_punctual']['lights'][light_id]
 
         if 'name' not in pylight.keys():
-            pylight['name'] = "Sun"
+            pylight['name'] = "Sun" # Uh... Is it okay to mutate the import data?
 
         sun = bpy.data.lights.new(name=pylight['name'], type="SUN")
+
+        if 'intensity' in pylight.keys():
+            if gltf.import_settings['convert_lighting_mode'] == 'SPEC':
+                sun.energy = pylight['intensity'] / PBR_WATTS_TO_LUMENS
+            elif gltf.import_settings['convert_lighting_mode'] == 'COMPAT':
+                sun.energy = pylight['intensity']
+            elif gltf.import_settings['convert_lighting_mode'] == 'RAW':
+                sun.energy = pylight['intensity']
+            else:
+                raise ValueError(gltf.import_settings['convert_lighting_mode'])
+
         return sun
+
+    @staticmethod
+    def _calc_energy_pointlike(gltf, pylight):
+        if gltf.import_settings['convert_lighting_mode'] == 'SPEC':
+            return pylight['intensity'] / PBR_WATTS_TO_LUMENS * 4 * pi
+        elif gltf.import_settings['convert_lighting_mode'] == 'COMPAT':
+            return pylight['intensity'] * 4 * pi
+        elif gltf.import_settings['convert_lighting_mode'] == 'RAW':
+            return pylight['intensity']
+        else:
+            raise ValueError(gltf.import_settings['convert_lighting_mode'])
 
     @staticmethod
     def create_point(gltf, light_id):
@@ -68,6 +88,10 @@ class BlenderLight():
             pylight['name'] = "Point"
 
         point = bpy.data.lights.new(name=pylight['name'], type="POINT")
+
+        if 'intensity' in pylight.keys():
+            point.energy = BlenderLight._calc_energy_pointlike(gltf, pylight)
+
         return point
 
     @staticmethod
@@ -89,5 +113,8 @@ class BlenderLight():
             spot.spot_blend = 1 - ( pylight['spot']['innerConeAngle'] / pylight['spot']['outerConeAngle'] )
         else:
             spot.spot_blend = 1.0
+
+        if 'intensity' in pylight.keys():
+            spot.energy = BlenderLight._calc_energy_pointlike(gltf, pylight)
 
         return spot


### PR DESCRIPTION
Closes #564.

Export mode selection:

![image](https://user-images.githubusercontent.com/37680486/196012983-b7fcbb0f-e75b-4487-bf67-f0bc80b96156.png)

Enum options and tooltips:

https://github.com/KhronosGroup/glTF-Blender-IO/blob/af9e7f06508a95425b05e485fa83681b268bbdfc/addons/io_scene_gltf2/__init__.py#L115-L124

<details><summary>Correctness Tests</summary>

Blender scene:

![image](https://user-images.githubusercontent.com/37680486/196012752-e00fb8a1-081f-4f98-8a44-23b21459f6c0.png)

Spec-compliant export, Khronos viewer with exposure set to compensate for unitless pipeline:

![image](https://user-images.githubusercontent.com/37680486/196012777-35de8f45-12a3-4108-afa1-0fcae58dd16f.png)

Spec-compliant export, Babylon.JS with exposure set to compensate for unitless pipeline:

![image](https://user-images.githubusercontent.com/37680486/196012782-2f247f26-15c8-4c4e-b3a2-1b97abc5f3b7.png)

Unitless export, Khronos viewer:

![image](https://user-images.githubusercontent.com/37680486/196012789-d6b0131c-aed1-4a4d-aa48-eb65a06a3542.png)

Unitless export, Babylon.JS:

![image](https://user-images.githubusercontent.com/37680486/196012798-22ca332f-cd00-489f-a78d-e2ade694660c.png)

Unitless export, Three.JS:

![image](https://user-images.githubusercontent.com/37680486/196012824-bf65e264-3727-4eda-97a6-769d618fce31.png)

</details>

I also tested re-importing exported files back into Blender, in all three conversion modes, to make sure they still looked right.

Structural changes to wider code:

- Renamed "Geometry" export subpanel to "Data", as it already contained material and now contains lighting options.
- Added `class ConvertGLTF2_Base`, for properties that apply to both import and export.
- Defined `PBR_WATTS_TO_LUMENS` in `gltf2_blender_conversions`, the first constant in that file.

<details><summary>Original Post</summary>

I believe this makes this part of the exporter... As spec-compliant as any other software. However.... Watts are *huge*. Or lumens are tiny. When I was in high school I had this 10W LED headlamp rated for 600lm. At 10% LED efficiency, that works out to around 600 lumens for every 1 watt of emitted light, which is also what Wolfram Alpha tells me to expect at a mid-visible wavelength. Obviously multiplying all exported light intensities by 600 also makes the models look a bit different. To get around that, I added an `export_lights_factor` setting that can be used to scale exported lumens back down, defaulting to `1.0` (technical physical correctness) but with a tooltip recommending inputting `1/600` for most export targets.

I suppose for a lumens-based workflow with Three.JS, you would want to use [`WebGLRenderer.physicallyCorrectLights`](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.physicallyCorrectLights). It is unfortunate, however, that neither of the reference viewers support anything like that, and unclear whether with Three.JS even that will correctly handle GLTF values as lumens per square radians as per the spec or just raw lumens, which would still be incorrect.

~~Note that there is also another implication of the spec that I have not implemented, as none of the reference model viewers implement it either, and I'm not sure it's intentional. I left a code comment explaining this. More info: https://github.com/KhronosGroup/glTF/issues/2213~~

~~I explicitly decided not to include a backwards-compatibility checkbox to continue exporting in watts, as that behaviour was incorrect. I figure it's not part of the spec, and every vendor and tool doing their own thing is how you end up with E.G. Collada.~~ I decided to include it as a "raw" mode for finer user control, rather than a "compatibility" mode to perpetuate incorrect results.

**Example/Test case**

EEVEE Render:

![PunctualRendered](https://user-images.githubusercontent.com/37680486/195223268-aab9ebb1-0647-4f11-93cb-a27a58118dbf.png)

Blender 3.3 export:

![PunctualExportedWatts](https://user-images.githubusercontent.com/37680486/195223285-7eaa7ff2-ae32-4027-8ba4-e8af738dfd97.png)

This PR (w/ "Lights Strength" set to 1/600):
![PunctualExportedLumens](https://user-images.githubusercontent.com/37680486/195223301-6ff420e4-beaa-4844-aa86-27f1047760ed.png)

*"Mr. Elephant" by [Glenn Melenhorst](https://glennmelenhorst.com/), from [Demo Files on blender.org](https://www.blender.org/download/demo-files/). Used as a demonstrative— Any problems you see in it are the result of me bodging the export.*

</details>