### PR TITLE
Handle ortho camera frame correctly. (Closes GH-944, GH-624.)

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cameras.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_cameras.py
@@ -68,9 +68,17 @@ def __gather_orthographic(blender_camera, export_settings):
             zfar=None,
             znear=None
         )
+        
+        _render = bpy.context.scene.render
+        scene_x = _render.resolution_x * _render.pixel_aspect_x
+        scene_y = _render.resolution_y * _render.pixel_aspect_y
+        scene_square = max(scene_x, scene_y)
+        del _render
+        
+        # `Camera().ortho_scale` (and also FOV FTR) maps to the maximum of either image width or image height— This is the box that gets shown from camera view with the checkbox `.show_sensor = True`.
 
-        orthographic.xmag = blender_camera.ortho_scale
-        orthographic.ymag = blender_camera.ortho_scale
+        orthographic.xmag = blender_camera.ortho_scale * (scene_x / scene_square) / 2
+        orthographic.ymag = blender_camera.ortho_scale * (scene_y / scene_square) / 2
 
         orthographic.znear = blender_camera.clip_start
         orthographic.zfar = blender_camera.clip_end
@@ -90,9 +98,11 @@ def __gather_perspective(blender_camera, export_settings):
             znear=None
         )
 
-        width = bpy.context.scene.render.pixel_aspect_x * bpy.context.scene.render.resolution_x
-        height = bpy.context.scene.render.pixel_aspect_y * bpy.context.scene.render.resolution_y
+        _render = bpy.context.scene.render
+        width = _render.pixel_aspect_x * _render.resolution_x
+        height = _render.pixel_aspect_y * _render.resolution_y
         perspective.aspect_ratio = width / height
+        del _render
 
         if width >= height:
             if blender_camera.sensor_fit != 'VERTICAL':

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_camera.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_camera.py
@@ -39,7 +39,7 @@ class BlenderCamera():
         if pycamera.type == "orthographic":
             cam.type = "ORTHO"
 
-            # TODO: xmag/ymag
+            cam.ortho_scale = max(pycamera.orthographic.xmag, pycamera.orthographic.ymag) * 2
 
             cam.clip_start = pycamera.orthographic.znear
             cam.clip_end = pycamera.orthographic.zfar


### PR DESCRIPTION
Blender:

![image](https://user-images.githubusercontent.com/37680486/195918787-71b52a16-6c57-453e-a108-06e50f49c944.png)

Before:

![image](https://user-images.githubusercontent.com/37680486/195918808-fbff3373-6e1b-416d-9f8c-ded20361f094.png)

After:

![image](https://user-images.githubusercontent.com/37680486/195918827-ddffc928-71be-4e83-96d3-79ffd92b38c0.png)

Tested with Babylon because I believe Three is currently also non-conformant.
https://github.com/mrdoob/three.js/issues/24800


Spec:

https://github.com/KhronosGroup/glTF/issues/1663

https://github.com/KhronosGroup/glTF/pull/2053

https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/Specification.adoc#31034-orthographic-projection

```ADoc
==== Orthographic projection

Let

- `r` be half the orthographic width, set by `camera.orthographic.xmag`;
- `t` be half the orthographic height, set by `camera.orthographic.ymag`;
- `f` be the distance to the far clipping plane, set by `camera.orthographic.zfar`;
- `n` be the distance to the near clipping plane, set by `camera.orthographic.znear`.
```

Closes #944.
Closes #624.