### PR TITLE
Fix #1765 Color Attribute import fix:

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -316,6 +316,10 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
 
         mesh.color_attributes[layer.name].data.foreach_set('color', squish(loop_cols[col_i]))
 
+    # Make sure the first Vertex Color Attribute is the rendered one
+    if num_cols > 0:
+        mesh.color_attributes.render_color_index = 0
+
     # Skinning
     # TODO: this is slow :/
     if num_joint_sets and mesh_options.skinning:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -451,7 +451,7 @@ def base_color(
     # Vertex Color
     if mh.vertex_color:
         node = mh.node_tree.nodes.new('ShaderNodeVertexColor')
-        node.layer_name = 'Col'
+        # Do not set the layer name, so rendered one will be used (At import => The first one)
         node.location = x - 250, y - 240
         # Outputs
         mh.node_tree.links.new(vcolor_color_socket, node.outputs['Color'])


### PR DESCRIPTION
Fix #1765 Color Attribute import fix:
- The first imported one is now the rendered one
- Color Attribute Node does no more specify the layer, so rendered one is used