### PR TITLE
Expand display of most enum properties.

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -874,10 +874,12 @@ class GLTF_PT_export_geometry_material(bpy.types.Panel):
         sfile = context.space_data
         operator = sfile.active_operator
 
-        layout.prop(operator, 'export_materials')
+        col = layout.column()
+        col.prop(operator, 'export_materials', expand=True)
+
         col = layout.column()
         col.active = operator.export_materials == "EXPORT"
-        col.prop(operator, 'export_image_format')
+        col.prop(operator, 'export_image_format', expand=True)
 
 class GLTF_PT_export_geometry_original_pbr(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
@@ -923,7 +925,8 @@ class GLTF_PT_export_geometry_lighting(bpy.types.Panel):
         sfile = context.space_data
         operator = sfile.active_operator
 
-        layout.prop(operator, 'convert_lighting_mode')
+        col = layout.column()
+        col.prop(operator, 'convert_lighting_mode', expand=True)
 
 class GLTF_PT_export_geometry_compression(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
@@ -1234,10 +1237,13 @@ class ImportGLTF2(Operator, ConvertGLTF2_Base, ImportHelper):
 
         layout.prop(self, 'import_pack_images')
         layout.prop(self, 'merge_vertices')
-        layout.prop(self, 'import_shading')
+        col = layout.column()
+        col.prop(self, 'import_shading', expand=True)
         layout.prop(self, 'guess_original_bind_pose')
-        layout.prop(self, 'bone_heuristic')
-        layout.prop(self, 'convert_lighting_mode')
+        col = layout.column()
+        col.prop(self, 'bone_heuristic', expand=True)
+        col = layout.column()
+        col.prop(self, 'convert_lighting_mode', expand=True)
 
     def invoke(self, context, event):
         import sys


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/37680486/196072668-96551984-4374-4bf1-8b77-fb9792504ebd.png) ![image](https://user-images.githubusercontent.com/37680486/196072687-fd65bb79-1148-4a49-840a-2d3ef11f1632.png)


*Entirely* subjective, but personally I like how this display type exposes all the options at a glance.

It might just be me, but personally I go through all the dropdowns anyway whenever I'm exporting a final copy of something, just to see all the options to be sure I have them set right. So it'd be faster to just have them all visible at the same time.

And I suppose from a UX perspective, most of the Enums are already hidden in subpanels that are closed by default anyway. So those subpanels already provide the the space-saving functionality of using a dropdown, and needing to open the dropdowns right after opening the subpanels feels like a redundant click.

Uses #1760 as a base. So if accepted, should not be merged before that one. ....I'll need to rebase for any further changes to #1760, and probably throw on a dummy commit after it's been merged so GH generates a clean diff view. (That one introduces a new enum, so I figured it should be in the tree for this.)
