### PR TITLE
Change `Bone Dir` default value `TEMPERANCE` to `BLENDER`

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -1200,10 +1200,11 @@ class ImportGLTF2(Operator, ConvertGLTF2_Base, ImportHelper):
     bone_heuristic: EnumProperty(
         name="Bone Dir",
         items=(
-            ("BLENDER", "Blender (best for re-importing)",
+            ("BLENDER", "Blender (keep original bone orientations in glTF, best for re-importing)",
+                "The glTF bone orientations are not changed on import and export. "
                 "Good for re-importing glTFs exported from Blender. "
                 "Bone tips are placed on their local +Y axis (in glTF space)"),
-            ("TEMPERANCE", "Temperance (average)",
+            ("TEMPERANCE", "Temperance (heuristic, average)",
                 "Decent all-around strategy. "
                 "A bone with one child has its tip placed on the local axis "
                 "closest to its child"),
@@ -1213,7 +1214,7 @@ class ImportGLTF2(Operator, ConvertGLTF2_Base, ImportHelper):
                 "Non-uniform scalings may get messed up though, so beware"),
         ),
         description="Heuristic for placing bones. Tries to make bones pretty",
-        default="TEMPERANCE",
+        default="BLENDER",
     )
 
     guess_original_bind_pose: BoolProperty(


### PR DESCRIPTION
Fixes #1662

As explained there, `Bone Dir` should keep the original glTF bone orientations by default, so it should use `BLENDER`. **The behavior of not using heuristics by default is same as other importers such as fbx, collada, etc.**

I also wrote a slightly more detailed description in ToolTip. I'm not sure if the enum name `BLENDER` is appropriate to begin with, but we can leave that alone for now.