### PR TITLE
Add export identifier

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -132,6 +132,16 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
 
     bl_options = {'PRESET'}
 
+    # Don't use export_ prefix here, I don't want it to be saved with other export settings
+    gltf_export_id: StringProperty(
+        name='Identifier',
+        description=(
+            'Identifier of caller (in case of addon calling this exporter. '
+            'Can be useful in case of Extension added by other addons'
+        ),
+        default=''
+    )
+
     export_format: EnumProperty(
         name='Format',
         items=(('GLB', 'glTF Binary (.glb)',
@@ -579,7 +589,7 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
         export_settings = {}
 
         export_settings['timestamp'] = datetime.datetime.now()
-
+        export_settings['gltf_export_id'] = self.gltf_export_id
         export_settings['gltf_filepath'] = self.filepath
         export_settings['gltf_filedirectory'] = os.path.dirname(export_settings['gltf_filepath']) + '/'
         export_settings['gltf_texturedirectory'] = os.path.join(


### PR DESCRIPTION
Can be useful in case of other addons that call glTF exporter by code, and using some Extension.
To avoid having an impact on regular glTF exporter, dev can now call the glTF exporter with 'gltf_exporter_id', and using it in export_settings to check if we are coming from an addon or, if empty, from a regular export