### PR TITLE
Fix #1227 filter_glob update when changing export type

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -110,6 +110,8 @@ def on_export_format_changed(self, context):
 
     # Also change the filter
     sfile.params.filter_glob = '*.glb' if self.export_format == 'GLB' else '*.gltf'
+    # Force update of file list, has update the filter does not update the real file list
+    bpy.ops.file.refresh()
 
 
 class ConvertGLTF2_Base:

--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -108,6 +108,9 @@ def on_export_format_changed(self, context):
         self.export_format,
     )
 
+    # Also change the filter
+    sfile.params.filter_glob = '*.glb' if self.export_format == 'GLB' else '*.gltf'
+
 
 class ConvertGLTF2_Base:
     """Base class containing options that should be exposed during both import and export."""
@@ -157,7 +160,7 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
             'Output format and embedding options. Binary is most efficient, '
             'but JSON (embedded or separate) may be easier to edit later'
         ),
-        default='GLB',
+        default='GLB', #Warning => If you change the default, need to change the default filter too
         update=on_export_format_changed,
     )
 
@@ -1169,7 +1172,7 @@ class ExportGLTF2(bpy.types.Operator, ExportGLTF2_Base, ExportHelper):
 
     filename_ext = ''
 
-    filter_glob: StringProperty(default='*.glb;*.gltf', options={'HIDDEN'})
+    filter_glob: StringProperty(default='*.glb', options={'HIDDEN'})
 
 
 def menu_func_export(self, context):


### PR DESCRIPTION
Fix #1227 
When changing export type (glb / gltf embeded / gltf separated), it changes automatically the filter in file export list.
(When GLB => displays only *.glb, otherwise => displays only *.gltf)

There is currently a bug in Blender preventing the list to be refreshed automatically.
Update is done when clicking on "Refresh File List"
https://developer.blender.org/T104221