### PR TITLE
Check for material when getting the node_tree

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_texture_info.py
@@ -180,7 +180,7 @@ def __gather_texture_transform_and_tex_coord(primary_socket, export_settings):
         node_tree = node.id_data
         for mesh in bpy.data.meshes:
             for material in mesh.materials:
-                if material.node_tree == node_tree:
+                if material and material.node_tree == node_tree:
                     i = mesh.uv_layers.find(node.uv_map)
                     if i >= 0:
                         texcoord_idx = i


### PR DESCRIPTION
Fixes #1846

This PR adds a check to make sure the material slot is not empty when checking for its node_tree.