### PR TITLE
Round normals to avoid vertex split

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -17,6 +17,7 @@ from mathutils import Vector
 
 from . import gltf2_blender_export_keys
 from ...io.com.gltf2_io_debug import print_console
+from ...io.com.gltf2_io_constants import NORMALS_ROUNDING_DIGIT
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_skins
 from io_scene_gltf2.io.com import gltf2_io_constants
 from io_scene_gltf2.blender.com import gltf2_blender_conversion
@@ -710,10 +711,13 @@ class PrimitiveCreator:
 
         self.normals = self.normals.reshape(len(self.blender_mesh.loops), 3)
 
+        self.normals = np.round(self.normals, NORMALS_ROUNDING_DIGIT)
+
         self.morph_normals = []
         for key_block in key_blocks:
             ns = np.array(key_block.normals_split_get(), dtype=np.float32)
             ns = ns.reshape(len(self.blender_mesh.loops), 3)
+            ns = np.round(ns, NORMALS_ROUNDING_DIGIT)
             self.morph_normals.append(ns)
 
         # Transform for skinning

--- a/addons/io_scene_gltf2/io/com/gltf2_io_constants.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_constants.py
@@ -161,3 +161,6 @@ GLTF_DATA_TYPE_MAT3 = "MAT3"
 GLTF_DATA_TYPE_MAT4 = "MAT4"
 
 GLTF_IOR = 1.5
+
+# Rounding digit used for normal rounding
+NORMALS_ROUNDING_DIGIT = 6

--- a/addons/io_scene_gltf2/io/com/gltf2_io_constants.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_constants.py
@@ -163,4 +163,4 @@ GLTF_DATA_TYPE_MAT4 = "MAT4"
 GLTF_IOR = 1.5
 
 # Rounding digit used for normal rounding
-NORMALS_ROUNDING_DIGIT = 6
+NORMALS_ROUNDING_DIGIT = 4


### PR DESCRIPTION
Fix #1849 
Round normals at export to avoid vertex split for quite identical normals
Rounding at 6 digits