### PR TITLE
Fix #1861 - variable name collision in recursive tree

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
@@ -182,8 +182,8 @@ class VExportTree:
             # If object is parented to bone, and Rest pose is used, we need to keep the world matrix
             # Of the rest pose, not the current world matrix
             if parent_uuid and self.nodes[parent_uuid].blender_type == VExportNode.BONE and self.export_settings['gltf_current_frame'] is False:
-                blender_bone = self.nodes[parent_uuid].blender_bone
-                node.matrix_world = (blender_bone.matrix @ blender_bone.bone.matrix_local.inverted_safe()).inverted_safe() @ node.matrix_world
+                _blender_bone = self.nodes[parent_uuid].blender_bone
+                node.matrix_world = (_blender_bone.matrix @ _blender_bone.bone.matrix_local.inverted_safe()).inverted_safe() @ node.matrix_world
 
             if node.blender_type == VExportNode.CAMERA and self.export_settings[gltf2_blender_export_keys.CAMERAS]:
                 if self.export_settings[gltf2_blender_export_keys.YUP]:


### PR DESCRIPTION
Fix #1861 - variable name collision in recursive tree