### PR TITLE
Fix normal normalization

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -709,6 +709,8 @@ class PrimitiveCreator:
         self.normals = self.normals.reshape(len(self.blender_mesh.loops), 3)
 
         self.normals = np.round(self.normals, NORMALS_ROUNDING_DIGIT)
+        # Force normalization of normals in case some normals are not (why ?)
+        PrimitiveCreator.normalize_vecs(self.normals)
 
         self.morph_normals = []
         for key_block in key_blocks:


### PR DESCRIPTION
In some cases, some normals are not normalized (see https://projects.blender.org/blender/blender-addons/issues/79104)
Let's add a normalization at export, to be sure normals are ok.
Now, lets check what's happen at import, maybe there is something to do too