### PR TITLE
Allow normalization in gather_attribute_change user extension

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitive_attributes.py
@@ -45,7 +45,7 @@ def gather_primitive_attributes(blender_primitive, export_settings):
     return attributes
 
 
-def array_to_accessor(array, component_type, data_type, include_max_and_min=False):
+def array_to_accessor(array, component_type, data_type, include_max_and_min=False, normalized=None):
 
     amax = None
     amin = None
@@ -63,7 +63,7 @@ def array_to_accessor(array, component_type, data_type, include_max_and_min=Fals
         max=amax,
         min=amin,
         name=None,
-        normalized=None,
+        normalized=normalized,
         sparse=None,
         type=data_type,
     )
@@ -193,6 +193,7 @@ def __gather_attribute(blender_primitive, attribute, export_settings):
                 data['data'],
                 component_type=data['component_type'],
                 data_type=data['data_type'],
-                include_max_and_min=include_max_and_mins.get(attribute, False)
+                include_max_and_min=include_max_and_mins.get(attribute, False),
+                normalized=data.get('normalized')
             )
         }


### PR DESCRIPTION
This PR allows to mark data as normalized from a user extension like https://github.com/julienduroure/gltf-hooks-examples/blob/main/gltf_attribute_change.py

The motivation being, that one might want to transform a `Float` attribute into a `UnsignedByte` color attribute that requires the `"normalized":true` tag in the glTF 2.0 accessor to be valid.

The only change is exposing the normalization boolean and allowing it to be set in a user extension like
```python
data["normalized"] = True
```