### PR TITLE
Check parent type to determine if a node is really a child of a bone

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
@@ -250,7 +250,7 @@ class VExportTree:
         # standard children (of object, or of instance collection)
         if blender_bone is None:
             for child_object in blender_children[blender_object]:
-                if child_object.parent_bone:
+                if child_object.parent_bone and child_object.parent_type in ("BONE", "BONE_RELATIVE"):
                     # Object parented to bones
                     # Will be manage later
                     continue


### PR DESCRIPTION
Fixes a bug where nodes would not be exported if they had previously been using BONE parenting but had later been changed to OBJECT parenting.

To reproduce:
1. Create a mesh
2. Create an armature with one bone
3. Set the mesh's parent to the bone in the armature
4. Change the mesh's "parent type" to object - Blender will change the parent to the armature instead of the bone but will *not* clear the `parent_bone` in the mesh object.
5. Export a glTF - the mesh won't appear in the output file