### PR TITLE
Add a mesh hook

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -39,13 +39,27 @@ def gather_node(vnode, export_settings):
     if skin is not None:
         vnode.skin = skin
 
+
+    # Hook to check if we should export mesh or not (force it to None)
+    class GltfHookNodeMesh:
+        def __init__(self):
+            self.export_mesh = True
+
+    gltf_hook_node_mesh = GltfHookNodeMesh()
+
+    export_user_extensions('gather_node_mesh_hook', export_settings, gltf_hook_node_mesh, blender_object)
+    if gltf_hook_node_mesh.export_mesh is True:
+        mesh = __gather_mesh(vnode, blender_object, export_settings)
+    else:
+        mesh = None
+
     node = gltf2_io.Node(
         camera=__gather_camera(vnode, export_settings),
         children=__gather_children(vnode, export_settings),
         extensions=__gather_extensions(vnode, export_settings),
         extras=__gather_extras(blender_object, export_settings),
         matrix=__gather_matrix(blender_object, export_settings),
-        mesh=__gather_mesh(vnode, blender_object, export_settings),
+        mesh=mesh,
         name=__gather_name(blender_object, export_settings),
         rotation=None,
         scale=None,

--- a/example-addons/example_gltf_exporter_extension/readme.md
+++ b/example-addons/example_gltf_exporter_extension/readme.md
@@ -73,4 +73,5 @@ gather_attribute_keep(self, keep_attribute, export_settings)
 gather_attribute_change(self, attribute, data, is_normalized_byte_color, export_settings)
 gather_attributes_change(self, attributes, export_settings)
 gather_gltf_additional_textures_hook(self, json, additioan_json_textures, export_settings)
+gather_node_mesh_hook(self, option, blender_object, export_settings)
 ```


### PR DESCRIPTION
This hook can force the mesh to None on a node, preventing exporting the mesh, but keeping the node itself

Example of use:

```
import bpy

bl_info = {
    "name": "glTF export mesh",
    "category": "Generic",
    "version": (1, 0, 0),
    "blender": (4, 1, 0),
    'location': 'File > Export > glTF 2.0',
    'description': 'Export mesh or not',
    'tracker_url': "https://github.com/julienduroure/gltf-hooks-examples",
    'isDraft': False,
    'developer': "Julien Duroure",
    'url': 'https://github.com/julienduroure',
}



class glTF2ExportUserExtension:

    def __init__(self):
        pass

    def gather_node_mesh_hook(self, option, blender_object, export_settings):
        # If object has custom property _export_mesh_, and this property is set to False => Do not export mesh
        # All other cases (not this custom property or custom property set to True) => We export the mesh
        if blender_object.get("export_mesh", True) is False:
            option.export_mesh = False


def register():
    pass

def unregister():
    pass

```