### PR TITLE
Fix #2083 - check node group with suffixes too

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials_pbr_metallic_roughness.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials_pbr_metallic_roughness.py
@@ -154,8 +154,10 @@ def __gather_metallic_roughness_texture(blender_material, orm_texture, export_se
     # Using directlty the Blender socket object
     if not hasMetal and not hasRough:
         metallic_roughness = get_socket_from_gltf_material_node(blender_material, "MetallicRoughness")
-        if metallic_roughness is None or not has_image_node_from_socket(metallic_roughness, export_settings):
+        if metallic_roughness.socket is None or not has_image_node_from_socket(metallic_roughness, export_settings):
             return None, {}, {}, None
+        else:
+            texture_input = (metallic_roughness, metallic_roughness)
     elif not hasMetal:
         texture_input = (roughness_socket,)
     elif not hasRough:
@@ -164,6 +166,7 @@ def __gather_metallic_roughness_texture(blender_material, orm_texture, export_se
         texture_input = (metallic_socket, roughness_socket)
 
     tex, uvmap_info, udim_info, factor = gather_texture_info(
+
         texture_input[0],
         orm_texture or texture_input,
         export_settings,

--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_search_node_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_search_node_tree.py
@@ -187,7 +187,7 @@ def get_socket_from_gltf_material_node(blender_material: bpy.types.Material, nam
     if blender_material.node_tree and blender_material.use_nodes:
         nodes = get_material_nodes(blender_material.node_tree, [blender_material], bpy.types.ShaderNodeGroup)
         # Some weird node groups with missing datablock can have no node_tree, so checking n.node_tree (See #1797)
-        nodes = [n for n in nodes if n[0].node_tree is not None and ( n[0].node_tree.name.lower().startswith(get_gltf_old_group_node_name()) or n[0].node_tree.name.lower() in gltf_node_group_names)]
+        nodes = [n for n in nodes if n[0].node_tree is not None and any([[n[0].node_tree.name.lower().startswith(g) for g in gltf_node_group_names]])]
         inputs = sum([[(input, node[1]) for input in node[0].inputs if input.name == name] for node in nodes], [])
         if inputs:
             return NodeSocket(inputs[0][0], inputs[0][1])


### PR DESCRIPTION
Fix #2083 - check node group with suffixes too

Appending materials can create the glTF output node with some .00x suffix.
Checking also this nodes in tree traversal for checking specific data (like occlusion)