### PR TITLE
Change scaling factor of default custom bones 

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -240,7 +240,7 @@ class BlenderNode():
             if gltf.import_settings['bone_heuristic'] == "BLENDER":
                 pose_bone.custom_shape = bpy.data.objects[gltf.bone_shape]
                 armature_min_dim = min([blender_arma.dimensions[0] / blender_arma.scale[0], blender_arma.dimensions[1]  / blender_arma.scale[1], blender_arma.dimensions[2] / blender_arma.scale[2]])
-                pose_bone.custom_shape_scale_xyz = Vector([armature_max_dim * 0.05] * 3)
+                pose_bone.custom_shape_scale_xyz = Vector([armature_min_dim * 0.05] * 3)
                 pose_bone.use_custom_shape_bone_size = False
 
     @staticmethod

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_node.py
@@ -239,8 +239,9 @@ class BlenderNode():
 
             if gltf.import_settings['bone_heuristic'] == "BLENDER":
                 pose_bone.custom_shape = bpy.data.objects[gltf.bone_shape]
-                armature_max_dim = max([blender_arma.dimensions[0] / blender_arma.scale[0], blender_arma.dimensions[1]  / blender_arma.scale[1], blender_arma.dimensions[2] / blender_arma.scale[2]])
-                pose_bone.custom_shape_scale_xyz = Vector([armature_max_dim * 0.2] * 3)
+                armature_min_dim = min([blender_arma.dimensions[0] / blender_arma.scale[0], blender_arma.dimensions[1]  / blender_arma.scale[1], blender_arma.dimensions[2] / blender_arma.scale[2]])
+                pose_bone.custom_shape_scale_xyz = Vector([armature_max_dim * 0.05] * 3)
+                pose_bone.use_custom_shape_bone_size = False
 
     @staticmethod
     def create_mesh_object(gltf, vnode):


### PR DESCRIPTION
adjusted as discussed [in this issue ](https://github.com/KhronosGroup/glTF-Blender-IO/issues/2075), it's possible these may be slightly too small on some armatures, however it at least avoids the issue of the giant globes preventing use of the armature at all.
Likely the actual scaling factor should be exposed in the importer panel so that an end user can easily adjust the default size one way or the other as best suits the armatures they work with.