### PR TITLE
Find unique structured array elements more efficiently

### DIFF
--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
@@ -163,3 +163,67 @@ def get_anisotropy_rotation_gltf_to_blender(rotation):
 def get_anisotropy_rotation_blender_to_gltf(rotation):
     # glTF rotation is in randian, Blender in 0 to 1
     return rotation * (2 * np.pi)
+
+def fast_structured_np_unique(arr, *args, **kwargs):
+    """
+    np.unique optimized for structured arrays when a sorted result is not required.
+
+    np.unique works through sorting, but sorting a structured array requires as many sorts as there are fields in the
+    structured dtype.
+
+    By viewing the array as a single non-structured dtype that sorts according to its bytes, unique elements can be
+    found with a single sort. Since the values are viewed as a different type to their original, this means that the
+    returned array of unique values may not be sorted according to their original type.
+
+    Float field caveats:
+    All elements of -0.0 in the input array will be replaced with 0.0 to ensure that both values are collapsed into one.
+    NaN values can have lots of different byte representations (e.g. signalling/quiet and custom payloads). Only the
+    duplicates of each unique byte representation will be collapsed into one.
+
+    Nested structured dtypes are not supported.
+    The behaviour of structured dtypes with overlapping fields is undefined.
+    """
+    structured_dtype = arr.dtype
+    fields = structured_dtype.fields
+    if fields is None:
+        raise RuntimeError('%s is not a structured dtype' % structured_dtype)
+
+    for field_name, (field_dtype, *_offset_and_optional_title) in fields.items():
+        if field_dtype.subdtype is not None:
+            raise RuntimeError('Nested structured types are not supported in %s' % structured_dtype)
+        if field_dtype.kind == 'f':
+            # Replace all -0.0 in the array with 0.0 because -0.0 and 0.0 have different byte representations.
+            arr[field_name][arr[field_name] == -0.0] = 0.0
+        elif field_dtype.kind not in "iuUSV":
+            # Signed integer, unsigned integer, unicode string, byte string (bytes) and raw bytes (void) can be left
+            # as they are. Everything else is unsupported.
+            raise RuntimeError('Unsupported structured field type %s for field %s' % (field_dtype, field_name))
+
+    structured_itemsize = structured_dtype.itemsize
+
+    # Integer types sort the fastest, but are only available for specific itemsizes.
+    uint_dtypes_by_itemsize = {1: np.uint8, 2: np.uint16, 4: np.uint32, 8: np.uint64}
+    # Signed/unsigned makes no noticeable speed difference, but using unsigned will result in ordering according to
+    # individual bytes like the other, non-integer types.
+    if structured_itemsize in uint_dtypes_by_itemsize:
+        entire_structure_dtype = uint_dtypes_by_itemsize[structured_itemsize]
+    else:
+        # Construct a flexible size dtype with matching itemsize to the entire structured dtype.
+        # Should always be 4 because each character in a unicode string is UCS4.
+        str_itemsize = np.dtype((np.str_, 1)).itemsize
+        if structured_itemsize % str_itemsize == 0:
+            # Unicode strings seem to be slightly faster to sort than bytes.
+            entire_structure_dtype = np.dtype((np.str_, structured_itemsize // str_itemsize))
+        else:
+            # Bytes seem to be slightly faster to sort than raw bytes (np.void).
+            entire_structure_dtype = np.dtype((np.bytes_, structured_itemsize))
+
+    result = np.unique(arr.view(entire_structure_dtype), *args, **kwargs)
+
+    unique = result[0] if isinstance(result, tuple) else result
+    # View in the original dtype.
+    unique = unique.view(arr.dtype)
+    if isinstance(result, tuple):
+        return (unique,) + result[1:]
+    else:
+        return unique

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -42,72 +42,6 @@ def extract_primitives(materials, blender_mesh, uuid_for_skined_data, blender_ve
     else:
         return primitive_creator.primitive_creation_shared()
 
-
-def fast_structured_np_unique(arr, *args, **kwargs):
-    """
-    np.unique optimized for structured arrays when a sorted result is not required.
-
-    np.unique works through sorting, but sorting a structured array requires as many sorts as there are fields in the
-    structured dtype.
-
-    By viewing the array as a single non-structured dtype that sorts according to its bytes, unique elements can be
-    found with a single sort. Since the values are viewed as a different type to their original, this means that the
-    returned array of unique values may not be sorted according to their original type.
-
-    Float field caveats:
-    All elements of -0.0 in the input array will be replaced with 0.0 to ensure that both values are collapsed into one.
-    NaN values can have lots of different byte representations (e.g. signalling/quiet and custom payloads). Only the
-    duplicates of each unique byte representation will be collapsed into one.
-
-    Nested structured dtypes are not supported.
-    The behaviour of structured dtypes with overlapping fields is undefined.
-    """
-    structured_dtype = arr.dtype
-    fields = structured_dtype.fields
-    if fields is None:
-        raise RuntimeError('%s is not a structured dtype' % structured_dtype)
-
-    for field_name, (field_dtype, *_offset_and_optional_title) in fields.items():
-        if field_dtype.subdtype is not None:
-            raise RuntimeError('Nested structured types are not supported in %s' % structured_dtype)
-        if field_dtype.kind == 'f':
-            # Replace all -0.0 in the array with 0.0 because -0.0 and 0.0 have different byte representations.
-            arr[field_name][arr[field_name] == -0.0] = 0.0
-        elif field_dtype.kind not in "iuUSV":
-            # Signed integer, unsigned integer, unicode string, byte string (bytes) and raw bytes (void) can be left
-            # as they are. Everything else is unsupported.
-            raise RuntimeError('Unsupported structured field type %s for field %s' % (field_dtype, field_name))
-
-    structured_itemsize = structured_dtype.itemsize
-
-    # Integer types sort the fastest, but are only available for specific itemsizes.
-    uint_dtypes_by_itemsize = {1: np.uint8, 2: np.uint16, 4: np.uint32, 8: np.uint64}
-    # Signed/unsigned makes no noticeable speed difference, but using unsigned will result in ordering according to
-    # individual bytes like the other, non-integer types.
-    if structured_itemsize in uint_dtypes_by_itemsize:
-        entire_structure_dtype = uint_dtypes_by_itemsize[structured_itemsize]
-    else:
-        # Construct a flexible size dtype with matching itemsize to the entire structured dtype.
-        # Should always be 4 because each character in a unicode string is UCS4.
-        str_itemsize = np.dtype((np.str_, 1)).itemsize
-        if structured_itemsize % str_itemsize == 0:
-            # Unicode strings seem to be slightly faster to sort than bytes.
-            entire_structure_dtype = np.dtype((np.str_, structured_itemsize // str_itemsize))
-        else:
-            # Bytes seem to be slightly faster to sort than raw bytes (np.void).
-            entire_structure_dtype = np.dtype((np.bytes_, structured_itemsize))
-
-    result = np.unique(arr.view(entire_structure_dtype), *args, **kwargs)
-
-    unique = result[0] if isinstance(result, tuple) else result
-    # View in the original dtype.
-    unique = unique.view(arr.dtype)
-    if isinstance(result, tuple):
-        return (unique,) + result[1:]
-    else:
-        return unique
-
-
 class PrimitiveCreator:
     def __init__(self, materials, blender_mesh, uuid_for_skined_data, blender_vertex_groups, modifiers, export_settings):
         self.blender_mesh = blender_mesh
@@ -697,7 +631,7 @@ class PrimitiveCreator:
 
     def primitive_creation_shared(self):
         primitives = []
-        self.dots, shared_dot_indices = fast_structured_np_unique(self.dots, return_inverse=True)
+        self.dots, shared_dot_indices = gltf2_blender_conversion.fast_structured_np_unique(self.dots, return_inverse=True)
 
         self.blender_idxs = self.dots['vertex_index']
 
@@ -772,7 +706,7 @@ class PrimitiveCreator:
             # Extract just dots used by this primitive, deduplicate them, and
             # calculate indices into this deduplicated list.
             self.prim_dots = self.dots[dot_indices]
-            self.prim_dots, indices = fast_structured_np_unique(self.prim_dots, return_inverse=True)
+            self.prim_dots, indices = gltf2_blender_conversion.fast_structured_np_unique(self.prim_dots, return_inverse=True)
 
             if len(self.prim_dots) == 0:
                 continue
@@ -846,7 +780,7 @@ class PrimitiveCreator:
             if self.blender_idxs_edges.shape[0] > 0:
                 # Export one glTF vert per unique Blender vert in a loose edge
                 self.blender_idxs = self.blender_idxs_edges
-                dots_edges, indices = fast_structured_np_unique(self.dots_edges, return_inverse=True)
+                dots_edges, indices = gltf2_blender_conversion.fast_structured_np_unique(self.dots_edges, return_inverse=True)
                 self.blender_idxs = np.unique(self.blender_idxs_edges)
 
                 self.attributes_edges_points = {}

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -42,6 +42,72 @@ def extract_primitives(materials, blender_mesh, uuid_for_skined_data, blender_ve
     else:
         return primitive_creator.primitive_creation_shared()
 
+
+def fast_structured_np_unique(arr, *args, **kwargs):
+    """
+    np.unique optimized for structured arrays when a sorted result is not required.
+
+    np.unique works through sorting, but sorting a structured array requires as many sorts as there are fields in the
+    structured dtype.
+
+    By viewing the array as a single non-structured dtype that sorts according to its bytes, unique elements can be
+    found with a single sort. Since the values are viewed as a different type to their original, this means that the
+    returned array of unique values may not be sorted according to their original type.
+
+    Float field caveats:
+    All elements of -0.0 in the input array will be replaced with 0.0 to ensure that both values are collapsed into one.
+    NaN values can have lots of different byte representations (e.g. signalling/quiet and custom payloads). Only the
+    duplicates of each unique byte representation will be collapsed into one.
+
+    Nested structured dtypes are not supported.
+    The behaviour of structured dtypes with overlapping fields is undefined.
+    """
+    structured_dtype = arr.dtype
+    fields = structured_dtype.fields
+    if fields is None:
+        raise RuntimeError('%s is not a structured dtype' % structured_dtype)
+
+    for field_name, (field_dtype, *_offset_and_optional_title) in fields.items():
+        if field_dtype.subdtype is not None:
+            raise RuntimeError('Nested structured types are not supported in %s' % structured_dtype)
+        if field_dtype.kind == 'f':
+            # Replace all -0.0 in the array with 0.0 because -0.0 and 0.0 have different byte representations.
+            arr[field_name][arr[field_name] == -0.0] = 0.0
+        elif field_dtype.kind not in "iuUSV":
+            # Signed integer, unsigned integer, unicode string, byte string (bytes) and raw bytes (void) can be left
+            # as they are. Everything else is unsupported.
+            raise RuntimeError('Unsupported structured field type %s for field %s' % (field_dtype, field_name))
+
+    structured_itemsize = structured_dtype.itemsize
+
+    # Integer types sort the fastest, but are only available for specific itemsizes.
+    uint_dtypes_by_itemsize = {1: np.uint8, 2: np.uint16, 4: np.uint32, 8: np.uint64}
+    # Signed/unsigned makes no noticeable speed difference, but using unsigned will result in ordering according to
+    # individual bytes like the other, non-integer types.
+    if structured_itemsize in uint_dtypes_by_itemsize:
+        entire_structure_dtype = uint_dtypes_by_itemsize[structured_itemsize]
+    else:
+        # Construct a flexible size dtype with matching itemsize to the entire structured dtype.
+        # Should always be 4 because each character in a unicode string is UCS4.
+        str_itemsize = np.dtype((np.str_, 1)).itemsize
+        if structured_itemsize % str_itemsize == 0:
+            # Unicode strings seem to be slightly faster to sort than bytes.
+            entire_structure_dtype = np.dtype((np.str_, structured_itemsize // str_itemsize))
+        else:
+            # Bytes seem to be slightly faster to sort than raw bytes (np.void).
+            entire_structure_dtype = np.dtype((np.bytes_, structured_itemsize))
+
+    result = np.unique(arr.view(entire_structure_dtype), *args, **kwargs)
+
+    unique = result[0] if isinstance(result, tuple) else result
+    # View in the original dtype.
+    unique = unique.view(arr.dtype)
+    if isinstance(result, tuple):
+        return (unique,) + result[1:]
+    else:
+        return unique
+
+
 class PrimitiveCreator:
     def __init__(self, materials, blender_mesh, uuid_for_skined_data, blender_vertex_groups, modifiers, export_settings):
         self.blender_mesh = blender_mesh
@@ -631,7 +697,7 @@ class PrimitiveCreator:
 
     def primitive_creation_shared(self):
         primitives = []
-        self.dots, shared_dot_indices = np.unique(self.dots, return_inverse=True)
+        self.dots, shared_dot_indices = fast_structured_np_unique(self.dots, return_inverse=True)
 
         self.blender_idxs = self.dots['vertex_index']
 
@@ -706,7 +772,7 @@ class PrimitiveCreator:
             # Extract just dots used by this primitive, deduplicate them, and
             # calculate indices into this deduplicated list.
             self.prim_dots = self.dots[dot_indices]
-            self.prim_dots, indices = np.unique(self.prim_dots, return_inverse=True)
+            self.prim_dots, indices = fast_structured_np_unique(self.prim_dots, return_inverse=True)
 
             if len(self.prim_dots) == 0:
                 continue
@@ -780,7 +846,7 @@ class PrimitiveCreator:
             if self.blender_idxs_edges.shape[0] > 0:
                 # Export one glTF vert per unique Blender vert in a loose edge
                 self.blender_idxs = self.blender_idxs_edges
-                dots_edges, indices = np.unique(self.dots_edges, return_inverse=True)
+                dots_edges, indices = fast_structured_np_unique(self.dots_edges, return_inverse=True)
                 self.blender_idxs = np.unique(self.blender_idxs_edges)
 
                 self.attributes_edges_points = {}

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -21,6 +21,7 @@ from ...io.imp.gltf2_io_binary import BinaryData
 from ...io.com.gltf2_io_constants import DataType, ComponentType
 from ...blender.com.gltf2_blender_conversion import get_attribute_type
 from ..com.gltf2_blender_extras import set_extras
+from ..com.gltf2_blender_conversion import fast_structured_np_unique
 from .gltf2_blender_material import BlenderMaterial
 from .gltf2_io_draco_compression_extension import decode_primitive
 
@@ -776,7 +777,7 @@ def merge_duplicate_verts(vert_locs, vert_normals, vert_joints, vert_weights, sk
         dots['sk%dy' % i] = locs[:, 1]
         dots['sk%dz' % i] = locs[:, 2]
 
-    unique_dots, unique_ind, inv_indices = np.unique(dots, return_index=True, return_inverse=True)
+    unique_dots, unique_ind, inv_indices = fast_structured_np_unique(dots, return_index=True, return_inverse=True)
 
     loop_vidxs = inv_indices[loop_vidxs]
     edge_vidxs = inv_indices[edge_vidxs]


### PR DESCRIPTION
np.unique works by sorting its input array and structured arrays are
sorted by sorting by each column sequentially with a stable sorting
algorithm. This means that every extra field in the structured array's
dtype adds an extra sort just to find unique elements.

When exporting shape key normals is enabled, 3 extra fields are added to
the `dots` array's structured dtype per shape key on the mesh, which can
quickly end up in over 100 sorts when finding the unique values.

By instead viewing a structured array as a non-structured dtype with the
same itemsize, unique values can be found with a single sort, but at the
cost of the result no longer being sorted according to the structured
dtype.

This non-structured dtype also has to be compared by its bytes, so -0.0
in any floating-point fields must be replaced with 0.0 beforehand and
any NaN values with different byte representations will be considered
unique from other NaN values.

For large meshes and/or meshes with many shape keys, this can reduce
export times by a few seconds.

---

This is heavily based on the similar [`io_scene_fbx.fbx_utils.fast_first_axis_unique`](https://projects.blender.org/blender/blender-addons/src/commit/a99528adb07d0c745b4f1ec5b1997e304b4dc048/io_scene_fbx/fbx_utils.py#L514) function I made for the FBX I/O add-on because finding unique elements along the first axis of a multidimensional array with np.unique internally just views each row and any extra dimensions as a structured dtype and then sorts that structured array view of the multidimensional array.

On a larger humanoid rigged model I have with a few hundred shape keys per mesh, this patch brings the export duration down from 40s to 31s (before this patch, it exports in 6s if I disable exporting shape key normals).

If desired, I can add explicit checks that the fields are not overlapping, though I think this is unlikely to ever be an issue.

If desired, I can add support for `bool` fields, though they don't appear to be used currently. For completeness, `bool` fields should set all values equal to `True` to `True`/`1` because its possible that `bool` fields could be constructed from a view of non-bool data. E.g. `np.arange(3, dtype=np.uint8).view(bool)` results in a `[False, True, True]` array, but the actual values will be `[0, 1, 2]`.