### PR TITLE
Import: update pbrSpecularGlossiness for Principled v2

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
@@ -12,159 +12,202 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import bpy
 from ...io.com.gltf2_io import TextureInfo
 from .gltf2_blender_pbrMetallicRoughness import \
-    base_color, emission, normal, occlusion, make_output_nodes, make_settings_node
-from .gltf2_blender_texture import texture
+    base_color, emission, normal, occlusion, make_settings_node
+from .gltf2_blender_material_utils import color_factor_and_texture
+from .gltf2_blender_texture import texture, get_source
+from .gltf2_blender_image import BlenderImage
+import numpy as np
 
 
 def pbr_specular_glossiness(mh):
     """Creates node tree for pbrSpecularGlossiness materials."""
-    # This does option #1 from
-    # https://github.com/KhronosGroup/glTF-Blender-IO/issues/303
+    ext = mh.get_ext('KHR_materials_pbrSpecularGlossiness', {})
 
-    # Sum a Glossy and Diffuse Shader
-    glossy_node = mh.node_tree.nodes.new('ShaderNodeBsdfGlossy')
-    diffuse_node = mh.node_tree.nodes.new('ShaderNodeBsdfDiffuse')
-    add_node = mh.node_tree.nodes.new('ShaderNodeAddShader')
-    glossy_node.location = 10, 220
-    diffuse_node.location = 10, 0
-    add_node.location = 230, 100
-    mh.node_tree.links.new(add_node.inputs[0], glossy_node.outputs[0])
-    mh.node_tree.links.new(add_node.inputs[1], diffuse_node.outputs[0])
+    pbr_node = mh.nodes.new('ShaderNodeBsdfPrincipled')
+    out_node = mh.nodes.new('ShaderNodeOutputMaterial')
+    pbr_node.location = 10, 300
+    out_node.location = 300, 300
+    mh.links.new(pbr_node.outputs[0], out_node.inputs[0])
 
-    emission_socket, alpha_socket, _ = make_output_nodes(
-        mh,
-        location=(370, 250),
-        additional_location=None, #No additional location needed for SpecGloss
-        shader_socket=add_node.outputs[0],
-        make_emission_socket=mh.needs_emissive(),
-        make_alpha_socket=not mh.is_opaque(),
-        make_volume_socket=None # No possible to have KHR_materials_volume with specular/glossiness
-    )
-
-    if emission_socket:
-        emission(
-            mh,
-            location=(-200, 860),
-            color_socket=emission_socket,
-            strength_socket=emission_socket.node.inputs['Strength']
-        )
+    locs = calc_locations(mh, ext)
 
     base_color(
         mh,
         is_diffuse=True,
-        location=(-200, 380),
-        color_socket=diffuse_node.inputs['Color'],
-        alpha_socket=alpha_socket,
+        location=locs['diffuse'],
+        color_socket=pbr_node.inputs['Base Color'],
+        alpha_socket=pbr_node.inputs['Alpha'] if not mh.is_opaque() else None,
     )
 
-    specular_glossiness(
+    emission(
         mh,
-        location=(-200, -100),
-        specular_socket=glossy_node.inputs['Color'],
-        roughness_socket=glossy_node.inputs['Roughness'],
-    )
-    copy_socket(
-        mh,
-        copy_from=glossy_node.inputs['Roughness'],
-        copy_to=diffuse_node.inputs['Roughness'],
+        location=locs['emission'],
+        color_socket=pbr_node.inputs['Emission Color'],
+        strength_socket=pbr_node.inputs['Emission Strength'],
     )
 
     normal(
         mh,
-        location=(-200, -580),
-        normal_socket=glossy_node.inputs['Normal'],
-    )
-    copy_socket(
-        mh,
-        copy_from=glossy_node.inputs['Normal'],
-        copy_to=diffuse_node.inputs['Normal'],
+        location=locs['normal'],
+        normal_socket=pbr_node.inputs['Normal'],
     )
 
     if mh.pymat.occlusion_texture is not None:
         if mh.settings_node is None:
             mh.settings_node = make_settings_node(mh)
-            mh.settings_node.location = (610, -1060)
+            mh.settings_node.location = 10, 425
+            mh.settings_node.width = 240
         occlusion(
             mh,
-            location=(510, -970),
+            location=locs['occlusion'],
             occlusion_socket=mh.settings_node.inputs['Occlusion'],
         )
 
+    # The F0 color is the specular tint modulated by
+    # ((1-IOR)/(1+IOR))^2. Setting IOR=1000 makes this factor
+    # approximately 1.
+    pbr_node.inputs['IOR'].default_value = 1000
 
-# [Texture] => [Spec/Gloss Factor] => [Gloss to Rough] =>
-def specular_glossiness(mh, location, specular_socket, roughness_socket):
-    x, y = location
-    spec_factor = mh.pymat.extensions \
-        ['KHR_materials_pbrSpecularGlossiness'] \
-        .get('specularFactor', [1, 1, 1])
-    gloss_factor = mh.pymat.extensions \
-        ['KHR_materials_pbrSpecularGlossiness'] \
-        .get('glossinessFactor', 1)
-    spec_gloss_texture = mh.pymat.extensions \
-        ['KHR_materials_pbrSpecularGlossiness'] \
-        .get('specularGlossinessTexture', None)
-    if spec_gloss_texture is not None:
-        spec_gloss_texture = TextureInfo.from_dict(spec_gloss_texture)
-
-    if spec_gloss_texture is None:
-        specular_socket.default_value = spec_factor + [1]
-        roughness_socket.default_value = 1 - gloss_factor
-        return
-
-    # (1 - x) converts glossiness to roughness
-    node = mh.node_tree.nodes.new('ShaderNodeInvert')
-    node.label = 'Invert (Gloss to Rough)'
-    node.location = x - 140, y - 75
-    # Outputs
-    mh.node_tree.links.new(roughness_socket, node.outputs[0])
-    # Inputs
-    node.inputs['Fac'].default_value = 1
-    glossiness_socket = node.inputs['Color']
-
-    x -= 250
-
-    # Mix in spec/gloss factor
-    if spec_factor != [1, 1, 1] or gloss_factor != 1:
-        if spec_factor != [1, 1, 1]:
-            node = mh.node_tree.nodes.new('ShaderNodeMix')
-            node.data_type = 'RGBA'
-            node.label = 'Specular Factor'
-            node.location = x - 140, y
-            node.blend_type = 'MULTIPLY'
-            # Outputs
-            mh.node_tree.links.new(specular_socket, node.outputs[2])
-            # Inputs
-            node.inputs['Factor'].default_value = 1.0
-            specular_socket = node.inputs[6]
-            node.inputs[7].default_value = spec_factor + [1]
-
-        if gloss_factor != 1:
-            node = mh.node_tree.nodes.new('ShaderNodeMath')
-            node.label = 'Glossiness Factor'
-            node.location = x - 140, y - 200
-            node.operation = 'MULTIPLY'
-            # Outputs
-            mh.node_tree.links.new(glossiness_socket, node.outputs[0])
-            # Inputs
-            glossiness_socket = node.inputs[0]
-            node.inputs[1].default_value = gloss_factor
-
-        x -= 200
-
-    texture(
+    # Specular
+    color_factor_and_texture(
         mh,
-        tex_info=spec_gloss_texture,
-        label='SPECULAR GLOSSINESS',
-        location=(x, y),
-        color_socket=specular_socket,
-        alpha_socket=glossiness_socket,
+        location=locs['specular'],
+        label='Specular Color',
+        socket=pbr_node.inputs['Specular Tint'],
+        factor=ext.get('specularFactor', [1, 1, 1]),
+        tex_info=ext.get('specularGlossinessTexture'),
+    )
+
+    # Glossiness
+    glossiness(
+        mh,
+        ext,
+        location=locs['glossiness'],
+        roughness_socket=pbr_node.inputs['Roughness'],
     )
 
 
-def copy_socket(mh, copy_from, copy_to):
-    """Copy the links/default value from one socket to another."""
-    copy_to.default_value = copy_from.default_value
-    for link in copy_from.links:
-        mh.node_tree.links.new(copy_to, link.from_socket)
+def glossiness(mh, ext, location, roughness_socket):
+    # Glossiness = glossinessFactor * specularGlossinessTexture.alpha
+    # Roughness = 1 - Glossiness
+
+    factor = ext.get('glossinessFactor', 1)
+    tex_info = ext.get('specularGlossinessTexture')
+    if tex_info is not None:
+        tex_info = TextureInfo.from_dict(tex_info)
+
+    # Simple case: no texture
+    if tex_info is None or factor == 0:
+        roughness_socket.default_value = 1 - factor
+        return
+
+    # Bake an image with the roughness. The reason we don't do
+    # 1-X with a node is that won't export.
+    roughness_img = make_roughness_image(mh, factor, tex_info)
+    if roughness_img is None:
+        return
+
+    texture(
+        mh,
+        tex_info,
+        location=location,
+        label='ROUGHNESS',
+        color_socket=None,
+        alpha_socket=roughness_socket,
+        is_data=False,
+        forced_image=roughness_img,
+    )
+
+
+def make_roughness_image(mh, glossiness_factor, tex_info):
+    """
+    Bakes the roughness (1-glossiness) into an image. The
+    roughness is in the alpha channel.
+    """
+    pytexture = mh.gltf.data.textures[tex_info.index]
+    source = get_source(mh, pytexture)
+
+    if source is None:
+        return None
+
+    pyimg = mh.gltf.data.images[source]
+    BlenderImage.create(mh.gltf, source)
+
+    # See if cached roughness texture already exists
+    if hasattr(pyimg, 'blender_roughness_image_name'):
+        return bpy.data.images[pyimg.blender_roughness_image_name]
+
+    orig_image = bpy.data.images[pyimg.blender_image_name]
+    # TODO: check for placeholder image and bail
+
+    # Make a copy of the specularGlossiness texture
+    # Avoids interfering if it's used elsewhere
+    image = orig_image.copy()
+
+    w, h = image.size
+    pixels = np.empty(w * h * 4, dtype=np.float32)
+    image.pixels.foreach_get(pixels)
+    pixels = pixels.reshape((w, h, 4))
+
+    # Glossiness = GlossinessFactor * Texture.alpha
+    # Roughness = 1 - Glossiness
+    if glossiness_factor != 1:
+        pixels[:, :, 3] *= glossiness_factor
+    pixels[:, :, 3] *= -1
+    pixels[:, :, 3] += 1
+
+    pixels = pixels.reshape(w * h * 4)
+    image.pixels.foreach_set(pixels)
+
+    image.pack()
+
+    # Cache for reuse
+    pyimg.blender_roughness_image_name = image.name
+
+    return image
+
+
+def calc_locations(mh, ext):
+    """Calculate locations to place each bit of the node graph at."""
+    # Lay the blocks out top-to-bottom, aligned on the right
+    x = -200
+    y = 0
+    height = 460  # height of each block
+    locs = {}
+
+    locs['occlusion'] = (x, y)
+    if mh.pymat.occlusion_texture is not None:
+        y -= height
+
+    locs['diffuse'] = (x, y)
+    if 'diffuseTexture' in ext or mh.vertex_color:
+        y -= height
+
+    locs['glossiness'] = (x, y)
+    gloss_factor = ext.get('glossinessFactor', 1)
+    if 'specularGlossinessTexture' in ext and gloss_factor != 0:
+        y -= height
+
+    locs['normal'] = (x, y)
+    if mh.pymat.normal_texture is not None:
+        y -= height
+
+    locs['specular'] = (x, y)
+    if 'specularGlossinessTexture' in ext:
+        y -= height
+
+    locs['emission'] = (x, y)
+    if mh.pymat.emissive_texture is not None:
+        y -= height
+
+    # Center things
+    total_height = -y
+    y_offset = total_height / 2 - 20
+    for key in locs:
+        x, y = locs[key]
+        locs[key] = (x, y + y_offset)
+
+    return locs


### PR DESCRIPTION
Rewrites pbrSpecularGlossiness code to use the new Principled v2 node.

Closes #1853.  
Closes #1857.

Implementation Notes:

* Uses the trick of setting IOR=1000 to make the F0 color equal the specular tint.
* The biggest problem is the glossiness, which is 1-roughness. This patch makes a copy of the specularGlossinessTexture and bakes the roughness into its alpha channel. I would have just used a Math node to do 1-X, but that wouldn't export.
* A `calc_locs` was added to calculate locations for the node blocks. It uses the socket order from the new Principled node.

Import of SpecGlossVsMetalRough from the sample models:

![SpecGlossVsMetalRough](https://github.com/KhronosGroup/glTF-Blender-IO/assets/11024420/12f4656e-9cfd-4e29-8b2f-681f724e0002)

You can see the new shader is generally too dark. Some edge reflections are better though. I don't know if there's a way to improve this.

Exporting works (the visual appearance roundtrips). When exporting, the material that used KHR_materials_pbrSpecularGlossiness will use KHR_materials_ior and KHR_materials_specular.

Here is what the shader nodes look like:

![Full shader graph for specGloss](https://github.com/KhronosGroup/glTF-Blender-IO/assets/11024420/0f9d24c9-702c-42d4-9b3f-5bc26b6fd10f)