### PR TITLE
Import: adjust positions of Mix Alpha nodes

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -405,7 +405,7 @@ def base_color(
         if needs_alpha_factor:
             node = mh.node_tree.nodes.new('ShaderNodeMath')
             node.label = 'Alpha Factor'
-            node.location = x - 140, y - 200
+            node.location = x - 140, y - 230
             # Outputs
             mh.node_tree.links.new(alpha_socket, node.outputs[0])
             # Inputs
@@ -438,7 +438,7 @@ def base_color(
         if alpha_socket is not None:
             node = mh.node_tree.nodes.new('ShaderNodeMath')
             node.label = 'Mix Vertex Alpha'
-            node.location = x - 140, y - 200
+            node.location = x - 140, y - 230
             node.operation = 'MULTIPLY'
             # Outputs
             mh.node_tree.links.new(alpha_socket, node.outputs[0])


### PR DESCRIPTION
Very simple patch. Adjusts the position of Mix Alpha nodes in the Base Color node block to accommodate the taller Mix Color nodes in recent Blender versions.

Before (Mix nodes overlap):

![](https://github.com/KhronosGroup/glTF-Blender-IO/assets/11024420/7a1721c5-112e-488d-8e6d-0d53f135c77e)

After:

![](https://github.com/KhronosGroup/glTF-Blender-IO/assets/11024420/669f30ff-2ef5-4a6a-99d4-11ab9121489d)
