### PR TITLE
Updates for Blender Python API changes from Blender 3.2 to 4.1

### DIFF
--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_conversion.py
@@ -149,6 +149,13 @@ def get_attribute_type(component_type, data_type):
     else:
         pass
 
+def get_attribute(attributes, name, data_type, domain):
+    attribute = attributes.get(name)
+    if attribute is not None and attribute.data_type == data_type and attribute.domain == domain:
+        return attribute
+    else:
+        return None
+
 def get_gltf_interpolation(interpolation):
         return {
         "BEZIER": "CUBICSPLINE",

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -1163,7 +1163,7 @@ class PrimitiveCreator:
             self.normals = np.array(self.normals, dtype=np.float32)
         else:
             self.normals = np.empty(len(self.blender_mesh.loops) * 3, dtype=np.float32)
-            self.blender_mesh.loops.foreach_get('normal', self.normals)
+            self.blender_mesh.corner_normals.foreach_get('vector', self.normals)
 
         self.normals = self.normals.reshape(len(self.blender_mesh.loops), 3)
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -889,8 +889,15 @@ class PrimitiveCreator:
 
     def __get_positions(self):
         self.locs = np.empty(len(self.blender_mesh.vertices) * 3, dtype=np.float32)
-        source = self.key_blocks[0].relative_key.data if self.key_blocks else self.blender_mesh.vertices
-        source.foreach_get('co', self.locs)
+        if self.key_blocks:
+            source = self.key_blocks[0].relative_key.data
+            foreach_attribute = 'co'
+        else:
+            position_attribute = gltf2_blender_conversion.get_attribute(self.blender_mesh.attributes, 'position', 'FLOAT_VECTOR', 'POINT')
+            source = position_attribute.data if position_attribute else None
+            foreach_attribute = 'vector'
+        if source:
+            source.foreach_get(foreach_attribute, self.locs)
         self.locs = self.locs.reshape(len(self.blender_mesh.vertices), 3)
 
         self.morph_locs = []

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -1134,7 +1134,7 @@ class PrimitiveCreator:
     def __get_uvs_attribute(self, blender_uv_idx, attr):
         layer = self.blender_mesh.uv_layers[blender_uv_idx]
         uvs = np.empty(len(self.blender_mesh.loops) * 2, dtype=np.float32)
-        layer.data.foreach_get('uv', uvs)
+        layer.uv.foreach_get('vector', uvs)
         uvs = uvs.reshape(len(self.blender_mesh.loops), 2)
 
         # Blender UV space -> glTF UV space

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -892,7 +892,7 @@ class PrimitiveCreator:
     def __get_positions(self):
         self.locs = np.empty(len(self.blender_mesh.vertices) * 3, dtype=np.float32)
         if self.key_blocks:
-            source = self.key_blocks[0].relative_key.data
+            source = self.key_blocks[0].relative_key.points
             foreach_attribute = 'co'
         else:
             position_attribute = gltf2_blender_conversion.get_attribute(self.blender_mesh.attributes, 'position', 'FLOAT_VECTOR', 'POINT')
@@ -905,7 +905,7 @@ class PrimitiveCreator:
         self.morph_locs = []
         for key_block in self.key_blocks:
             vs = np.empty(len(self.blender_mesh.vertices) * 3, dtype=np.float32)
-            key_block.data.foreach_get('co', vs)
+            key_block.points.foreach_get('co', vs)
             vs = vs.reshape(len(self.blender_mesh.vertices), 3)
             self.morph_locs.append(vs)
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_primitives_extract.py
@@ -344,10 +344,12 @@ class PrimitiveCreator:
 
 
     def populate_dots_data(self):
-        vidxs = np.empty(len(self.blender_mesh.loops))
-        self.blender_mesh.loops.foreach_get('vertex_index', vidxs)
-        self.dots['vertex_index'] = vidxs
-        del vidxs
+        corner_vertex_indices = gltf2_blender_conversion.get_attribute(self.blender_mesh.attributes, '.corner_vert', 'INT', 'CORNER')
+        if corner_vertex_indices:
+            vidxs = np.empty(len(self.blender_mesh.loops), dtype=np.intc)
+            corner_vertex_indices.data.foreach_get('value', vidxs)
+            self.dots['vertex_index'] = vidxs
+            del vidxs
 
         for attr in self.blender_attributes:
             if 'skip_getting_to_dots' in attr:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -376,7 +376,7 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
 
             ob.shape_key_add(name=sk_name)
             key_block = mesh.shape_keys.key_blocks[sk_name]
-            key_block.data.foreach_set('co', squish(sk_vert_locs[sk_i]))
+            key_block.points.foreach_set('co', squish(sk_vert_locs[sk_i], np.float32))
 
             sk_i += 1
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -310,7 +310,8 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
     position_attribute.data.foreach_set('vector', squish(vert_locs, np.float32))
 
     mesh.loops.add(len(loop_vidxs))
-    mesh.loops.foreach_set('vertex_index', loop_vidxs)
+    corner_vert_attribute = attribute_ensure(mesh.attributes, '.corner_vert', 'INT', 'CORNER')
+    corner_vert_attribute.data.foreach_set('value', squish(loop_vidxs, np.intc))
 
     mesh.edges.add(len(edge_vidxs) // 2)
     mesh.edges.foreach_set('vertices', edge_vidxs)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -314,7 +314,8 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
     corner_vert_attribute.data.foreach_set('value', squish(loop_vidxs, np.intc))
 
     mesh.edges.add(len(edge_vidxs) // 2)
-    mesh.edges.foreach_set('vertices', edge_vidxs)
+    edge_verts_attribute = attribute_ensure(mesh.attributes, '.edge_verts', 'INT32_2D', 'EDGE')
+    edge_verts_attribute.data.foreach_set('value', squish(edge_vidxs, np.intc))
 
     mesh.polygons.add(num_faces)
 

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -693,7 +693,7 @@ def set_poly_smoothing(gltf, pymesh, mesh, vert_normals, loop_vidxs):
     poly_sharps = np.empty(num_polys, dtype=bool)
 
     poly_normals = np.empty(num_polys * 3, dtype=np.float32)
-    mesh.polygons.foreach_get('normal', poly_normals)
+    mesh.polygon_normals.foreach_get('vector', poly_normals)
     poly_normals = poly_normals.reshape(num_polys, 3)
 
     f = 0

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -321,9 +321,7 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
 
     # All polys are tris
     loop_starts = np.arange(0, 3 * num_faces, step=3)
-    loop_totals = np.full(num_faces, 3)
     mesh.polygons.foreach_set('loop_start', loop_starts)
-    mesh.polygons.foreach_set('loop_total', loop_totals)
 
     for uv_i in range(num_uvs):
         name = 'UVMap' if uv_i == 0 else 'UVMap.%03d' % uv_i

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -572,9 +572,10 @@ def points_edges_tris(mode, indices):
     return points, edges, tris
 
 
-def squish(array):
-    """Squish nD array into 1D array (required by foreach_set)."""
-    return array.reshape(array.size)
+def squish(array, dtype=None):
+    """Squish nD array into a C-contiguous (required for faster access with the buffer protocol in foreach_set) 1D array
+    (required by foreach_set). Optionally converting the array to a different dtype."""
+    return np.ascontiguousarray(array, dtype=dtype).reshape(array.size)
 
 
 def colors_rgb_to_rgba(rgb):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -334,14 +334,9 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
 
     for col_i in range(num_cols):
         name = 'Color' if col_i == 0 else 'Color.%03d' % col_i
-        layer = mesh.vertex_colors.new(name=name)
+        layer = mesh.color_attributes.new(name, 'BYTE_COLOR', 'CORNER')
 
-        if layer is None:
-            print("WARNING: Vertex colors are ignored because the maximum number of vertex color layers has been "
-                "reached.")
-            break
-
-        mesh.color_attributes[layer.name].data.foreach_set('color', squish(loop_cols[col_i]))
+        layer.data.foreach_set('color', squish(loop_cols[col_i], np.float32))
 
     # Make sure the first Vertex Color Attribute is the rendered one
     if num_cols > 0:

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -306,7 +306,8 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
     # Start creating things
 
     mesh.vertices.add(len(vert_locs))
-    mesh.vertices.foreach_set('co', squish(vert_locs))
+    position_attribute = attribute_ensure(mesh.attributes, 'position', 'FLOAT_VECTOR', 'POINT')
+    position_attribute.data.foreach_set('vector', squish(vert_locs, np.float32))
 
     mesh.loops.add(len(loop_vidxs))
     mesh.loops.foreach_set('vertex_index', loop_vidxs)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -390,7 +390,8 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
                 and 'mappings' in prim.extensions['KHR_materials_variants'].keys()
 
     if has_materials:
-        material_indices = np.empty(num_faces, dtype=np.uint32)
+        bl_material_index_dtype = np.intc
+        material_indices = np.empty(num_faces, dtype=bl_material_index_dtype)
         empty_material_slot_index = None
         f = 0
 
@@ -453,7 +454,8 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
                         vari = variant_primitive.variants.add()
                         vari.variant.variant_idx = variant
 
-        mesh.polygons.foreach_set('material_index', material_indices)
+        material_index_attribute = attribute_ensure(mesh.attributes, 'material_index', 'INT', 'FACE')
+        material_index_attribute.data.foreach_set('value', material_indices)
 
     # Custom Attributes
     for idx, attr in enumerate(attributes):

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -652,6 +652,15 @@ def normalize_vecs(vectors):
     norms = np.linalg.norm(vectors, axis=1, keepdims=True)
     np.divide(vectors, norms, out=vectors, where=norms != 0)
 
+def attribute_ensure(attributes, name, data_type, domain):
+    attribute = attributes.get(name)
+    if attribute is None:
+        return attributes.new(name, data_type, domain)
+    if attribute.domain == domain and attribute.data_type == data_type:
+        return attribute
+    # There is an existing attribute, but it has the wrong domain or data_type.
+    attributes.remove(attribute)
+    return attributes.new(name, data_type, domain)
 
 def set_poly_smoothing(gltf, pymesh, mesh, vert_normals, loop_vidxs):
     num_polys = len(mesh.polygons)

--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py
@@ -330,7 +330,7 @@ def do_primitives(gltf, mesh_idx, skin_idx, mesh, ob):
             print("WARNING: UV map is ignored because the maximum number of UV layers has been reached.")
             break
 
-        layer.data.foreach_set('uv', squish(loop_uvs[uv_i]))
+        layer.uv.foreach_set('vector', squish(loop_uvs[uv_i], np.float32))
 
     for col_i in range(num_cols):
         name = 'Color' if col_i == 0 else 'Color.%03d' % col_i


### PR DESCRIPTION
This PR contains a number of updates to use newer and non-deprecated
Blender APIs.

In most cases, the old APIs are emulated for backwards compatibility,
which makes them slower to access.

A couple of helper functions have been added for getting attributes and
`squish()` has been modified to ensure the result is C-contiguous and
optionally take an argument to change the dtype of the returned array.

No changes other than performance are expected.

This updates:
- `Mesh.vertex_colors` -> `Mesh.color_attributes`
- `MeshPolygon.material_index` -> 'material_index' attribute
- `MeshUVLoopLayer.data` -> `MeshUVLoopLayer.uv`
- `MeshVertex.co` -> 'position' attribute
- `MeshPolygon.use_smooth` -> 'sharp_face' attribute
- `MeshLoop.vertex_index` -> '.corner_vert' attribute
- `MeshEdge.vertices` -> '.edge_verts' attribute
- `MeshPolygon.loop_total` -> Removed because it is read-only now
- `ShapeKey.data` -> `ShapeKey.points`
- `MeshPolygon.normal` -> `Mesh.polygon_normals`
- `MeshLoop.normal` -> `Mesh.corner_normals`

---

The commits have been organised in the order in which the newer APIs were introduced. Please let me know if you would like this broken up into smaller PRs.