### PR TITLE
Import: remove make_output_nodes

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_unlit.py
+++ b/addons/io_scene_gltf2/blender/imp/gltf2_blender_KHR_materials_unlit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .gltf2_blender_pbrMetallicRoughness import base_color, make_output_nodes
+from .gltf2_blender_pbrMetallicRoughness import base_color
 
 
 def unlit(mh):


### PR DESCRIPTION
Follow up to #2128.

Most of `make_output_nodes` is now unused. Remove it, moving its sole responsibility, creation of the volume node, into the main metal-roughness shader creation function.

Should be a pure refactor with no change in behavior.