### PR TITLE
fix #1961 use bpy.context.window.scene instead of bpy.context.scene

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather.py
@@ -34,7 +34,7 @@ def gather_gltf2(export_settings):
     scenes = []
     animations = []  # unfortunately animations in gltf2 are just as 'root' as scenes.
     active_scene = None
-    store_user_scene = bpy.context.scene
+    store_user_scene = bpy.context.window.scene
     scenes_to_export = bpy.data.scenes if export_settings['gltf_active_scene'] is False else [scene for scene in bpy.data.scenes if scene.name == store_user_scene.name]
     for blender_scene in scenes_to_export:
         scenes.append(__gather_scene(blender_scene, export_settings))


### PR DESCRIPTION
Hi ! 
This is a tiny PR to fix #1961 
Ensures that the exporter uses ```bpy.context.window.scene``` instead of ```bpy.context.scene```
It also fixes additional issues when you create scenes to export dynamically , and bpy.context.scene does not sync with 
```bpy.context.window.scene``` (which , unlike the first, is user settable).

Thanks for this fantastic tool btw :)