### PR TITLE
Export: add NodeNav tool for navigating node trees

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_texture_info.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_texture_info.py
@@ -173,12 +173,13 @@ def __gather_normal_scale(primary_socket, export_settings):
 def __gather_occlusion_strength(primary_socket, export_settings):
     # Look for a MixRGB node that mixes with pure white in front of
     # primary_socket. The mix factor gives the occlusion strength.
-    node = previous_node(primary_socket)
-    if node and node.node.type == 'MIX' and node.node.blend_type == 'MIX':
-        fac = get_const_from_socket(NodeSocket(node.node.inputs['Factor'], node.group_path), kind='VALUE')
-        col1 = get_const_from_socket(NodeSocket(node.node.inputs[6], node.group_path), kind='RGB')
-        col2 = get_const_from_socket(NodeSocket(node.node.inputs[7], node.group_path), kind='RGB')
+    nav = primary_socket.to_node_nav()
+    nav.move_back()
+    if nav.moved and nav.node.type == 'MIX' and nav.node.blend_type == 'MIX':
+        fac = nav.get_constant('Factor')
         if fac is not None:
+            col1 = nav.get_constant('#A_Color')
+            col2 = nav.get_constant('#B_Color')
             if col1 == [1.0, 1.0, 1.0] and col2 is None:
                 return fac
             if col1 is None and col2 == [1.0, 1.0, 1.0]:

--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_search_node_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_search_node_tree.py
@@ -194,10 +194,209 @@ def get_socket_from_gltf_material_node(blender_material: bpy.types.Material, nam
 
     return NodeSocket(None, None)
 
+
+class NodeNav:
+    """Helper for navigating through node trees."""
+    def __init__(self, node, in_socket=None, out_socket=None):
+        self.node = node             # Current node
+        self.out_socket = in_socket  # Socket through which we arrived at this node
+        self.in_socket = out_socket  # Socket through which we will leave this node
+        self.stack = []              # Stack of (group node, socket) pairs descended through to arrive here
+        self.moved = False           # Whether the last move_back call moved back or not
+
+    def copy(self):
+        new = NodeNav(self.node)
+        new.assign(self)
+        return new
+
+    def assign(self, other):
+        self.node = other.node
+        self.in_socket = other.in_socket
+        self.out_socket = other.out_socket
+        self.stack = other.stack.copy()
+        self.moved = other.moved
+
+    def select_input_socket(self, in_soc):
+        """Selects an input socket.
+
+        Most operations that operate on the input socket can be passed an in_soc
+        parameter to select an input socket before running.
+        """
+        if in_soc is None:
+            # Keep current selected input socket
+            return
+        elif isinstance(in_soc, bpy.types.NodeSocket):
+            assert in_soc.node == self.node
+            self.in_socket = in_soc
+        elif isinstance(in_soc, int):
+            self.in_socket = self.node.inputs[in_soc]
+        else:
+            assert isinstance(in_soc, str)
+            # An identifier like "#A_Color" selects a socket by
+            # identifier. This is useful for sockets that cannot be
+            # selected because of non-unique names.
+            if in_soc.startswith('#'):
+                ident = in_soc.removeprefix('#')
+                for socket in self.node.inputs:
+                    if socket.identifier == ident:
+                        self.in_socket = socket
+                        return
+            # Select by regular name
+            self.in_socket = self.node.inputs[in_soc]
+
+    def get_out_socket_index(self):
+        assert self.out_socket
+        for i, soc in enumerate(self.node.outputs):
+            if soc == self.out_socket:
+                return i
+        assert False
+
+    def descend(self):
+        """Descend into a group node."""
+        if self.node and self.node.type == 'GROUP' and self.node.node_tree and self.out_socket:
+            i = self.get_out_socket_index()
+            self.stack.append((self.node, self.out_socket))
+            self.node = next(node for node in self.node.node_tree.nodes if node.type == 'GROUP_OUTPUT')
+            self.in_socket = self.node.inputs[i]
+            self.out_socket = None
+
+    def ascend(self):
+        """Ascend from a group input node back to the group node."""
+        if self.stack and self.node and self.node.type == 'GROUP_INPUT' and self.out_socket:
+            i = self.get_out_socket_index()
+            self.node, self.out_socket = self.stack.pop()
+            self.in_socket = self.node.inputs[i]
+
+    def move_back(self, in_soc=None):
+        """Move backwards through an input socket to the next node."""
+        self.moved = False
+
+        self.select_input_socket(in_soc)
+
+        if not self.in_socket or not self.in_socket.is_linked:
+            return
+
+        # Warning, slow! socket.links is O(total number of links)!
+        link = self.in_socket.links[0]
+
+        self.node = link.from_node
+        self.out_socket = link.from_socket
+        self.in_socket = None
+        self.moved = True
+
+        # Continue moving
+        if self.node.type == 'REROUTE':
+            self.move_back(0)
+        elif self.node.type == 'GROUP':
+            self.descend()
+            self.move_back()
+        elif self.node.type == 'GROUP_INPUT':
+            self.ascend()
+            self.move_back()
+
+    def peek_back(self, in_soc=None):
+        """Peeks backwards through an input socket without modifying self."""
+        s = self.copy()
+        s.select_input_socket(in_soc)
+        s.move_back()
+        return s
+
+    def get_constant(self, in_soc=None):
+        """Gets a constant from an input socket. Returns None if non-constant."""
+        self.select_input_socket(in_soc)
+
+        if not self.in_socket:
+            return None
+
+        # Get constant from unlinked socket's default value
+        if not self.in_socket.is_linked:
+            if self.in_socket.type == 'RGBA':
+                color = list(self.in_socket.default_value)
+                color = color[:3]  # drop unused alpha component (assumes shader tree)
+                return color
+
+            elif self.in_socket.type == 'SHADER':
+                # Treat unlinked shader sockets as black
+                return [0.0, 0.0, 0.0]
+
+            elif self.in_socket.type == 'VECTOR':
+                return list(self.in_socket.default_value)
+
+            elif self.in_socket.type == 'VALUE':
+                return self.in_socket.default_value
+
+            else:
+                return None
+
+        # Check for a constant in the next node
+        nav = self.peek_back()
+        if nav.moved:
+            if self.in_socket.type == 'RGBA':
+                if nav.node.type == 'RGB':
+                    color = list(nav.out_socket.default_value)
+                    color = color[:3]  # drop unused alpha component (assumes shader tree)
+                    return color
+
+            elif self.in_socket.type == 'VALUE':
+                if nav.node.type == 'VALUE':
+                    return nav.node.out_socket.default_value
+
+        return None
+
+    def get_factor(self, in_soc=None):
+        """Gets a factor, eg. metallicFactor. Either a constant or constant multiplier."""
+        self.select_input_socket(in_soc)
+
+        if not self.in_socket:
+            return None
+
+        # Constant
+        fac = self.get_constant()
+        if fac is not None:
+            return fac
+
+        # Multiplied by constant
+        nav = self.peek_back()
+        if nav.moved:
+            x1, x2 = None, None
+
+            if self.in_socket.type == 'RGBA':
+                is_mul = (
+                    nav.node.type == 'MIX' and
+                    nav.node.data_type == 'RGBA' and
+                    nav.node.blend_type == 'MULTIPLY'
+                )
+                if is_mul:
+                    # TODO: check factor is 1?
+                    x1 = nav.get_constant('#A_Color')
+                    x2 = nav.get_constant('#B_Color')
+
+            elif self.in_socket.type == 'VALUE':
+                if nav.node.type == 'MATH' and nav.node.operation == 'MULTIPLY':
+                    x1 = nav.get_constant(0)
+                    x2 = nav.get_constant(1)
+
+            if x1 is not None and x2 is None: return x1
+            if x2 is not None and x1 is None: return x2
+
+        return None
+
+
 class NodeSocket:
     def __init__(self, socket, group_path):
         self.socket = socket
         self.group_path = group_path
+
+    def to_node_nav(self):
+        assert self.socket
+        nav = NodeNav(
+            self.socket.node,
+            out_socket=self.socket if self.socket.is_output else None,
+            in_socket=self.socket if not self.socket.is_output else None,
+        )
+        # No output socket information
+        nav.stack = [(node, None) for node in self.group_path]
+        return nav
 
 class ShNode:
     def __init__(self, node, group_path):


### PR DESCRIPTION
Adds a new tool to the exporter for searching node trees called a NodeNav (name is up for discussion).

A NodeNav generalizes and unifies the current NodeSocket and ShNode classes. It holds

* a current node
* the output socket through which we arrived at the node
* the input socket where we're going to go next
* the stack of Group nodes we descended through to reach here

You can use it to move backwards through the node tree, like previous_node and previous_socket.

```py
nav.move_back('Base Color')         # moves backwards through the Base Color input
if nav.moved: ...                   # check whether the last move succeeded or not
nav2 = nav.peek_back('Base Color')  # like move_back, but returns a new NodeNav
nav.get_constant('Base Color')      # gets a constant like get_const_from_socket
```

and it handles tracking descent for you so you don't have to manage the group_path manually

```py
# Old
get_const_from_socket(NodeSocket(node.node.inputs[6], node.group_path), kind='RGB')
# New
nav.get_constant(6)
```

NodeNav is intended to eventually be able to replace all the tools in search_node_tree.py, but for now it coexists with them. Only a few places are converted to use it in this PR. This works by converting NodeSockets to NodeNavs.

There are two other nice features to note

1. You do not have to pass eg `kind='VALUE'` to get_constant, it detects this automatically based on the socket's type.
2. You can select sockets by *identifier* instead of name by prefixing the name with a `#`. This lets you select sockets with non-unique names that currently require an index.

    ```py
    # Eg. to select the A input to a Color Mix node
    nav.get_constant(6)           # select nav.node.inputs[6], poor readability
    nav.get_constant('A')         # doesn't work, there are multiple sockets named 'A'
    nav.get_constant('#A_Color')  # works!
    ```
