### PR TITLE
glTF embedded option

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -131,6 +131,25 @@ def on_export_action_filter_changed(self, context):
         del bpy.types.Scene.gltf_action_filter_active
 
 
+def get_format_items(scene, context):
+
+
+    items = (('GLB', 'glTF Binary (.glb)',
+                'Exports a single file, with all data packed in binary form. '
+                'Most efficient and portable, but more difficult to edit later'),
+               ('GLTF_SEPARATE', 'glTF Separate (.gltf + .bin + textures)',
+                'Exports multiple files, with separate JSON, binary and texture data. '
+                'Easiest to edit later'))
+
+    if bpy.context.preferences.addons['io_scene_gltf2'].preferences \
+            and bpy.context.preferences.addons['io_scene_gltf2'].preferences['allow_embedded_format']:
+            # At initialization, the preferences are not yet loaded
+        items += (('GLTF_EMBEDDED', 'glTF Embedded (.gltf)',
+                    'Exports a single file, with all data packed in JSON. '
+                    'Less efficient than binary, but easier to edit later'
+                ),)
+
+    return items
 
 
 class ConvertGLTF2_Base:
@@ -264,17 +283,12 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
 
     export_format: EnumProperty(
         name='Format',
-        items=(('GLB', 'glTF Binary (.glb)',
-                'Exports a single file, with all data packed in binary form. '
-                'Most efficient and portable, but more difficult to edit later'),
-               ('GLTF_SEPARATE', 'glTF Separate (.gltf + .bin + textures)',
-                'Exports multiple files, with separate JSON, binary and texture data. '
-                'Easiest to edit later')),
+        items=get_format_items,
         description=(
             'Output format. Binary is most efficient, '
             'but JSON may be easier to edit later'
         ),
-        default='GLB', #Warning => If you change the default, need to change the default filter too
+        default=0, #Warning => If you change the default, need to change the default filter too
         update=on_export_format_changed,
     )
 
@@ -1155,6 +1169,8 @@ class GLTF_PT_export_main(bpy.types.Panel):
             layout.prop(operator, 'export_keep_originals')
             if operator.export_keep_originals is False:
                 layout.prop(operator, 'export_texture_dir', icon='FILE_FOLDER')
+        if operator.export_format == 'GLTF_EMBEDDED':
+            layout.label(text="This is the least efficient of the available forms, and should only be used when required.", icon='ERROR')
 
         layout.prop(operator, 'export_copyright')
         layout.prop(operator, 'will_save_settings')
@@ -2122,6 +2138,12 @@ class GLTF_AddonPreferences(bpy.types.AddonPreferences):
         subtype='FILE_PATH'
     )
 
+    allow_embedded_format: bpy.props.BoolProperty(
+        default = False,
+        name='Allow glTF Embedded format',
+        description="Allow glTF Embedded format"
+    )
+
     def draw(self, context):
         layout = self.layout
         row = layout.row()
@@ -2130,6 +2152,10 @@ class GLTF_AddonPreferences(bpy.types.AddonPreferences):
         row.prop(self, "animation_ui", text="Animation UI")
         row = layout.row()
         row.prop(self, "gltfpack_path_ui", text="Path to gltfpack")
+        row = layout.row()
+        row.prop(self, "allow_embedded_format", text="Allow glTF Embedded format")
+        if self.allow_embedded_format:
+            layout.label(text="This is the least efficient of the available forms, and should only be used when required.", icon='ERROR')
 
 def menu_func_import(self, context):
     self.layout.operator(ImportGLTF2.bl_idname, text='glTF 2.0 (.glb/.gltf)')

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_export.py
@@ -117,8 +117,11 @@ def __create_buffer(exporter, export_settings):
     if export_settings['gltf_format'] == 'GLB':
         buffer = exporter.finalize_buffer(export_settings['gltf_filedirectory'], is_glb=True)
     else:
-        exporter.finalize_buffer(export_settings['gltf_filedirectory'],
-                                 export_settings['gltf_binaryfilename'])
+        if export_settings['gltf_format'] == 'GLTF_EMBEDDED':
+            exporter.finalize_buffer(export_settings['gltf_filedirectory'])
+        else:
+            exporter.finalize_buffer(export_settings['gltf_filedirectory'],
+                                     export_settings['gltf_binaryfilename'])
 
     return buffer
 

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gltf2_exporter.py
@@ -135,7 +135,7 @@ class GlTF2Exporter:
                     f.write(self.__buffer.to_bytes())
                 uri = buffer_name
             else:
-                pass # This is no more possible, we don't export embedded buffers
+                uri = self.__buffer.to_embed_string()
 
             buffer = gltf2_io.Buffer(
                 byte_length=self.__buffer.byte_length,

--- a/addons/io_scene_gltf2/io/exp/gltf2_io_buffer.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_buffer.py
@@ -59,3 +59,6 @@ class Buffer:
 
     def clear(self):
         self.__data = b""
+
+    def to_embed_string(self):
+        return 'data:application/octet-stream;base64,' + base64.b64encode(self.__data).decode('ascii')

--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -770,6 +770,19 @@ referenced by the ``.gltf`` file.
    Be aware that sharing this format requires sharing all of these separate files
    together as a group.
 
+glTF Embedded (``.gltf``)
+-------------------------
+
+This produces a JSON text-based ``.gltf`` file, with all mesh data and
+image data encoded (using Base64) within the file. This form is useful if
+the asset must be shared over a plain-text-only connection.
+
+.. warning::
+
+   This is the least efficient of the available forms, and should only be used when required.
+   Available only when you activated it in addon preferences.
+
+
 Properties
 ==========
 


### PR DESCRIPTION
Get glTF Embedded format back.

Because we don't recommend to use it when other alternative are possible ( .glb or .gltf separated), we put an option in addon user preferences to enable it.
By default, user will see only .glb and .gltf Separated. 