### PR TITLE
[WIP] Export: use nodes for Alpha clipping

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials.py
@@ -40,7 +40,8 @@ from .gltf2_blender_search_node_tree import \
     get_node_socket, \
     get_material_nodes, \
     NodeSocket, \
-    get_vertex_color_info
+    get_vertex_color_info, \
+    gather_alpha_info
 
 @cached
 def get_material_cache_key(blender_material, export_settings):
@@ -95,10 +96,15 @@ def gather_material(blender_material, export_settings):
         emission_strength = max(emissive_factor)
         emissive_factor = [f / emission_strength for f in emissive_factor]
 
+    alpha_socket = get_socket(blender_material, "Alpha")
+    if isinstance(alpha_socket.socket, bpy.types.NodeSocket):
+        alpha_info = gather_alpha_info(alpha_socket.to_node_nav())
+    else:
+        alpha_info = gather_alpha_info(None)
 
     material = gltf2_io.Material(
-        alpha_cutoff=__gather_alpha_cutoff(blender_material, export_settings),
-        alpha_mode=__gather_alpha_mode(blender_material, export_settings),
+        alpha_cutoff=__gather_alpha_cutoff(alpha_info, export_settings),
+        alpha_mode=__gather_alpha_mode(alpha_info, export_settings),
         double_sided=__gather_double_sided(blender_material, extensions, export_settings),
         emissive_factor=emissive_factor,
         emissive_texture=emissive_texture,
@@ -191,18 +197,16 @@ def __filter_material(blender_material, export_settings):
     return export_settings['gltf_materials']
 
 
-def __gather_alpha_cutoff(blender_material, export_settings):
-    if blender_material.blend_method == 'CLIP':
-        return blender_material.alpha_threshold
+def __gather_alpha_cutoff(alpha_info, export_settings):
+    if alpha_info['alphaMode'] == 'MASK':
+        cutoff = alpha_info['alphaCutoff']
+        return None if cutoff == 0.5 else cutoff
     return None
 
 
-def __gather_alpha_mode(blender_material, export_settings):
-    if blender_material.blend_method == 'CLIP':
-        return 'MASK'
-    elif blender_material.blend_method in ['BLEND', 'HASHED']:
-        return 'BLEND'
-    return None
+def __gather_alpha_mode(alpha_info, export_settings):
+    mode = alpha_info['alphaMode']
+    return None if mode == 'OPAQUE' else mode
 
 
 def __gather_double_sided(blender_material, extensions, export_settings):
@@ -379,11 +383,16 @@ def __export_unlit(blender_material, export_settings):
 
     base_color_texture, uvmap_info, udim_info = gltf2_unlit.gather_base_color_texture(info, export_settings)
 
+    if info.get('alpha_socket'):
+        alpha_info = gather_alpha_info(info['alpha_socket'].to_node_nav())
+    else:
+        alpha_info = gather_alpha_info(None)
+
     vc_info = get_vertex_color_info(info.get('rgb_socket'), info.get('alpha_socket'), export_settings)
 
     material = gltf2_io.Material(
-        alpha_cutoff=__gather_alpha_cutoff(blender_material, export_settings),
-        alpha_mode=__gather_alpha_mode(blender_material, export_settings),
+        alpha_cutoff=__gather_alpha_cutoff(alpha_info, export_settings),
+        alpha_mode=__gather_alpha_mode(alpha_info, export_settings),
         double_sided=__gather_double_sided(blender_material, {}, export_settings),
         extensions={"KHR_materials_unlit": Extension("KHR_materials_unlit", {}, required=False)},
         extras=__gather_extras(blender_material, export_settings),

--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials_pbr_metallic_roughness.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials_pbr_metallic_roughness.py
@@ -25,7 +25,8 @@ from .gltf2_blender_search_node_tree import \
     has_image_node_from_socket, \
     get_const_from_default_value_socket, \
     get_socket, \
-    get_factor_from_socket
+    get_factor_from_socket, \
+    gather_alpha_info
 
 @cached
 def gather_material_pbr_metallic_roughness(blender_material, orm_texture, export_settings):
@@ -71,10 +72,8 @@ def __gather_base_color_factor(blender_material, export_settings):
 
     alpha_socket = get_socket(blender_material, "Alpha")
     if isinstance(alpha_socket.socket, bpy.types.NodeSocket):
-        if export_settings['gltf_image_format'] != "NONE":
-            alpha = get_factor_from_socket(alpha_socket, kind='VALUE')
-        else:
-            alpha = get_const_from_default_value_socket(alpha_socket, kind='VALUE')
+        alpha_info = gather_alpha_info(alpha_socket.to_node_nav())
+        alpha = alpha_info['alphaFactor']
 
     base_color_socket = get_socket(blender_material, "Base Color")
     if base_color_socket.socket is None:

--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials_unlit.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials_unlit.py
@@ -18,7 +18,8 @@ from .gltf2_blender_search_node_tree import \
     NodeSocket, \
     previous_socket, \
     previous_node, \
-    get_factor_from_socket
+    get_factor_from_socket, \
+    gather_alpha_info
 
 def detect_shadeless_material(blender_material, export_settings):
     """Detect if this material is "shadeless" ie. should be exported
@@ -127,7 +128,8 @@ def gather_base_color_factor(info, export_settings):
     if 'rgb_socket' in info:
         rgb = get_factor_from_socket(info['rgb_socket'], kind='RGB')
     if 'alpha_socket' in info:
-        alpha = get_factor_from_socket(info['alpha_socket'], kind='VALUE')
+        alpha_info = gather_alpha_info(info['alpha_socket'].to_node_nav())
+        alpha = alpha_info['alphaFactor']
 
     if rgb is None: rgb = [1.0, 1.0, 1.0]
     if alpha is None: alpha = 1.0

--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_search_node_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_search_node_tree.py
@@ -382,6 +382,226 @@ class NodeNav:
         return None
 
 
+# Gather information about alpha from the Alpha socket. Alpha has the
+# general form
+#
+#  alpha = alpha_clip(factor * color attribute * texture)
+#
+# Alpha mode is determined by the nodes too (previously it used the
+# Eevee blend_method).
+def gather_alpha_info(alpha_nav):
+    info = {
+        'alphaMode': None,
+        'alphaCutoff': None,
+        'alphaFactor': None,
+        'alphaColorAttrib': None,
+    }
+    if not alpha_nav:
+        return info
+
+    # Opaque?
+    c = alpha_nav.get_constant()
+    if c == 1:
+        info['alphaMode'] = 'OPAQUE'
+        return info
+
+    # Check for alpha clipping
+    cutoff = detect_alpha_clip(alpha_nav)
+    if cutoff is not None:
+        info['alphaMode'] = 'MASK'
+        info['alphaCutoff'] = cutoff
+
+    # Reads the factor and color attribute by checking for variations on
+    # -> [Multiply by Factor] -> [Multiply by Color Attrib Alpha] ->
+
+    for _ in range(2):  # Twice, to handle both factor and attrib
+        # No factor found yet?
+        if info['alphaFactor'] is None:
+            a = alpha_nav.get_constant()
+            if a is not None:
+                info['alphaFactor'] = a
+                break
+
+            a = detect_multiply_by_constant(alpha_nav)
+            if a is not None:
+                info['alphaFactor'] = a
+                continue
+
+        # No color attrib found yet?
+        if info['alphaColorAttrib'] is None:
+            attr = get_color_attrib(alpha_nav)
+            if attr is not None:
+                info['alphaColorAttr'] = attr
+                break
+
+            attr = detect_multiply_by_color_attrib(alpha_nav)
+            if attr is not None:
+                info['alphaColorAttr'] = attr
+                continue
+
+        break
+
+    # Set alpha mode
+    if info['alphaMode'] is None:
+        # Is zero? Weird, but okay.
+        if info['alphaFactor'] == 0:
+            info['alphaMode'] = 'MASK'
+            info['alphaCutoff'] = 0.5
+        else:
+            info['alphaMode'] = 'BLEND'
+
+    return info
+
+
+# Detects a node setup for doing alpha clip/mask, ie.
+#
+# alpha = alpha >= cutoff ? 1.0 : 0.0
+#
+# If detected, alpha_nav is advanced to point to the new Alpha socket
+# and the alphaCutoff value is returned. Otherwise, returns None.
+#
+# Nodes will look like:
+#  Alpha -> [Math:Round] -> Alpha Socket
+#  Alpha -> [Math:X < cutoff] -> [Math:1 - X] -> Alpha Socket
+def detect_alpha_clip(alpha_nav):
+    nav = alpha_nav.peek_back()
+    if not nav.moved:
+        return None
+
+    # Detect [Math:Round]
+    if nav.node.type == 'MATH' and nav.node.operation == 'ROUND':
+        nav.select_input_socket(0)
+        alpha_nav.assign(nav)
+        return 0.5
+
+    # Detect 1 - (X < cutoff)
+    # (There is no >= node)
+    elif nav.node.type == 'MATH' and nav.node.operation == 'SUBTRACT':
+        if nav.get_constant(0) == 1.0:
+            nav2 = nav.peek_back(1)
+            if nav2.moved and nav2.node.type == 'MATH':
+                in0 = nav2.get_constant(0)
+                in1 = nav2.get_constant(1)
+                # X < cutoff
+                if nav2.node.operation == 'LESS_THAN' and in0 is None and in1 is not None:
+                    nav2.select_input_socket(0)
+                    alpha_nav.assign(nav2)
+                    return in1
+                # cutoff > X
+                elif nav2.node.operation == 'GREATER_THAN' and in0 is not None and in1 is None:
+                    nav2.select_input_socket(1)
+                    alpha_nav.assign(nav2)
+                    return in0
+
+    return None
+
+
+# When nav connects to a multiply node (A*B), returns NodeNavs that
+# point at both factors (A, B). Otherwise, returns None, None.
+#
+# Works for both colors and floats.
+def get_multiply_factors(nav):
+    prev = nav.peek_back()
+    if prev.moved:
+        if nav.in_socket.type == 'RGBA':
+            is_mul = (
+                prev.node.type == 'MIX' and
+                prev.node.data_type == 'RGBA' and
+                prev.node.blend_type == 'MULTIPLY' and
+                prev.get_constant('Fac') == 1
+            )
+            if is_mul:
+                fac1 = prev
+                fac1.select_input_socket('#A_Color')
+                fac2 = prev.copy()
+                fac2.select_input_socket('#B_Color')
+
+                return fac1, fac2
+
+        elif nav.in_socket.type == 'VALUE':
+            if prev.node.type == 'MATH' and prev.node.operation == 'MULTIPLY':
+                fac1 = prev
+                fac1.select_input_socket(0)
+                fac2 = prev.copy()
+                fac2.select_input_socket(1)
+
+                return fac1, fac2
+
+    return None, None
+
+
+# Detects if nav is multiplied by a constant. If detected, the constant
+# is returned, and nav is advanced to the other factor in the
+# multiplication. Otherwise, returns None.
+def detect_multiply_by_constant(nav):
+    fac1, fac2 = get_multiply_factors(nav)
+    if fac1 is None:
+        return None
+
+    c = fac1.get_constant()
+    if c is not None:
+        nav.assign(fac2)
+        return c
+
+    # Try other order too
+    c = fac2.get_constant()
+    if c is not None:
+        nav.assign(fac1)
+        return c
+
+    return None
+
+
+# Detects if nav is multiplied by a color attribute. If detected, the
+# color attribute name is returned, and nav is advanced to the other
+# factor in the multiplication. Otherwise, returns None.
+#
+# Note: ignores whether the multiplication is by the attribute's RGB or
+# Alpha.
+def detect_multiply_by_color_attrib(nav):
+    fac1, fac2 = get_multiply_factors(nav)
+    if fac1 is None:
+        return None
+
+    attr = get_color_attrib(fac1)
+    if attr is not None:
+        nav.assign(fac2)
+        return attr
+
+    # Try other order too
+    attr = get_color_attrib(fac2)
+    if attr is not None:
+        nav.assign(fac1)
+        return attr
+
+    return None
+
+
+# Checks if nav connects to a Color Attribute node. An Attribute node is
+# also accepted, but there's no check that the attribute is actually a
+# *color* attribute in that case.
+#
+# Returns the name of the color attribute if detected. Note that a blank
+# name, "", means to use the mesh's active render color attribute.
+# Otherwise, returns None.
+def get_color_attrib(nav):
+    nav = nav.peek_back()
+    if not nav.moved:
+        return None
+
+    if nav.node.type == 'VERTEX_COLOR':
+        return nav.node.layer_name
+
+    if nav.node.type == 'ATTRIBUTE':
+        if nav.node.attribute_type == 'GEOMETRY':
+            # Does NOT use color attribute when blank
+            name = nav.node.attribute_name
+            if name:
+                return name
+
+    return None
+
+
 class NodeSocket:
     def __init__(self, socket, group_path):
         self.socket = socket
@@ -641,22 +861,14 @@ def get_vertex_color_info(color_socket, alpha_socket, export_settings):
                     attribute_color_type = "name"
 
     if alpha_socket is not None and alpha_socket.socket is not None:
-        node = previous_node(alpha_socket)
-        if node.node is not None:
-            if node.node.type == 'MIX' and node.node.data_type == "FLOAT" and node.node.blend_type == 'MULTIPLY':
-                use_vc, attribute_alpha, use_active = get_attribute_name(NodeSocket(node.node.inputs[2], node.group_path), export_settings)
-                if use_vc is False:
-                    use_vc, attribute_alpha, use_active = get_attribute_name(NodeSocket(node.node.inputs[3], node.group_path), export_settings)
-                if use_vc is True and use_active is True:
-                    attribute_alpha_type = "active"
-                elif use_vc is True and use_active is None and attribute_alpha is not None:
-                    attribute_alpha_type = "name"
-            elif node.node.type in ["ATTRIBUTE", "VERTEX_COLOR"]:
-                use_vc, attribute_color, use_active = get_attribute_name(NodeSocket(node.node.outputs[0], node.group_path), export_settings)
-                if use_vc is True and use_active is True:
-                    attribute_color_type = "active"
-                elif use_vc is True and use_active is None and attribute_color is not None:
-                    attribute_color_type = "name"
+        alpha_info = gather_alpha_info(alpha_socket.to_node_nav())
+
+        if alpha_info['alphaColorAttrib'] == '':
+            attribute_alpha = None
+            attribute_alpha_type = 'active'
+        elif alpha_info['alphaColorAttrib'] is not None:
+            attribute_alpha = alpha_info['alphaColorAttrib']
+            attribute_alpha_type = 'name'
 
     return {"color": attribute_color, "alpha": attribute_alpha, "color_type": attribute_color_type, "alpha_type": attribute_alpha_type}
 


### PR DESCRIPTION
Does #2111 for the exporter.  
Uses nodes to determine the alpha mode and cutoff.

To export OPAQUE materials, just set Alpha to 1.

![](https://github.com/KhronosGroup/glTF-Blender-IO/assets/11024420/167229ea-0ceb-4cf2-a239-ea4e32b3523d)

To export MASK materials, use either `round(alpha)` or `1-(alpha < cutoff)`.

![](https://github.com/KhronosGroup/glTF-Blender-IO/assets/11024420/1cce8d3d-8c31-4558-af02-1113bb8f71c3)

(Constant 0 Alpha also exports as MASK.)

Other setups use BLEND.

----

Implemented by adding a `gather_alpha_info` function that parses all the info from nodes hanging off the Alpha socket *except* the texture. There are several utility functions to support it.

This should also solve #2110 for Alpha color attributes (not RGB colors).

Tested lightly for both Principled and unlit with stuff like

![](https://github.com/KhronosGroup/glTF-Blender-IO/assets/11024420/349e6b96-6d7b-4958-84e7-4bfb247183a7)