### PR TITLE
Fix #2189 - regression crash in GN lamp instance export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -193,7 +193,7 @@ def __gather_extensions(vnode, export_settings):
     extensions = {}
 
     blender_lamp = None
-    if export_settings["gltf_lights"] and vnode.blender_type == VExportNode.INSTANCE:
+    if export_settings["gltf_lights"] and vnode.blender_type == VExportNode.INSTANCE and vnode.data is not None:
         if vnode.data.type in LIGHTS:
             blender_lamp = vnode.data
     elif export_settings["gltf_lights"] and blender_object is not None and (blender_object.type == "LAMP" or blender_object.type == "LIGHT"):


### PR DESCRIPTION
Fix #2189 - regression crash in GN lamp instance export