### PR TITLE
fix invalid escape sequence

### DIFF
--- a/addons/io_scene_gltf2/io/exp/gltf2_io_image_data.py
+++ b/addons/io_scene_gltf2/io/exp/gltf2_io_image_data.py
@@ -32,9 +32,9 @@ class ImageData:
         return hash(self._data)
 
     def adjusted_name(self):
-        regex_dot = re.compile("\.")
+        regex_dot = re.compile(r"\.")
         adjusted_name = re.sub(regex_dot, "_", self.name)
-        new_name = "".join([char for char in adjusted_name if char not in "!#$&'()*+,/:;<>?@[\]^`{|}~"])
+        new_name = "".join([char for char in adjusted_name if char not in r"!#$&'()*+,/:;<>?@[\]^`{|}~"])
         return new_name
 
     @property


### PR DESCRIPTION
```cmd
C:\Program Files (x86)\Steam\steamapps\common\Blender\4.1\scripts\addons\io_scene_gltf2\io\exp\gltf2_io_image_data.py:25: DeprecationWarning: invalid escape sequence '\.'
  regex_dot = re.compile("\.")
C:\Program Files (x86)\Steam\steamapps\common\Blender\4.1\scripts\addons\io_scene_gltf2\io\exp\gltf2_io_image_data.py:27: DeprecationWarning: invalid escape sequence '\]'
  new_name = "".join([char for char in adjusted_name if char not in "!#$&'()*+,/:;<>?@[\]^`{|}~"])
```

Using `warnings.filterwarnings('error')`

```cmd
Blender 4.2.0 Alpha (hash c61ecf1f4094 built 2024-03-22 01:51:54)
Traceback (most recent call last):
  File "<string>", line 23, in <module>
  File "<string>", line 14, in func
  File "C:\blender\blender-4.2.0-alpha+main.c61ecf1f4094-windows.amd64-release\4.2\scripts\addons\io_scene_gltf2\io\exp\gltf2_io_image_data.py", line 25
    regex_dot = re.compile("\.")
                           ^^^^
SyntaxError: invalid escape sequence '\.'
```