### PR TITLE
Enable the Collection export feature

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
@@ -552,15 +552,24 @@ class VExportTree:
             if all([c.hide_render for c in self.nodes[uuid].blender_object.users_collection]):
                 return False
 
-        if self.export_settings['gltf_active_collection'] and not self.export_settings['gltf_active_collection_with_nested']:
-            found = any(x == self.nodes[uuid].blender_object for x in bpy.context.collection.objects)
+        # If we are given a collection, use all objects from it
+        if self.export_settings['gltf_collection']:
+            local_collection = bpy.data.collections.get((self.export_settings['gltf_collection'], None))
+            if not local_collection:
+                return False
+            found = any(x == self.nodes[uuid].blender_object for x in local_collection.all_objects)
             if not found:
                 return False
+        else:
+            if self.export_settings['gltf_active_collection'] and not self.export_settings['gltf_active_collection_with_nested']:
+                found = any(x == self.nodes[uuid].blender_object for x in bpy.context.collection.objects)
+                if not found:
+                    return False
 
-        if self.export_settings['gltf_active_collection'] and self.export_settings['gltf_active_collection_with_nested']:
-            found = any(x == self.nodes[uuid].blender_object for x in bpy.context.collection.all_objects)
-            if not found:
-                return False
+            if self.export_settings['gltf_active_collection'] and self.export_settings['gltf_active_collection_with_nested']:
+                found = any(x == self.nodes[uuid].blender_object for x in bpy.context.collection.all_objects)
+                if not found:
+                    return False
 
         if BLENDER_GLTF_SPECIAL_COLLECTION in bpy.data.collections and self.nodes[uuid].blender_object.name in \
                 bpy.data.collections[BLENDER_GLTF_SPECIAL_COLLECTION].objects:


### PR DESCRIPTION
This enables GLTF to be used as a Collection exporter [0].

To enable this, two general changes were made:
- The `export_scene.gltf` operator was configured on the File Handler
- A `collection` string property was added to the export Operator

This `collection` property is akin to the special `filepath` and
`directory` properties in that this is how Blender will communicate with
the addon. The string is simply the name of the collection to be used.

The layout is slightly changed when using Collection export: the various
"Limit To" options are not drawn/used. Feedback was received about this
during development, with our other exporters, where the users found them
confusing when the exporter was set on a collection. Basically, if a
collection exporter is being used, we assume the user really wants
everything regardless of selection or renderability etc.

[0] To test, go to `Collection Properties` -> `Exporters` -> `Add` and
select "glTF 2.0" after applying this patch.

