### PR TITLE
Fix #2216 fix gather light with full hierarchy

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -193,6 +193,9 @@ def __gather_extensions(vnode, export_settings):
     extensions = {}
 
     blender_lamp = None
+    if vnode.blender_type == VExportNode.COLLECTION:
+        return None
+
     if export_settings["gltf_lights"] and vnode.blender_type == VExportNode.INSTANCE and vnode.data is not None:
         if vnode.data.type in LIGHTS:
             blender_lamp = vnode.data


### PR DESCRIPTION
Possible fix for the crash when trying to access non-existing `type` attribute on `blender_object`. 
This is apparently happening because `Collection` nodes are being passed.