### PR TITLE
Active vertex color export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials.py
@@ -666,9 +666,9 @@ def get_base_material(material_idx, materials, export_settings):
             
             
     if export_settings['gltf_vertex_color'] == 'ACTIVE':
+        #if user requests it, will export active mesh vertex color, instead of material determined vertex color
     
         material_info["vc_info"] = {"color_type": "active", "alpha_type": "active"}
-        # VC will have alpha, if alpha is used or not
         material_info["vc_info"]["alpha_mode"] = "BLEND"
 
 

--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials.py
@@ -656,21 +656,13 @@ def get_base_material(material_idx, materials, export_settings):
             export_settings
         )
 
-    if material is None:
-        # If no material, the mesh can still have vertex color
+    if (material is None and export_settings['gltf_active_vertex_color_when_no_material'] is True) or (export_settings['gltf_vertex_color'] == 'ACTIVE'):
+        # If no material implementation, the mesh can still have vertex color
         # So, retrieving it if user request it
-        if export_settings['gltf_active_vertex_color_when_no_material'] is True:
-            material_info["vc_info"] = {"color_type": "active", "alpha_type": "active"}
-            # VC will have alpha, as there is no material to know if alpha is used or not
-            material_info["vc_info"]["alpha_mode"] = "BLEND"
-            
-            
-    if export_settings['gltf_vertex_color'] == 'ACTIVE':
-        #if user requests it, will export active mesh vertex color, instead of material determined vertex color
-    
         material_info["vc_info"] = {"color_type": "active", "alpha_type": "active"}
+        # VC will have alpha, as there is no material to know if alpha is used or not
         material_info["vc_info"]["alpha_mode"] = "BLEND"
-
+          
 
 
     return material, material_info

--- a/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/material/gltf2_blender_gather_materials.py
@@ -663,6 +663,14 @@ def get_base_material(material_idx, materials, export_settings):
             material_info["vc_info"] = {"color_type": "active", "alpha_type": "active"}
             # VC will have alpha, as there is no material to know if alpha is used or not
             material_info["vc_info"]["alpha_mode"] = "BLEND"
+            
+            
+    if export_settings['gltf_vertex_color'] == 'ACTIVE':
+    
+        material_info["vc_info"] = {"color_type": "active", "alpha_type": "active"}
+        # VC will have alpha, if alpha is used or not
+        material_info["vc_info"]["alpha_mode"] = "BLEND"
+
 
 
     return material, material_info


### PR DESCRIPTION
Noticed that setting vertex color in the exporter to "active' seems to do nothing, or at least not exporting alpha in any capacity
so had it default to exporting active vertex color and vertex alpha if this setting is chosen

There's another instance of gltf_vertex_color == ACTIVE being used elsewhere,as well as double implementation of "gltf_active_vertex_color_when_no_material' is True" seemingly, so I reimplemented this simply next to the seemingly functional reimplementation of "gltf_active_vertex_color_when_no_material' is True" with just a conditional