### PR TITLE
add additional search for external draco library in python module

### DIFF
--- a/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
@@ -60,7 +60,6 @@ def dll_path() -> Path:
 
     if path is None or library_name is None:
         print('WARNING', 'Unsupported platform {}, Draco mesh compression is unavailable'.format(sys.platform))
-        return None
 
     return path / library_name
 

--- a/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
@@ -14,9 +14,22 @@
 
 import os
 import sys
+import glob
 from pathlib import Path
 import bpy
 
+def find_draco_dll_in_module():
+    bpy_path = Path(bpy.__file__).resolve()
+    bpy_dir = bpy_path.parents[4]
+    lib_dir = bpy_dir / 'lib'
+    
+    draco_files = glob.glob(str(lib_dir / 'libextern_draco.*'))
+    
+    if draco_files:
+        return Path(draco_files[0])
+    else:
+        return None
+    
 def dll_path() -> Path:
     """
     Get the DLL path depending on the underlying platform.
@@ -28,6 +41,7 @@ def dll_path() -> Path:
     python_version = 'python{v[0]}.{v[1]}'.format(v=sys.version_info)
 
     path = os.environ.get('BLENDER_EXTERN_DRACO_LIBRARY_PATH')
+    path = find_draco_dll_in_module()
     if path is None:
         path = {
             'win32': blender_root / python_lib / 'site-packages',

--- a/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
@@ -18,6 +18,11 @@ from pathlib import Path
 import bpy
 
 def find_draco_dll_in_module(library_name: str) -> Path:
+    """
+    Get the extern Draco library if it exist in the default location used when
+    build PYthon as a module
+    :return: DLL/shared library path.
+    """
     bpy_path = Path(bpy.__file__).resolve()
     bpy_dir = bpy_path.parents[4]
     lib_dir = bpy_dir / 'lib'

--- a/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
@@ -35,17 +35,17 @@ def dll_path() -> Path:
     """
     lib_name = 'extern_draco'
     blender_root = Path(bpy.app.binary_path).parent
-    python_lib = Path(f'{bpy.app.version[0]}.{bpy.app.version[1]}/python/lib')
-    python_version = f'python{sys.version_info[0]}.{sys.version_info[1]}'
+    python_lib = Path('{v[0]}.{v[1]}/python/lib'.format(v=bpy.app.version))
+    python_version = 'python{v[0]}.{v[1]}'.format(v=sys.version_info)
 
     path = os.environ.get('BLENDER_EXTERN_DRACO_LIBRARY_PATH')
     if path is not None:
         return Path(path)
 
     library_name = {
-        'win32': f'{lib_name}.dll',
-        'linux': f'lib{lib_name}.so',
-        'darwin': f'lib{lib_name}.dylib'
+        'win32': '{}.dll'.format(lib_name),
+        'linux': 'lib{}.so'.format(lib_name),
+        'darwin': 'lib{}.dylib'.format(lib_name)
     }.get(sys.platform)
 
     path = find_draco_dll_in_module(library_name)
@@ -59,7 +59,7 @@ def dll_path() -> Path:
     }.get(sys.platform)
 
     if path is None or library_name is None:
-        print(f'WARNING: Unsupported platform {sys.platform}, Draco mesh compression is unavailable')
+        print('WARNING', 'Unsupported platform {}, Draco mesh compression is unavailable'.format(sys.platform))
         return None
 
     return path / library_name


### PR DESCRIPTION
**Problem:** 
Building Blender as a Python module does not support Draco compression when exporting using gltf. This is important for my application but has also been brought up on forums and as issue [113469](https://projects.blender.org/blender/blender/issues/113469)

**Solution:**
Blender cmake files will need to be updated to lift restrictions on building the external Draco library when also setting `WITH_PYTHON_MODULE=ON`. I have submitted a separate PR to `projects.blender.org` to address this here: https://projects.blender.org/blender/blender/pulls/125556

[glTF-Blender-IO](https://github.com/KhronosGroup/glTF-Blender-IO) will need to perform an additional search for Draco library in the usual Python module location. Note users can set `BLENDER_EXTERN_DRACO_LIBRARY_PATH` but this additional search streamlines the usage of Draco compression when using Python as a module. The proposed search uses an extension wildcard so it should word cross-platorm.

Test confirming Draco compression is enable if `libextern_draco.dylib` is present in `[bpy_dir]/lib`:
```python
bpy.ops.export_scene.gltf(
    filepath=os.path.join('/tmp', 'draco_test.glb'),
    export_format='GLB',
    export_apply=True,
    use_visible=True,
    export_draco_mesh_compression_enable=True
)
```

```bash
gltf-transform inspect /tmp/draco_test.glb

 OVERVIEW
 ────────────────────────────────────────────
┌────────────────────┬───────────────────────────────────────────────────┐
│ key                │ value                                             │
├────────────────────┼───────────────────────────────────────────────────┤
│ version            │ 2.0                                               │
├────────────────────┼───────────────────────────────────────────────────┤
│ generator          │ Khronos glTF Blender I/O v4.2.57                  │
├────────────────────┼───────────────────────────────────────────────────┤
│ extensionsUsed     │ KHR_draco_mesh_compression, KHR_texture_transform │
├────────────────────┼───────────────────────────────────────────────────┤
│ extensionsRequired │ KHR_draco_mesh_compression, KHR_texture_transform │
└────────────────────┴───────────────────────────────────────────────────┘
```
```