### PR TITLE
Account for library when gathering image URI

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/image.py
+++ b/addons/io_scene_gltf2/blender/exp/material/image.py
@@ -56,7 +56,11 @@ def gather_image(
         uri, factor_uri = __gather_uri(image_data, mime_type, name, export_settings)
     else:
         # Retrieve URI relative to exported glTF files
-        uri = __gather_original_uri(image_data.original.filepath, export_settings)
+        uri = __gather_original_uri(
+            image_data.original.filepath,
+            blender_shader_sockets[0].socket.id_data.library,
+            export_settings
+        )
         # In case we can't retrieve image (for example packed images, with original moved)
         # We don't create invalid image without uri
         factor_uri = None
@@ -81,9 +85,9 @@ def gather_image(
     # We also return image_data, as it can be used to generate same file with another extension for WebP management
     return image, image_data, factor, None
 
-def __gather_original_uri(original_uri, export_settings):
+def __gather_original_uri(original_uri, library, export_settings):
+    path_to_image = bpy.path.abspath(original_uri, library=library)
 
-    path_to_image = bpy.path.abspath(original_uri)
     if not os.path.exists(path_to_image): return None
     try:
         rel_path = os.path.relpath(


### PR DESCRIPTION
When exporting a scene that has linked objects with materials that have relative paths to images, the absolute path of those images was being determined by taking that path relative to the current scene's path, instead of relative to the original path of the library, which would result in the images not being found if the current scene and the library weren't in the same directory. This PR fixes that.