### PR TITLE
Minimal fix for #2302

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_tree.py
@@ -461,7 +461,7 @@ class VExportTree:
         for child in self.nodes[uuid].children:
             if self.nodes[uuid].blender_type == VExportNode.INST_COLLECTION or self.nodes[uuid].is_instancier == VExportNode.INSTANCIER:
                 # We need to split children into 2 categories: real children, and objects inside the collection
-                if self.nodes[uuid].children_type[child] == VExportNode.CHILDREN_IS_IN_COLLECTION:
+                if self.nodes[uuid].children_type.get(child, VExportNode.CHILDREN_REAL) == VExportNode.CHILDREN_IS_IN_COLLECTION:
                     self.recursive_filter_tag(child, self.nodes[uuid].keep_tag)
                 else:
                     self.recursive_filter_tag(child, parent_keep_tag)


### PR DESCRIPTION
This fixes #2302. It exports the GN object mesh even if that's not included in the output, but that's a [different bug](https://github.com/KhronosGroup/glTF-Blender-IO/issues/2309).