### PR TITLE
Note requirements for exact class names

### DIFF
--- a/example-addons/example_gltf_exporter_extension/__init__.py
+++ b/example-addons/example_gltf_exporter_extension/__init__.py
@@ -56,6 +56,7 @@ def draw(context, layout):
         body.prop(props, 'float_property', text="Some float value")
 
 
+# Note: the class must have this exact name
 class glTF2ExportUserExtension:
 
     def __init__(self):

--- a/example-addons/example_gltf_exporter_extension/readme.md
+++ b/example-addons/example_gltf_exporter_extension/readme.md
@@ -1,6 +1,6 @@
 Here you'll find information on how to add extensions to a glTF file from an external Blender addon.
 
-Add a class named `gltf2ExportUserExtension` to your addon and instantiate an object of the class `io_scene_gltf2.io.com.gltf2_io_extensions.Extension`
+Add a class named `gltf2ExportUserExtension` (must be this name) to your addon and instantiate an object of the class `io_scene_gltf2.io.com.gltf2_io_extensions.Extension`
 
 ```python
 class glTF2ExportUserExtension:

--- a/example-addons/example_gltf_importer_extension/__init__.py
+++ b/example-addons/example_gltf_importer_extension/__init__.py
@@ -45,6 +45,7 @@ def draw(context, layout):
         body.prop(props, 'float_property', text="Some float value")
 
 
+# Note: the class must have this exact name
 class glTF2ImportUserExtension:
 
     def __init__(self):

--- a/example-addons/example_gltf_importer_extension/readme.md
+++ b/example-addons/example_gltf_importer_extension/readme.md
@@ -1,5 +1,6 @@
 Here you'll find information on how to add importer extensions from a glTF file from an external Blender addon.
 
+First, your importer must define a class with this exact name:
 
 ```python
 class glTF2ImportUserExtension:


### PR DESCRIPTION
The example docs and code previously did not make it clear that the exact class names must be used for the add-on extension to function.