### PR TITLE
Describe mesh_node_idx more clearly

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/vnode.py
@@ -60,7 +60,7 @@ class VNode:
         self.rotation_after = Quaternion((1, 0, 0, 0))
         self.rotation_before = Quaternion((1, 0, 0, 0))
 
-        # Indices of the glTF node where the mesh, etc. came from.
+        # Index in the glTF "nodes" array where this mesh/camera/light came from
         # (They can get moved around.)
         self.mesh_node_idx = None
         self.camera_node_idx = None


### PR DESCRIPTION
The previous comment made it unclear whether `mesh_node_idx` refers to the index in the `meshes` array or the `nodes` array.

Further, the use of the word "Indices" implies that multiple, different index values are present for a single VNode. As best as I can tell, two of the three attributes will always be `None`, with only one attribute getting the index in the "nodes" collection, depending on the type of object (camera, light, or "mesh" node).