### PR TITLE
Fix #2351 - fix copy/past typo in hook

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/animation/fcurves/channels.py
+++ b/addons/io_scene_gltf2/blender/exp/animation/fcurves/channels.py
@@ -295,7 +295,7 @@ def __gather_animation_fcurve_channel(obj_uuid: str,
         )
 
         blender_object = export_settings['vtree'].nodes[obj_uuid].blender_object
-        export_user_extensions('animation_gather_fcurve_channel_target', export_settings, blender_object, bone)
+        export_user_extensions('animation_gather_fcurve_channel', export_settings, blender_object, bone, channel_group)
 
 
         return animation_channel

--- a/example-addons/example_gltf_exporter_extension/readme.md
+++ b/example-addons/example_gltf_exporter_extension/readme.md
@@ -62,6 +62,7 @@ animation_gather_sk_channels(self, blender_object, blender_action_name, export_s
 animation_gather_sk_channel(self, blender_object, blender_action_name, export_settings)
 animation_gather_fcurve_channel_target(self, blender_object, bone_name, export_settings)
 animation_gather_fcurve_channel_sampler(self, blender_object, bone_name, export_settings)
+animation_gather_fcurve_channel(self, blender_object, bone_name, channel_group, export_settings)
 gather_gltf_hook(self, active_scene_idx, scenes, animations, export_settings)
 gather_gltf_encoded_hook(self, gltf_format, sort_order, export_settings)
 gather_tree_filter_tag_hook(self, tree, export_settings)


### PR DESCRIPTION
Fix #2351 - fix copy/past typo in hook