### PR TITLE
Fix stdout spam

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -991,6 +991,12 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
         default=False
     )
 
+    export_loglevel: IntProperty(
+        name='Log Level',
+        description="Log Level",
+        default=-1,
+    )
+
     # Custom scene property for saving settings
     scene_key = "glTF2ExportSettings"
 
@@ -1076,7 +1082,11 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
         # All custom export settings are stored in this container.
         export_settings = {}
 
-        export_settings['loglevel'] = set_debug_log()
+        # Get log level from parameters
+        # If not set, get it from Blender app debug value
+        export_settings['gltf_loglevel'] = self.export_loglevel
+        if export_settings['gltf_loglevel'] < 0:
+            export_settings['loglevel'] = set_debug_log()
 
         export_settings['exported_images'] = {}
         export_settings['exported_texture_nodes'] = []

--- a/addons/io_scene_gltf2/io/com/debug.py
+++ b/addons/io_scene_gltf2/io/com/debug.py
@@ -19,6 +19,7 @@
 import time
 import logging
 import logging.handlers
+import sys
 
 #
 # Globals
@@ -75,22 +76,30 @@ def profile_end(label=None):
 class Log:
     def __init__(self, loglevel):
         self.logger = logging.getLogger('glTFImporter')
+        self.error_logger = logging.getLogger('glTFImporter_errors')
 
         # For console display
-        self.console_handler = logging.StreamHandler()
+        self.console_handler = logging.StreamHandler(sys.stdout)
         formatter = logging.Formatter('%(asctime)s | %(levelname)s: %(message)s', "%H:%M:%S")
         self.console_handler.setFormatter(formatter)
+
+        # For console display - errors
+        self.error_console_handler = logging.StreamHandler(sys.stderr)
+        formatter_error = logging.Formatter('%(asctime)s | %(levelname)s: %(message)s', "%H:%M:%S")
+        self.error_console_handler.setFormatter(formatter_error)
 
         # For popup display
         self.popup_handler = logging.handlers.MemoryHandler(1024 * 10)
 
         self.logger.addHandler(self.console_handler)
+        self.error_logger.addHandler(self.error_console_handler)
         # self.logger.addHandler(self.popup_handler) => Make sure to not attach the popup handler to the logger
 
         self.logger.setLevel(int(loglevel))
+        self.error_logger.setLevel(logging.ERROR)
 
     def error(self, message, popup=False):
-        self.logger.error(message)
+        self.error_logger.error(message)
         if popup:
             self.popup_handler.buffer.append(('ERROR', message))
 
@@ -110,7 +119,7 @@ class Log:
             self.popup_handler.buffer.append(('DEBUG', message))
 
     def critical(self, message, popup=False):
-        self.logger.critical(message)
+        self.error_logger.critical(message)
         if popup:
             # There is no Critical level in Blender, so we use error
             self.popup_handler.buffer.append(('ERROR', message))
@@ -125,5 +134,6 @@ class Log:
 
     def flush(self):
         self.logger.removeHandler(self.console_handler)
+        self.error_logger.removeHandler(self.error_console_handler)
         self.popup_handler.flush()
         self.logger.removeHandler(self.popup_handler)


### PR DESCRIPTION
2 main enhancements here:

- error log will go to stderr, and others to stdout
- A new parameter in operator to set the loglevel from command line bpy.ops.export_scene.gltf(loglevel=logging.INFO)
- If not set from the ops, value is -1, and is set, as before, from the bpy.app.debug_value