### PR TITLE
Fix sampling step alignement

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/animation/action.py
+++ b/addons/io_scene_gltf2/blender/exp/animation/action.py
@@ -14,6 +14,7 @@
 
 import bpy
 import typing
+from math import ceil
 from ....io.com import gltf2_io
 from ....io.exp.user_extensions import export_user_extensions
 from ....blender.com.conversion import get_gltf_interpolation
@@ -75,10 +76,26 @@ def gather_actions_animations(export_settings):
 
     return new_animations
 
+# We need to align if step is not 1
+# For example, cache will get frame 1/4/7/10 if step is 3, with an action starting at frame 1
+# If all backing is enabled, and scene start at 0, we will get frame 0/3/6/9 => Cache will fail
+# Set the reference frame from the first action retrieve, and align all actions to this frame
+def _align_frame_start(reference_frame_start, frame, export_settings):
+
+    if reference_frame_start is None:
+        return frame
+
+    if export_settings['gltf_frame_step'] == 1:
+        return frame
+
+    return reference_frame_start + export_settings['gltf_frame_step'] * ceil((frame - reference_frame_start) / export_settings['gltf_frame_step'])
+
 
 def prepare_actions_range(export_settings):
 
     track_slide = {}
+
+    start_frame_reference = None
 
     vtree = export_settings['vtree']
     for obj_uuid in vtree.get_all_objects():
@@ -124,8 +141,16 @@ def prepare_actions_range(export_settings):
                 start_frame = max(bpy.context.scene.frame_start, start_frame)
                 end_frame = min(bpy.context.scene.frame_end, end_frame)
 
-            export_settings['ranges'][obj_uuid][blender_action.name]['start'] = start_frame
+            export_settings['ranges'][obj_uuid][blender_action.name]['start'] = _align_frame_start(start_frame_reference, start_frame, export_settings)
             export_settings['ranges'][obj_uuid][blender_action.name]['end'] = end_frame
+
+            if start_frame_reference is None:
+                start_frame_reference = start_frame
+
+                # Recheck all actions to align to this frame
+                for obj_uuid_tmp in export_settings['ranges'].keys():
+                    for action_name_tmp in export_settings['ranges'][obj_uuid_tmp].keys():
+                        export_settings['ranges'][obj_uuid_tmp][action_name_tmp]['start'] = _align_frame_start(start_frame_reference, export_settings['ranges'][obj_uuid_tmp][action_name_tmp]['start'], export_settings)
 
             if export_settings['gltf_negative_frames'] == "SLIDE":
                 if track is not None:
@@ -163,7 +188,7 @@ def prepare_actions_range(export_settings):
 
             if type_ == "SHAPEKEY" and export_settings['gltf_bake_animation']:
                 export_settings['ranges'][obj_uuid][obj_uuid] = {}
-                export_settings['ranges'][obj_uuid][obj_uuid]['start'] = bpy.context.scene.frame_start
+                export_settings['ranges'][obj_uuid][obj_uuid]['start'] = _align_frame_start(start_frame_reference, bpy.context.scene.frame_start, export_settings)
                 export_settings['ranges'][obj_uuid][obj_uuid]['end'] = bpy.context.scene.frame_end
 
             # For baking drivers
@@ -173,7 +198,7 @@ def prepare_actions_range(export_settings):
                     if obj_dr not in export_settings['ranges']:
                         export_settings['ranges'][obj_dr] = {}
                     export_settings['ranges'][obj_dr][obj_uuid + "_" + blender_action.name] = {}
-                    export_settings['ranges'][obj_dr][obj_uuid + "_" + blender_action.name]['start'] = start_frame
+                    export_settings['ranges'][obj_dr][obj_uuid + "_" + blender_action.name]['start'] = _align_frame_start(start_frame_reference, start_frame, export_settings)
                     export_settings['ranges'][obj_dr][obj_uuid + "_" + blender_action.name]['end'] = end_frame
 
         if len(blender_actions) == 0 and export_settings['gltf_bake_animation']:
@@ -181,7 +206,7 @@ def prepare_actions_range(export_settings):
             # In case of baking animation, we will use scene frame range
             # Will be calculated later if max range. Can be set here if scene frame range
             export_settings['ranges'][obj_uuid][obj_uuid] = {}
-            export_settings['ranges'][obj_uuid][obj_uuid]['start'] = bpy.context.scene.frame_start
+            export_settings['ranges'][obj_uuid][obj_uuid]['start'] = _align_frame_start(start_frame_reference, bpy.context.scene.frame_start, export_settings)
             export_settings['ranges'][obj_uuid][obj_uuid]['end'] = bpy.context.scene.frame_end
 
             # For baking drivers
@@ -192,7 +217,7 @@ def prepare_actions_range(export_settings):
                         export_settings['ranges'][obj_dr] = {}
                     export_settings['ranges'][obj_dr][obj_uuid + "_" + obj_uuid] = {}
                     export_settings['ranges'][obj_dr][obj_uuid + "_" +
-                                                      obj_uuid]['start'] = bpy.context.scene.frame_start
+                                                      obj_uuid]['start'] = _align_frame_start(start_frame_reference, bpy.context.scene.frame_start, export_settings)
                     export_settings['ranges'][obj_dr][obj_uuid + "_" + obj_uuid]['end'] = bpy.context.scene.frame_end
 
     if (export_settings['gltf_negative_frames'] == "SLIDE"


### PR DESCRIPTION
Root issue is having a sampling step different than 1, and full object baking enable.

Step is 3
Action starts at 1, so the action will try to export frames 1 / 4 / 7 / 10, etc...
But full object backing is enable, and scene starts at 0.
So cached data are on frame 0 / 3 / 6 / 9 / 12, etc...

When we are trying to export the action on armature after the full bake on empty, we are trying to retrieve frame 1, but cache was on 0 / 3 / 6 / 9

Workaround before I fix it:

    Set step at 1 (probably not what you want)
    Keep step at 3, but start scene at 1 instead of 0 => This will align the cache to same values
