### PR TITLE
Diffuse bsdf export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/pbr_metallic_roughness.py
+++ b/addons/io_scene_gltf2/blender/exp/material/pbr_metallic_roughness.py
@@ -24,6 +24,7 @@ from .search_node_tree import \
     has_image_node_from_socket, \
     get_const_from_default_value_socket, \
     get_socket, \
+    get_node_socket, \
     get_factor_from_socket, \
     gather_alpha_info, \
     gather_color_info
@@ -96,6 +97,8 @@ def __gather_base_color_factor(blender_material, export_settings):
     if base_color_socket.socket is None:
         base_color_socket = get_socket_from_gltf_material_node(
             blender_material.node_tree, blender_material.use_nodes, "BaseColorFactor")
+    if base_color_socket.socket is None:
+        base_color_socket = get_node_socket(blender_material.node_tree, bpy.types.ShaderNodeBsdfDiffuse, "Color")
     if base_color_socket.socket is not None and isinstance(base_color_socket.socket, bpy.types.NodeSocket):
         if export_settings['gltf_image_format'] != "NONE":
             rgb_vc_info = gather_color_info(base_color_socket.to_node_nav())
@@ -144,6 +147,8 @@ def __gather_base_color_texture(blender_material, export_settings):
     if base_color_socket.socket is None:
         base_color_socket = get_socket_from_gltf_material_node(
             blender_material.node_tree, blender_material.use_nodes, "BaseColor")
+    if base_color_socket.socket is None:
+        base_color_socket = get_node_socket(blender_material.node_tree, bpy.types.ShaderNodeBsdfDiffuse, "Color")
 
     alpha_socket = get_socket(blender_material.node_tree, blender_material.use_nodes, "Alpha")
 

--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -119,9 +119,9 @@ The material export process handles the settings described below.
 Base Color
 ^^^^^^^^^^
 
-The glTF base color is determined by looking for a Base Color input on a Principled BSDF node.
-If the input is unconnected, the input's default color (the color field next to the unconnected socket)
-is used as the Base Color for the glTF material.
+The glTF base color is determined by looking for a Base Color input on a Principled BSDF node
+or a Color input on a Diffuse BSDF node. If the input is unconnected, the input's default color
+(the color field next to the unconnected socket) is used as the Base Color for the glTF material.
 
 .. figure:: /images/addons_import-export_scene-gltf2_material-base-color-solid-green.png
 


### PR DESCRIPTION
This addresses #2448. 

- No change in test pass rate before and after.
- Exporting and then importing in blender produces expected results.
- Added relevant documentation.

Roughness was not added as I felt that it wouldn't reflect what the user is expecting and goes against the principle of least astonishment.

Code uses get_node_socket with the ShaderNodeBsdfDiffuse type after all other attempts of loading Color have failed.