### PR TITLE
Collection Exporter: set collection custom prop as glTF scene extras

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gather.py
+++ b/addons/io_scene_gltf2/blender/exp/gather.py
@@ -139,5 +139,9 @@ def __gather_scene(blender_scene, export_settings):
 
 def __gather_extras(blender_object, export_settings):
     if export_settings['gltf_extras']:
+        # If case of collection export, use custom properties of the collection instead of the scene
+        # So Collection custom properties are exported as glTF Scene extras
+        if export_settings['gltf_collection']:
+            return generate_extras(bpy.data.collections[export_settings['gltf_collection']])
         return generate_extras(blender_object)
     return None

--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -1152,6 +1152,7 @@ Here are the options & specificity for collection export:
 
 - Include part of options are not available for collection exporter (like every other exporter).
 - Option to export at collection center (at center of mass of all root objects of the collection).
+- Custom Properties of the collection are exported as Scene glTF extras.
 
 
 Contributing


### PR DESCRIPTION
For collection export, it makes sense to use the collection custom properties, and to use them as glTF Scene extras