### PR TITLE
New way of registering UI for hooks + example

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -1055,21 +1055,6 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
                 self.report({"ERROR"}, "Loading export settings failed. Removed corrupted settings")
                 del context.scene[self.scene_key]
 
-        import sys
-        preferences = bpy.context.preferences
-        for addon_name in preferences.addons.keys():
-            try:
-                if hasattr(
-                        sys.modules[addon_name],
-                        'glTF2ExportUserExtension') or hasattr(
-                        sys.modules[addon_name],
-                        'glTF2ExportUserExtensions'):
-                    exporter_extension_layout_draw[addon_name] = sys.modules[addon_name].draw_export if hasattr(
-                        sys.modules[addon_name], 'draw_export') else sys.modules[addon_name].draw
-            except Exception:
-                pass
-
-        self.has_active_exporter_extensions = len(exporter_extension_layout_draw.keys()) > 0
         return ExportHelper.invoke(self, context, event)
 
     def save_settings(self, context):

--- a/example-addons/example_gltf_exporter_extension/__init__.py
+++ b/example-addons/example_gltf_exporter_extension/__init__.py
@@ -37,15 +37,41 @@ class ExampleExtensionProperties(bpy.types.PropertyGroup):
         )
 
 def register():
+    # Register the properties
     bpy.utils.register_class(ExampleExtensionProperties)
+
+    # If you plan to use the Scene Exporter (File => Export => glTF 2.0), you probably want to register the properties to the scene
     bpy.types.Scene.ExampleExtensionProperties = bpy.props.PointerProperty(type=ExampleExtensionProperties)
 
+    # If you plan to use Collection Exporters, you may want to register the properties to the collection, instead of the scene
+    # bpy.types.Collection.ExampleExtensionProperties = bpy.props.PointerProperty(type=ExampleExtensionProperties)
+
+    # Use the following 2 lines to register the UI for this hook
+    from io_scene_gltf2 import exporter_extension_layout_draw
+    exporter_extension_layout_draw['Example glTF Extension'] = draw_export # Make sure to use the same name in unregister()
+
 def unregister():
+    # Unregister the properties
     bpy.utils.unregister_class(ExampleExtensionProperties)
     del bpy.types.Scene.ExampleExtensionProperties
 
+    # If you registered the properties to the collection, you should unregister them here
+    # del bpy.types.Collection.ExampleExtensionProperties
+
+    # Use the following 2 lines to unregister the UI for this hook
+    from io_scene_gltf2 import exporter_extension_layout_draw
+    del exporter_extension_layout_draw['Example glTF Extension'] # Make sure to use the same name in register()
+
 
 def draw_export(context, layout):
+
+    # Note: If you are using Collection Exporter, you may want to restrict UI for some collections
+    # You can access the collection like this: context.collection
+    # So you can check if you want to show the UI for this collection or not, using
+    # if context.collection.name != "Coll":
+    #     return
+
+
     header, body = layout.panel("GLTF_addon_example_exporter", default_closed=False)
     header.use_property_split = False
 
@@ -67,6 +93,13 @@ class glTF2ExportUserExtension:
         self.properties = bpy.context.scene.ExampleExtensionProperties
 
     def gather_node_hook(self, gltf2_object, blender_object, export_settings):
+
+        # Note: If you are using Collection Exporters, you may want to restrict the export for some collections
+        # You can access the collection like this: export_settings['gltf_collection']
+        # So you can check if you want to use this hook for this collection or not, using
+        # if export_settings['gltf_collection'] != "Coll":
+        #     return
+
         if self.properties.enabled:
             if gltf2_object.extensions is None:
                 gltf2_object.extensions = {}


### PR DESCRIPTION
- Explicit registration for hook UI
- Add some examples for collection exporters

Note: I still have to verify that addon_core's addons are always imported & registered before any other user defined addons.
Seem to be the case, but I need to check with Blender dev team (Campbell?)  this is always the case.