### PR TITLE
Fix #2481 Reset skin if mesh failed to export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/nodes.py
@@ -53,6 +53,13 @@ def gather_node(vnode, export_settings):
     else:
         mesh = None
 
+    # If mesh is skined, but failed to export
+    # We should ignore the skin too,
+    # As it will generate a not valid glTF file
+    if mesh is None and skin is not None:
+        skin = None
+        vnode.skin = None
+
     node = gltf2_io.Node(
         camera=__gather_camera(vnode, export_settings),
         children=__gather_children(vnode, export_settings),


### PR DESCRIPTION
Avoiding a not valid glTF file