### PR TITLE
Fix 'dev/null' for windows

### DIFF
--- a/tests/test/test.js
+++ b/tests/test/test.js
@@ -250,7 +250,8 @@ describe('Exporter', function () {
 
         variants.forEach(function (variant) {
             var args = variant[1];
-            args += ' 2>&1 > /dev/null'; // avoid str overflows
+            const devNull = process.platform === "win32" ? "NUL" : "/dev/null";
+            args += ' 2>&1 > ' + devNull; // avoid str overflows
             describe(blenderVersion + '_export' + variant[0], function () {
                 blenderSampleScenes.forEach((scene) => {
                     it(scene, function (done) {


### PR DESCRIPTION
Description
----
Corrected stdio output target to "NUL" for windows platform, currently unittests does not run on Windows.

Comments
---
Might be a better solution to pass the 'silent' option to exec() call rather then piping to dev/null but this seemed like the simplest solution as my javascript isn't great.

Could run most test but some tests fail, unsure of this is windows specific or not. Tests that fail are mostly related to the name of the exported '.png' files for scenes/08 tests (see image below) and some UDIM counter issue.

![image](https://github.com/user-attachments/assets/ef8642aa-19c2-45b0-98d6-3324a6b452eb)
