### PR TITLE
Clamp vertex colors

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/primitive_attributes.py
+++ b/addons/io_scene_gltf2/blender/exp/primitive_attributes.py
@@ -192,6 +192,7 @@ def __gather_attribute(blender_primitive, attribute, export_settings):
         ) and blender_primitive["attributes"][attribute]['component_type'] == gltf2_io_constants.ComponentType.UnsignedShort:
         # Byte Color vertex color, need to normalize
 
+        data['data'] = np.clip(data['data'], 0, 1)
         data['data'] *= 65535
         data['data'] += 0.5  # bias for rounding
         data['data'] = data['data'].astype(np.uint16)


### PR DESCRIPTION
Some models have issues with values outside the 0-1 range which causes the vertex color to wrap around and produce incorrect values