### PR TITLE
Export Named VC option

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -531,10 +531,18 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
              'Export vertex color when used by material'),
             ('ACTIVE', 'Active',
              'Export active vertex color'),
+            ('NAME', 'Name',
+             'Export vertex color with this name'),
             ('NONE', 'None',
              'Do not export vertex color')),
         description='How to export vertex color',
         default='MATERIAL'
+    )
+
+    export_vertex_color_name: StringProperty(
+        name='Vertex Color Name',
+        description='Name of vertex color to export',
+        default='Color'
     )
 
     export_all_vertex_colors: BoolProperty(
@@ -1161,6 +1169,10 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
         else:
             export_settings['gltf_all_vertex_colors'] = self.export_all_vertex_colors
             export_settings['gltf_active_vertex_color_when_no_material'] = self.export_active_vertex_color_when_no_material
+        if self.export_vertex_color == 'NAME':
+            export_settings['gltf_vertex_color_name'] = self.export_vertex_color_name
+        else:
+            export_settings['gltf_vertex_color_name'] = ""
 
         export_settings['gltf_unused_textures'] = self.export_unused_textures
         export_settings['gltf_unused_images'] = self.export_unused_images
@@ -1496,7 +1508,10 @@ def export_panel_data_mesh(layout, operator):
         if sub_body:
             row = sub_body.row()
             row.prop(operator, 'export_vertex_color')
-            if operator.export_vertex_color == "ACTIVE":
+            row = sub_body.row()
+            if operator.export_vertex_color == "NAME":
+                row.prop(operator, 'export_vertex_color_name')
+            if operator.export_vertex_color in ["ACTIVE", "NAME"]:
                 row = sub_body.row()
                 row.label(
                     text="Note that fully compliant glTF 2.0 engine/viewer will use it as multiplicative factor for base color.",

--- a/addons/io_scene_gltf2/blender/exp/primitive_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/primitive_extract.py
@@ -527,15 +527,22 @@ class PrimitiveCreator:
                 if material_info['vc_info']['color_type'] is None and material_info['vc_info']['alpha_type'] is None:
 
                     # If user wants to force active vertex color, we need to add it
-                    if (base_material is not None and self.export_settings['gltf_vertex_color'] == "ACTIVE") or (
+                    if (base_material is not None and self.export_settings['gltf_vertex_color'] in ["ACTIVE", "NAME"]) or (
                             base_material is None and self.export_settings['gltf_active_vertex_color_when_no_material'] is True):
                         # We need to add the active vertex color as COLOR_0
                         vc_color_name = None
                         vc_alpha_name = None
 
-                        if self.blender_mesh.color_attributes.render_color_index != -1:
-                            vc_color_name = self.blender_mesh.color_attributes[self.blender_mesh.color_attributes.render_color_index].name
-                            vc_alpha_name = self.blender_mesh.color_attributes[self.blender_mesh.color_attributes.render_color_index].name
+                        # Active Vertex Color
+                        if (base_material is not None and self.export_settings['gltf_vertex_color'] == "ACTIVE") or (
+                            base_material is None and self.export_settings['gltf_active_vertex_color_when_no_material'] is True):
+                            if self.blender_mesh.color_attributes.render_color_index != -1:
+                                vc_color_name = self.blender_mesh.color_attributes[self.blender_mesh.color_attributes.render_color_index].name
+                                vc_alpha_name = self.blender_mesh.color_attributes[self.blender_mesh.color_attributes.render_color_index].name
+                        # Named Vertex Color
+                        elif (base_material is not None and self.export_settings['gltf_vertex_color'] == "NAME"):
+                            vc_color_name = self.export_settings['gltf_vertex_color_name'] if self.blender_mesh.color_attributes.find(self.export_settings['gltf_vertex_color_name']) != -1 else None
+                            vc_alpha_name = self.export_settings['gltf_vertex_color_name'] if self.blender_mesh.color_attributes.find(self.export_settings['gltf_vertex_color_name']) != -1 else None
 
                         if vc_color_name is not None:
 
@@ -552,7 +559,7 @@ class PrimitiveCreator:
 
                             elif materials_use_vc is None:
                                 materials_use_vc = vc_key
-                                add_alpha = True  # As we are using the active Vertex Color without checking node tree, we need to add alpha
+                                add_alpha = True  # As we are using the active Vertex Color (or named) without checking node tree, we need to add alpha
                                 self.vc_infos.append({
                                     'color': vc_color_name,
                                     'alpha': vc_alpha_name,


### PR DESCRIPTION
Add an option (in VC enum) to export a given (named) Vertex Color.
As for "Active", this is not fully glTF compliant