### PR TITLE
Fix #423 - import multiple scenes as collections

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -1931,6 +1931,12 @@ class ImportGLTF2(Operator, ConvertGLTF2_Base, ImportHelper):
         default=True,
     )
 
+    import_scene_as_collection: BoolProperty(
+        name='Import Scene as Collection',
+        description='Import the scene as a collection',
+        default=True,
+    )
+
     def draw(self, context):
         operator = self
         layout = self.layout
@@ -2046,7 +2052,9 @@ def import_ux_panel(layout, operator):
     header, body = layout.panel("GLTF_import_ux", default_closed=False)
     header.label(text="Pipeline")
     if body:
-        body.prop(operator, 'import_select_created_objects')
+        body.prop(operator, 'import_scene_as_collection')
+        if operator.import_scene_as_collection is True:
+            body.prop(operator, 'import_select_created_objects')
         body.prop(operator, 'import_scene_extras')
 
 def import_texture_panel(layout, operator):

--- a/addons/io_scene_gltf2/blender/exp/exporter.py
+++ b/addons/io_scene_gltf2/blender/exp/exporter.py
@@ -350,7 +350,7 @@ class GlTF2Exporter:
 
         The scene should be built up with the generated glTF classes
         :param scene: gltf2_io.Scene type. Root node of the scene graph
-        :param active: If true, sets the glTD.scene index to the added scene
+        :param active: If true, sets the glTF.scene index to the added scene
         :return: nothing
         """
         if self.__finalized:

--- a/addons/io_scene_gltf2/blender/imp/node.py
+++ b/addons/io_scene_gltf2/blender/imp/node.py
@@ -131,7 +131,13 @@ class BlenderNode():
         if hasattr(obj, 'gltf2_animation_rest'):
             obj.gltf2_animation_rest = Matrix.LocRotScale(obj.location, obj.rotation_quaternion, obj.scale)
 
-        bpy.data.scenes[gltf.blender_scene].collection.objects.link(obj)
+        # Add to scene, by linking to the collections
+        if len(vnode.scenes) == 0:
+            # Add to the orphan collection
+            gltf.blender_collections[None].objects.link(obj)
+        else:
+            for c in vnode.scenes:
+                gltf.blender_collections[c].objects.link(obj)
 
         return obj
 

--- a/addons/io_scene_gltf2/blender/imp/node.py
+++ b/addons/io_scene_gltf2/blender/imp/node.py
@@ -137,7 +137,19 @@ class BlenderNode():
             gltf.blender_collections[None].objects.link(obj)
         else:
             for c in vnode.scenes:
-                gltf.blender_collections[c].objects.link(obj)
+                if gltf.import_settings['import_scene_as_collection'] is True:
+                    gltf.blender_collections[c].objects.link(obj)
+                else:
+                    if len(gltf.data.scenes) == 1:
+                        # Assign to the scene collection of the scene
+                        gltf.blender_scenes[c].collection.objects.link(obj)
+                    else:
+                        if c == gltf.data.scene:
+                            # Assign to the active collection
+                            gltf.blender_collections[c].objects.link(obj)
+                        else:
+                            # Assign to the scene collection of the scene
+                            gltf.blender_scenes[c].collection.objects.link(obj)
 
         return obj
 

--- a/addons/io_scene_gltf2/blender/imp/scene.py
+++ b/addons/io_scene_gltf2/blender/imp/scene.py
@@ -68,6 +68,12 @@ class BlenderScene():
             BlenderScene.select_imported_objects(gltf)
             BlenderScene.set_active_object(gltf)
 
+        # Exlude not default scens(s) collection(s)
+        if gltf.data.scene is not None:
+            for scene_idx, coll in gltf.blender_collections.items():
+                if scene_idx != gltf.data.scene:
+                    bpy.context.layer_collection.children[coll.name].exclude = True
+
     @staticmethod
     def create_animations(gltf):
         """Create animations."""

--- a/addons/io_scene_gltf2/blender/imp/scene.py
+++ b/addons/io_scene_gltf2/blender/imp/scene.py
@@ -64,15 +64,16 @@ class BlenderScene():
 
         if bpy.context.mode != 'OBJECT':
             bpy.ops.object.mode_set(mode='OBJECT')
-        if gltf.import_settings['import_select_created_objects']:
+        if gltf.import_settings['import_select_created_objects'] and gltf.import_settings['import_scene_as_collection'] is True:
             BlenderScene.select_imported_objects(gltf)
             BlenderScene.set_active_object(gltf)
 
-        # Exlude not default scens(s) collection(s)
-        if gltf.data.scene is not None:
-            for scene_idx, coll in gltf.blender_collections.items():
-                if scene_idx != gltf.data.scene:
-                    bpy.context.layer_collection.children[coll.name].exclude = True
+        # Exlude not default scene(s) collection(s), if we are in collection
+        if gltf.import_settings['import_scene_as_collection'] is True:
+            if gltf.data.scene is not None:
+                for scene_idx, coll in gltf.blender_collections.items():
+                    if scene_idx != gltf.data.scene:
+                        bpy.context.layer_collection.children[coll.name].exclude = True
 
     @staticmethod
     def create_animations(gltf):

--- a/addons/io_scene_gltf2/blender/imp/vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/vnode.py
@@ -154,6 +154,17 @@ def init_vnodes(gltf):
     # Create a map of all scene / blender collections
     gltf.blender_collections = {}
     gltf.active_collection = bpy.context.collection
+    gltf.blender_scenes = {}
+
+    # Create needed scenes
+    for idx_scene, scene in enumerate(gltf.data.scenes or []):
+        # Create a new scene for all not default scenes
+        if idx_scene != gltf.data.scene:
+            new_scene = bpy.data.scenes.new(name=scene.name or "Scene %d" % idx_scene)
+            gltf.blender_scenes[idx_scene] = new_scene
+        else:
+            gltf.blender_scenes[idx_scene] = bpy.context.scene
+
 
     # If we have only 1 scene, we can use the active collection
     # If we have multiple scenes, we create a collection for each scene (as child of active collection)
@@ -162,12 +173,20 @@ def init_vnodes(gltf):
         gltf.blender_collections[gltf.data.scene] = bpy.context.collection
     elif len(gltf.data.scenes) > 1:
         for idx_scene, scene in enumerate(gltf.data.scenes or []):
-            # Create a new collection for the scene
-            collection = bpy.data.collections.new(gltf.data.scenes[idx_scene].name or "Scene %d" % idx_scene)
-            # Link the collection to the active collection
-            gltf.active_collection.children.link(collection)
-            # Add the collection to the map
-            gltf.blender_collections[idx_scene] = collection
+            if gltf.import_settings['import_scene_as_collection'] is True:
+                # Create a new collection for the scene
+                collection = bpy.data.collections.new(gltf.data.scenes[idx_scene].name or "Scene %d" % idx_scene)
+                # Link the collection to the active collection or the collection of the scene
+                # Collection on current scene
+                gltf.active_collection.children.link(collection)
+                # Add the collection to the map
+                gltf.blender_collections[idx_scene] = collection
+            else:
+                if idx_scene == gltf.data.scene:
+                    gltf.blender_collections[idx_scene] = gltf.active_collection
+                # No collection creation, so no linking
+                # Link between glTF scence and blender scene is already done
+
 
     # Check if we have orphan nodes
     orphan_nodes = [node for node in gltf.vnodes if len(gltf.vnodes[node].scenes) == 0]

--- a/addons/io_scene_gltf2/blender/imp/vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/vnode.py
@@ -387,6 +387,7 @@ def move_skinned_meshes(gltf):
         gltf.vnodes[new_id].parent = arma
         gltf.vnodes[arma].children.append(new_id)
         gltf.vnodes[new_id].mesh_node_idx = vnode.mesh_node_idx
+        gltf.vnodes[new_id].scenes = vnode.scenes
         vnode.mesh_node_idx = None
 
 

--- a/docs/blender_docs/scene_gltf2.rst
+++ b/docs/blender_docs/scene_gltf2.rst
@@ -856,6 +856,12 @@ Bone Shape Scale
 Pipeline
 ^^^^^^^^
 
+Import Scenes as Collections
+   Import glTF scenes as collections. This is the default.
+   For single scene import, all objects are created in active collection
+   For multiple scenes import, each scene is imported as a collection. Non default scene are excluded from View Layer.
+   If there are some orphan nodes (not in any scenes), an Orphan Collection is created (excluded from View Layer too).
+   When off, the glTF scene is imported in the Blender active scene. Other glTF scenes are imported as new Blender Scenes.
 Select Imported Objects
    Select created objects after import.
 Import Scene Extras


### PR DESCRIPTION
Fix #423 - import multiple scenes as collections

- For single scene import => All is created in active collection
- For multiple scenes import => Each scene is imported as a collection. Non default scene are excluded from view_layer
- If there are some orphan nodes (not in any scenes) => An Orphan Collection is created (excluded too)

![image](https://github.com/user-attachments/assets/5a73f282-5fdc-41f1-a999-ce779bf94a12)
