### PR TITLE
Fix handling missing images when exporting glTF

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/encode_image.py
+++ b/addons/io_scene_gltf2/blender/exp/material/encode_image.py
@@ -423,6 +423,7 @@ class ExportImage:
             return _encode_temp_image(tmp_image, self.file_format, export_settings)
 
     def __encode_from_image_tile(self, udim_image, tile, export_settings):
+        data = None
         src_path = bpy.path.abspath(udim_image.filepath_raw).replace("<UDIM>", tile)
 
         if os.path.isfile(src_path):
@@ -443,6 +444,7 @@ class ExportImage:
         # We don't manage UDIM packed image, so this could not happen to be here
         # Lets display an error
         export_settings['log'].error("UDIM packed images are not supported for export. Please unpack them before exporting.")
+        return b''
 
 
 def _encode_temp_image(tmp_image: bpy.types.Image, file_format: str, export_settings) -> bytes:


### PR DESCRIPTION
## Description
Currently, when trying to export images using glTF, but the image is not found, `data` is not set in this function:
```python
    def __encode_from_image_tile(self, udim_image, tile, export_settings):
        src_path = bpy.path.abspath(udim_image.filepath_raw).replace("<UDIM>", tile)

        if os.path.isfile(src_path):
            with open(src_path, 'rb') as f:
                data = f.read()

        if data:
            if self.file_format == 'PNG':
                if data.startswith(b'\x89PNG'):
                    return data
            elif self.file_format == 'JPEG':
                if data.startswith(b'\xff\xd8\xff'):
                    return data
            elif self.file_format == 'WEBP':
                if data[8:12] == b'WEBP':
                    return data

        # We don't manage UDIM packed image, so this could not happen to be here
        # Lets display an error
        export_settings['log'].error("UDIM packed images are not supported for export. Please unpack them before exporting.")
```

This causes an error in Blender:
![Screenshot 2025-03-10 195536](https://github.com/user-attachments/assets/30ad1ad2-ed6f-44cf-8d75-93db0ab124e5)

WIth this change, the error is handled properly and shown:
![Screenshot 2025-03-10 195710](https://github.com/user-attachments/assets/7423264b-db40-47f1-b74c-fe04d78bacca)


