### PR TITLE
GPU instances nodes removal fixes

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/exporter.py
+++ b/addons/io_scene_gltf2/blender/exp/exporter.py
@@ -278,26 +278,23 @@ class GlTF2Exporter:
             self.__traverse(holder.extensions)
 
             # Remove children from original Empty
-            new_children = []
-            for child_idx in node.children:
-                if child_idx not in insts:
-                    new_children.append(child_idx)
-            node.children = new_children
+            insts_set = set(insts)
+            node.children = [child_idx for child_idx in node.children if child_idx not in insts_set]
 
             self.nodes_idx_to_remove.extend(insts)
 
         for child_idx in node.children:
-                child = self.__gltf.nodes[child_idx]
-                self.manage_gpu_instancing(child, also_mesh=child.mesh is not None)
+            child = self.__gltf.nodes[child_idx]
+            self.manage_gpu_instancing(child, also_mesh=child.mesh is not None)
 
     def manage_gpu_instancing_nodes(self, export_settings):
         if export_settings['gltf_gpu_instances'] is True:
 
             self.nodes_idx_to_remove = []
-            for scene_num in range(len(self.__gltf.scenes)):
+            for scene in self.__gltf.scenes:
                 # Modify the scene data in case of EXT_mesh_gpu_instancing export
 
-                for node_idx in self.__gltf.scenes[scene_num].nodes:
+                for node_idx in scene.nodes:
                     node = self.__gltf.nodes[node_idx]
                     if node.mesh is None:
                         self.manage_gpu_instancing(node)
@@ -306,35 +303,36 @@ class GlTF2Exporter:
 
             if self.nodes_idx_to_remove:
                 self.nodes_idx_to_remove.sort()
+                to_remove = set(self.nodes_idx_to_remove)
 
-                for scene_num, scene in enumerate(self.__gltf.scenes):
+                old_to_new = {}
+                node_count = 0
+                for node_idx in range(len(self.__gltf.nodes)):
+                    if node_idx in to_remove:
+                        continue
+                    old_to_new[node_idx] = node_count
+                    node_count += 1
 
+                for scene in self.__gltf.scenes:
                     # Slides other nodes index
                     for node_idx in scene.nodes:
-                        self.recursive_slide_node_idx(node_idx)
+                        self.recursive_slide_node_idx(node_idx, old_to_new)
 
-                    new_node_list = []
-                    for node_idx in scene.nodes:
-                        len_ = len([i for i in self.nodes_idx_to_remove if i < node_idx])
-                        new_node_list.append(node_idx - len_)
-                    scene.nodes = new_node_list
+                    scene.nodes = [old_to_new[node_idx] for node_idx in scene.nodes]
 
-                    for skin in self.__gltf.skins:
-                        new_joint_list = []
-                        for node_idx in skin.joints:
-                            len_ = len([i for i in self.nodes_idx_to_remove if i < node_idx])
-                            new_joint_list.append(node_idx - len_)
-                        skin.joints = new_joint_list
-                        if skin.skeleton is not None:
-                            len_ = len([i for i in self.nodes_idx_to_remove if i < skin.skeleton])
-                            skin.skeleton = skin.skeleton - len_
+                for skin in self.__gltf.skins:
+                    skin.joints = [old_to_new[node_idx] for node_idx in skin.joints]
+
+                    if skin.skeleton is not None:
+                        skin.skeleton = old_to_new[skin.skeleton]
 
                 # Remove animation channels that was targeting a node that will be removed
                 new_animation_list = []
                 for animation in self.__gltf.animations:
                     new_channel_list = []
                     for channel in animation.channels:
-                        if channel.target.node not in self.nodes_idx_to_remove:
+                        if channel.target.node in old_to_new:
+                            channel.target.node = old_to_new[channel.target.node]
                             new_channel_list.append(channel)
                     animation.channels = new_channel_list
                     if len(animation.channels) > 0:
@@ -364,16 +362,13 @@ class GlTF2Exporter:
         if active:
             self.__gltf.scene = scene_num
 
-    def recursive_slide_node_idx(self, node_idx):
+    def recursive_slide_node_idx(self, node_idx: int, old_to_new: dict):
         node = self.__gltf.nodes[node_idx]
 
-        new_node_children = []
-        for child_idx in node.children:
-            len_ = len([i for i in self.nodes_idx_to_remove if i < child_idx])
-            new_node_children.append(child_idx - len_)
+        new_node_children = [old_to_new[node_idx] for node_idx in node.children]
 
         for child_idx in node.children:
-            self.recursive_slide_node_idx(child_idx)
+            self.recursive_slide_node_idx(child_idx, old_to_new)
 
         node.children = new_node_children
 


### PR DESCRIPTION
It reworks code dealing with nodes instancing - in particular part which removes nodes added to instancing.

### What it does

- Gathers removed nodes from all scenes and applies deletion at once.
(in old code self.nodes_idx_to_remove is cleaned up in loop(not before it), which will cause to only delete nodes from last processed scene)

- Uses sets to check if node is deleted, instead of lists.
This probably has the most effect on speed for big-sized instance collections(should help with https://github.com/KhronosGroup/glTF-Blender-IO/issues/2199 )

- Instead of calculating shifts for node indices it uses single dict mapping.
I haven't checked exact performance effect, but to iterate all deleted objects for every remaining object can result in bad speed for specific scenes. There is still some O(n^2)-ish speed behavior, but i suspect it rather related to node creation and better be investigated separately.
Also results in simpler code.

- Applies new node index to animation's target.
Previously it was just checking if node is deleted, without changing index to new.
Should solve https://github.com/KhronosGroup/glTF-Blender-IO/issues/2423

### Examples to reproduce

All made in blender 4.4.3. For every example, both GPU instances and GN instancing should be enabled.

- [big_instancing.zip](https://github.com/user-attachments/files/20908874/big_instancing.zip)

amount of instances can be controlled by density
for 40k instances it takes 25 seconds(before fix) vs 10 second(after)for me.
for 100k - 155 vs 48.

- [two_scenes.zip](https://github.com/user-attachments/files/20908930/two_scenes.zip)

When exported, result is looking strange for "Scene", which likely to be caused by bad indices.
Also some "GN Instance" objects can be seen in node list in JSON, even if GN instancing is enabled as option and it should remove it.

- [animation_deleted.zip](https://github.com/user-attachments/files/20908933/animation_deleted.zip)

When exported, animation target has node ids in JSON, which is too big to be real.

### Note

There is more optimizations i would like to try(beside said creation), but better be done as separate pull request[s].

Instancing generally looks like it be better done using direct transform gathering from GN/instancing/particles rather than generating and unifying nodes - but that will require entirely different approach with its own problems.
