### PR TITLE
Collection Exporter: Allow choosing which axis to center the collection on collection export

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -640,6 +640,18 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
         default=False,
     )
 
+    center_collection_at_axis: EnumProperty(
+        name="Center Collections at axis",
+        description="Choose in which axis to center the collection",
+        options= {'ENUM_FLAG'},
+        items=(
+            ('X', "X", "Centers the collection in the x axis"),
+            ('Y', "Y", "Centers the collection in the y axis"),
+            ('Z', "Z", "Centers the collection in the z axis"),
+        ),
+        default={'X','Y','Z'},
+    )
+
     export_extras: BoolProperty(
         name='Custom Properties',
         description='Export custom properties as glTF extras',
@@ -1194,6 +1206,7 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
         export_settings['gltf_active_scene'] = self.use_active_scene
         export_settings['gltf_collection'] = self.collection
         export_settings['gltf_at_collection_center'] = self.at_collection_center
+        export_settings['gltf_center_collection_at_axis'] = self.center_collection_at_axis
 
         export_settings['gltf_selected'] = self.use_selection
         export_settings['gltf_layers'] = True  # self.export_layers
@@ -1437,6 +1450,15 @@ def export_panel_collection(layout, operator, is_file_browser):
     header.label(text="Collection")
     if body:
         body.prop(operator, 'at_collection_center')
+        split = body.split(factor=0.4, align=False)
+        split.alignment = 'RIGHT'
+        split.active = operator.at_collection_center
+        split.label(text="Center at axis:")
+        row = split.row(align=True)
+        row.use_property_split = False
+        row.prop_enum(operator, "center_collection_at_axis", value='X')
+        row.prop_enum(operator, "center_collection_at_axis", value='Y')
+        row.prop_enum(operator, "center_collection_at_axis", value='Z')
 
 
 def export_panel_include(layout, operator, is_file_browser):

--- a/addons/io_scene_gltf2/blender/exp/tree.py
+++ b/addons/io_scene_gltf2/blender/exp/tree.py
@@ -982,5 +982,6 @@ class VExportTree:
         if len(centers) == 0:
             self.export_settings['gltf_collection_center'] = Vector((0.0, 0.0, 0.0))
             return
-
-        self.export_settings['gltf_collection_center'] = sum(centers, Vector()) / len(centers)
+        center_at = self.export_settings['gltf_center_collection_at_axis']
+        axis = Vector((float('X' in center_at), float('Y' in center_at), float('Z' in center_at)))
+        self.export_settings['gltf_collection_center'] = (sum(centers, Vector()) / len(centers)) * axis


### PR DESCRIPTION
When exporting collections with the `Export at Collection Center`
option enabled, this enables to choose which axis to center the collection,

----
<img width="357" height="443" alt="image" src="https://github.com/user-attachments/assets/7edf7ec4-544b-4be3-b9f1-79ebfed8fab2" />
