### PR TITLE
Improve unlinking of objects from collections

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/node.py
+++ b/addons/io_scene_gltf2/blender/imp/node.py
@@ -177,7 +177,18 @@ class BlenderNode():
                 1, 1, 1))
         bpy.data.collections[BLENDER_GLTF_SPECIAL_COLLECTION].objects.link(bpy.context.object)
         gltf.bone_shape = bpy.context.object.name
-        bpy.context.collection.objects.unlink(bpy.context.object)
+        try:
+            bpy.context.collection.objects.unlink(bpy.context.object)
+        except:
+            # If the collection was not in context, use active_collection instead.
+            gltf.active_collection.objects.unlink(bpy.context.object)
+            # Most likely reason for the context to fail if if the collection was hidden but active.
+            # Unhide from viewport
+            gltf.active_collection.hide_viewport = False
+            for child in bpy.context.view_layer.layer_collection.children:
+                # Unhide if hidden from view layer
+                if child.name == gltf.active_collection.name:
+                    child.hide_viewport = False
 
     @staticmethod
     def calc_empty_display_size(gltf, vnode_id):


### PR DESCRIPTION
Handle case where the custom bone icosphere cannot be unlinked from collection, by unlinking from gltf.active_collection instead. Also ensures the active collection is then unhidden from the viewport so newly imported objects aren't hidden inside. 

If a collection is active but hidden, after creating the Icosphere Blender will give error message
"...\scripts\addons_core\io_scene_gltf2\blender\imp\node.py", line 170, in armature_display
    bpy.context.collection.objects.unlink(bpy.context.object)
RuntimeError: Error: Object 'Icosphere.001' not in collection 'Scene Collection' "
and halt, leaving the icosphere linked to both the active+hidden collection and the glTF_not_exported collection, with no object imported. 

This PR fixes that. 

Tested on Blender 5.1.0A.