### PR TITLE
Fix crash when GPU instancing attributes property does not exist

### DIFF
--- a/addons/io_scene_gltf2/blender/imp/vnode.py
+++ b/addons/io_scene_gltf2/blender/imp/vnode.py
@@ -211,15 +211,16 @@ def init_vnodes(gltf):
 
 
 def manage_gpu_instancing(gltf, vnode, i, ext, mesh_id):
+    attrs = ext.get('attributes', {})
 
-    trans_list = BinaryData.get_data_from_accessor(gltf, ext['attributes'].get('TRANSLATION', None)) \
-        if ext['attributes'].get('TRANSLATION', None) is not None else None
+    trans_list = BinaryData.get_data_from_accessor(gltf, attrs.get('TRANSLATION', None)) \
+        if attrs.get('TRANSLATION', None) is not None else None
 
-    rot_list = BinaryData.get_data_from_accessor(gltf, ext['attributes'].get('ROTATION', None)) \
-        if ext['attributes'].get('ROTATION', None) is not None else None
+    rot_list = BinaryData.get_data_from_accessor(gltf, attrs.get('ROTATION', None)) \
+        if attrs.get('ROTATION', None) is not None else None
 
-    scale_list = BinaryData.get_data_from_accessor(gltf, ext['attributes'].get('SCALE', None)) \
-        if ext['attributes'].get('SCALE', None) is not None else None
+    scale_list = BinaryData.get_data_from_accessor(gltf, attrs.get('SCALE', None)) \
+        if attrs.get('SCALE', None) is not None else None
 
     # Retrieve the first available attribute to get the number of children
     val = next((elem for elem in [


### PR DESCRIPTION
The [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) extension's `"attributes"` property is not required, therefore the extension does not forbid excluding it to result in a GPU-instanced mesh that gets instanced zero times. In the current main branch, the code does not handle this case, resulting in the Python code crashing and showing this error:

<img width="1704" height="752" alt="Screenshot 2025-11-16 at 1 45 47 PM" src="https://github.com/user-attachments/assets/879f7237-7c4b-4130-b18d-eb7fa98faeb2" />

This PR adds the line `attrs = ext.get('attributes', {})` and replaces `ext['attributes']` with `attrs` to fix this problem, and also has the benefit of reducing duplication of `ext['attributes']` six times.