### PR TITLE
Node.index attribute

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/exporter.py
+++ b/addons/io_scene_gltf2/blender/exp/exporter.py
@@ -346,6 +346,9 @@ class GlTF2Exporter:
                 self.__gltf.nodes = [node for idx, node in enumerate(
                     self.__gltf.nodes) if idx not in to_remove]
 
+                for node in self.__gltf.nodes:
+                    node.index = old_to_new[node.index]
+
     def add_scene(self, scene: gltf2_io.Scene, active: bool = False, export_settings=None):
         """
         Add a scene to the glTF.
@@ -412,6 +415,13 @@ class GlTF2Exporter:
         :param property: A property type object that should be converted to a reference
         :return: a reference or the object itself if it is not child or root
         """
+        if isinstance(property, gltf2_io.Node):
+            if property.index is None:
+                property.index = len(self.__gltf.nodes)
+                self.__gltf.nodes.append(property)
+
+            return property.index
+
         gltf_list = self.__childOfRootPropertyTypeLookup.get(type(property), None)
         if gltf_list is None:
             # The object is not of a child of root --> don't convert to reference

--- a/addons/io_scene_gltf2/io/com/gltf2_io.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io.py
@@ -964,6 +964,8 @@ class Node:
         self.translation = translation
         self.weights = weights
 
+        self.index = None
+
     @staticmethod
     def from_dict(obj):
         assert isinstance(obj, dict)


### PR DESCRIPTION
Uses https://github.com/KhronosGroup/glTF-Blender-IO/pull/2577 (its easier to see impact with other parts being optimized, also actually uses some logic from), so this is draft.

Adds index attribute to Node, and uses it for GlTF2Exporter.__to_reference()'s search, which mean there is no need to iterate all existing nodes for every new added one.

Mostly affects files with instancing, but also can help with files with big number of nodes. Speeds up export a lot(for my example it changes time from ~88sec to ~8sec). Unused in import.
Should only work if Node object is used in only one export.

Now, this PR contradicts idea of data classes being generated with quicktype. So, maybe new code commentary is needed(along with others such). 
(In my viewpoint it is better to have manually written classes(even if on top of current generated), and there is even potential for things to became slower in new quicktype versions - but this is just an assumption).
Also there is an option to store indices in GlTF2Exporter using name as key instead(considering name is unique), but that mean slightly more complex state management.

There is more classes which can use index logic - can add them too, but Node seems to be most used.

Blender version used for testing - 5.0.1 RC
File used for testing: [big_instancing.zip](https://github.com/user-attachments/files/24338749/big_instancing.zip)
