### PR TITLE
Support extensions on Accessor, BufferView, and Buffer types

### DIFF
--- a/addons/io_scene_gltf2/io/imp/user_extensions.py
+++ b/addons/io_scene_gltf2/io/imp/user_extensions.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+class MutatingArgument:
+    """simple wrapper to pass a value by reference"""
+    def __init__(self, value):
+        self.value = value
+
 def import_user_extensions(hook_name, gltf, *args):
     for extension in gltf.import_user_extensions:
         hook = getattr(extension, hook_name, None)


### PR DESCRIPTION
Fixes #2634

Creates a new class type to enable an argument changing value entirely, since you cannot pass values by reference in Python.

Splits the old BinaryData.get_buffer_view into BinaryData.get_buffer_slice as a convenience method.

Added extension hooks:

- `load_buffer_before_hook(Buffer, &resultBuffer, gltf)`
- `load_buffer_after_book(Buffer, &resultBuffer, gltf)`
- `get_buffer_view_before_hook(BufferView, &resultSlice, gltf)`
- `get_buffer_view_after_hook(BufferView, &resultSlice, gltf)`
- `decode_accessor_before_hook(Accessor, &accessorArray, gltf)`
- `decode_accessor_after_hook(Accessor, &accessorArray, gltf)`

This would be within spec for glTF 2.0 as specified in section 3.12; 

> glTF defines an extension mechanism that allows the base format to be extended with new capabilities. Any glTF object MAY have an optional extensions property