### PR TITLE
Fix  #2569 - fix variant export

### DIFF
--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_ui.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_ui.py
@@ -14,6 +14,7 @@
 
 import bpy
 from ..com.material_helpers import get_gltf_node_name, create_settings_group
+from .gltf2_blender_utils import find_unused_name
 
 ################ glTF Material Output node ###########################################
 
@@ -61,10 +62,17 @@ def add_gltf_settings_to_menu(self, context):
 
 # Global UI panel
 
+def on_variant_name_update(self, context):
+    already_used_names = [v.name for v in bpy.data.scenes[0].gltf2_KHR_materials_variants_variants
+                            if v != self]
+    self.name = find_unused_name(already_used_names, self.name)
+
 
 class gltf2_KHR_materials_variants_variant(bpy.types.PropertyGroup):
     variant_idx: bpy.props.IntProperty()
-    name: bpy.props.StringProperty(name="Variant Name")
+    name: bpy.props.StringProperty(
+        name="Variant Name",
+        update=on_variant_name_update)
 
 
 class SCENE_UL_gltf2_variants(bpy.types.UIList):

--- a/addons/io_scene_gltf2/blender/com/gltf2_blender_utils.py
+++ b/addons/io_scene_gltf2/blender/com/gltf2_blender_utils.py
@@ -78,3 +78,24 @@ def fast_structured_np_unique(arr, *args, **kwargs):
         return (unique,) + result[1:]
     else:
         return unique
+
+def find_unused_name(haystack, desired_name):
+    """Finds a name not in haystack and <= 63 UTF-8 bytes.
+    (the limit on the size of a Blender name.)
+    If a is taken, tries a.001, then a.002, etc.
+    """
+    stem = desired_name[:63]
+    suffix = ''
+    cntr = 1
+    while True:
+        name = stem + suffix
+
+        if len(name.encode('utf-8')) > 63:
+            stem = stem[:-1]
+            continue
+
+        if name not in haystack:
+            return name
+
+        suffix = '.%03d' % cntr
+        cntr += 1

--- a/addons/io_scene_gltf2/blender/imp/blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/blender_gltf.py
@@ -15,9 +15,11 @@
 import bpy
 from mathutils import Vector, Quaternion, Matrix
 from ...io.imp.user_extensions import import_user_extensions
+from ..com.gltf2_blender_utils import find_unused_name
 from .scene import BlenderScene
 from .material import BlenderMaterial
 from .image import BlenderImage
+
 
 
 class BlenderGlTF():
@@ -239,7 +241,7 @@ class BlenderGlTF():
                 # for its NLA tracks.
                 desired_name = anim.name or "Anim_%d" % anim_idx
                 # TRS animations & Pointer will be created as separate tracks
-                anim.track_name = BlenderGlTF.find_unused_name(track_names, desired_name)
+                anim.track_name = find_unused_name(track_names, desired_name)
                 track_names.add(anim.track_name)
 
                 for channel_idx, channel in enumerate(anim.channels):
@@ -307,7 +309,7 @@ class BlenderGlTF():
                     if shapekey_name is None:
                         shapekey_name = "target_" + str(sk)
 
-                    shapekey_name = BlenderGlTF.find_unused_name(used_names, shapekey_name)
+                    shapekey_name = find_unused_name(used_names, shapekey_name)
                     used_names.add(shapekey_name)
 
                     mesh.shapekey_names.append(shapekey_name)
@@ -599,27 +601,6 @@ class BlenderGlTF():
             gltf.data.materials[int(pointer_tab[2])
                                 ].extensions["KHR_materials_anisotropy"]["animations"][anim_idx].append(channel_idx)
 
-    @staticmethod
-    def find_unused_name(haystack, desired_name):
-        """Finds a name not in haystack and <= 63 UTF-8 bytes.
-        (the limit on the size of a Blender name.)
-        If a is taken, tries a.001, then a.002, etc.
-        """
-        stem = desired_name[:63]
-        suffix = ''
-        cntr = 1
-        while True:
-            name = stem + suffix
-
-            if len(name.encode('utf-8')) > 63:
-                stem = stem[:-1]
-                continue
-
-            if name not in haystack:
-                return name
-
-            suffix = '.%03d' % cntr
-            cntr += 1
 
     @staticmethod
     def manage_material_variants(gltf):


### PR DESCRIPTION
Avoid 2 variants with same name
This will not fix older files, we need to manually update your variant names