### PR TITLE
check `gltf_action_filter` attribute existence before clearing

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -139,7 +139,7 @@ def on_export_action_filter_changed(self, context):
                 item.keep = True
                 item.action = action
 
-    else:
+    elif hasattr(bpy.data.scenes[0], "gltf_action_filter"):
         bpy.data.scenes[0].gltf_action_filter.clear()
         del bpy.types.Scene.gltf_action_filter
         del bpy.types.Scene.gltf_action_filter_active


### PR DESCRIPTION
The update handler `on_export_action_filter_changed` assumes if the `export_action_filter` setting is `False` it must have been `True` before, which isn't always true. I am exporting via command line with something like:

``` shell
$(BLENDER) -b $(INPUT) --python-expr "import bpy; bpy.ops.export_scene.gltf(filepath='$(OUTPUT)', **bpy.context.scene['glTF2ExportSettings'])"
```

The default is `False`, as is the saved export setting in the scene, in which case the update handler is triggered but was never `True`. Resulting in:

```
Traceback (most recent call last):
  File "/Applications/Blender.app/Contents/Resources/4.5/scripts/addons_core/io_scene_gltf2/__init__.py", line 130, in on_export_action_filter_changed
    bpy.data.scenes[0].gltf_action_filter.clear()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Scene' object has no attribute 'gltf_action_filter'
```