### PR TITLE
Use (newly created) active_render_index to retrieve UVMap

### DIFF
--- a/addons/io_scene_gltf2/__init__.py
+++ b/addons/io_scene_gltf2/__init__.py
@@ -18,7 +18,7 @@ bl_info = {
     # "author": "Julien Duroure, Scurest, Norbert Nopper, Urs Hanselmann, Moritz Becher, Benjamin Schmithüsen, Jim Eckerlein", # Original Authors
     'author': "Blender Foundation, Khronos Group",
     "version": (5, 2, 20),
-    'blender': (4, 4, 0),
+    'blender': (5, 2, 0),
     'location': 'File > Import-Export',
     'description': 'Import-Export as glTF 2.0',
     'warning': '',

--- a/addons/io_scene_gltf2/blender/exp/material/materials.py
+++ b/addons/io_scene_gltf2/blender/exp/material/materials.py
@@ -559,16 +559,6 @@ def __export_unlit(bmat, export_settings):
     return material, uvmap_info, vc_info, udim_info
 
 
-def get_render_uvmap_index(blender_mesh):
-    # retrieve render render UVMap
-    active_uvmap_idx = 0
-    for i in range(len(blender_mesh.uv_layers)):
-        if blender_mesh.uv_layers[i].active_render is True:
-            active_uvmap_idx = i
-            break
-    return active_uvmap_idx
-
-
 def get_final_material(mesh, blender_material, attr_indices, base_material, uvmap_info, export_settings):
 
     # First, we need to calculate all index of UVMap
@@ -590,9 +580,9 @@ def get_final_material(mesh, blender_material, attr_indices, base_material, uvma
                 indices[m] = i
             else:
                 # Using render index
-                indices[m] = get_render_uvmap_index(mesh)
+                indices[m] = mesh.uv_layers.active_render_index
         elif v['type'] == 'Render':
-            indices[m] = get_render_uvmap_index(mesh)
+            indices[m] = mesh.uv_layers.active_render_index
         elif v['type'] == "Attribute":
             # This can be a regular UVMap or a custom attribute
             i = mesh.uv_layers.find(v['value'])

--- a/addons/io_scene_gltf2/blender/exp/primitive_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/primitive_extract.py
@@ -21,7 +21,7 @@ from ...io.exp.user_extensions import export_user_extensions
 from ...io.com import constants as gltf2_io_constants
 from ..com import conversion as gltf2_blender_conversion
 from ..com.gltf2_blender_utils import fast_structured_np_unique
-from .material.materials import get_base_material, get_render_uvmap_index, get_new_material_texture_shared
+from .material.materials import get_base_material, get_new_material_texture_shared
 from .material.texture_info import gather_udim_texture_info
 from . import skins as gltf2_blender_gather_skins
 from . attribute_utils import extract_attribute_data
@@ -664,13 +664,13 @@ class PrimitiveCreator:
             all_uvmaps = {}
             for tex in material_info['udim_info'].keys():
                 if material_info['uv_info'][tex]['type'] == "Render":
-                    index_uvmap = get_render_uvmap_index(self.blender_mesh)
+                    index_uvmap = self.blender_mesh.uv_layers.active_render_index
                     uvmap_name = "TEXCOORD_" + str(index_uvmap)
                 elif material_info['uv_info'][tex]['type'] == "Fixed":
                     index_uvmap = self.blender_mesh.uv_layers.find(material_info['uv_info'][tex]['value'])
                     if index_uvmap < 0:
                         # Using render index
-                        index_uvmap = get_render_uvmap_index(self.blender_mesh)
+                        index_uvmap = self.blender_mesh.uv_layers.active_render_index
                     uvmap_name = "TEXCOORD_" + str(index_uvmap)
                 else:  # Attribute
                     # This can be a regular UVMap, or a custom attribute


### PR DESCRIPTION
Before, we had to loop on uv layers to retrieve the active render layer (by check on each layer).
Now, we can use active_render_index to retrieve directly the active render layer index