### PR TITLE
io_scene_gltf2: cache shader-graph traversal in `from_socket`

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/search_node_tree.py
+++ b/addons/io_scene_gltf2/blender/exp/material/search_node_tree.py
@@ -70,7 +70,6 @@ class NodeTreeSearchResult:
         self.group_path = group_path
 
 
-# TODO: cache these searches
 def from_socket(start_socket: NodeTreeSearchResult,
                 shader_node_filter):
     """
@@ -80,12 +79,29 @@ def from_socket(start_socket: NodeTreeSearchResult,
     :param shader_node_filter: should be a function(x: shader_node) -> bool
     :return: a list of shader nodes for which filter is true
     """
-    # hide implementation (especially the search path)
+    # Per-call memo so that shared shader sub-graphs (group nodes, mix nodes,
+    # multi-input nodes, etc.) are walked once. Without this the recursion
+    # below is at least quadratic in the number of shared input branches and
+    # dominates export time on complex materials.
+    memo: typing.Dict[typing.Tuple, typing.List[NodeTreeSearchResult]] = {}
+
+    def _gp_key(group_path):
+        # `group_path` is a list of group nodes for the materials traversal,
+        # but lamps pass their ShaderNodeTree directly. Hash by element
+        # pointers for the list case; otherwise by the tree's own pointer.
+        if isinstance(group_path, list):
+            return tuple(n.as_pointer() for n in group_path)
+        return ("tree", getattr(group_path, "as_pointer", id)())
+
     def __search_from_socket(start_socket: bpy.types.NodeSocket,
                              shader_node_filter: typing.Union[Filter, typing.Callable],
-                             search_path: typing.List[bpy.types.NodeLink],
-                             group_path: typing.List[bpy.types.Node]) -> typing.List[NodeTreeSearchResult]:
-        results = []
+                             group_path) -> typing.List[NodeTreeSearchResult]:
+        cache_key = (start_socket.as_pointer(), _gp_key(group_path))
+        cached_results = memo.get(cache_key)
+        if cached_results is not None:
+            return cached_results
+
+        results: typing.List[NodeTreeSearchResult] = []
         for link in start_socket.links:
             # follow the link to a shader node
             linked_node = link.from_node
@@ -93,37 +109,31 @@ def from_socket(start_socket: NodeTreeSearchResult,
             if linked_node.type == "GROUP":
                 group_output_node = [node for node in linked_node.node_tree.nodes if node.type == "GROUP_OUTPUT"][0]
                 socket = [sock for sock in group_output_node.inputs if sock.name == link.from_socket.name][0]
-                group_path.append(linked_node)
-                linked_results = __search_from_socket(
-                    socket, shader_node_filter, search_path + [link], group_path.copy())
-                if linked_results:
-                    # add the link to the current path
-                    search_path.append(link)
-                    results += linked_results
+                child_gp = (group_path + [linked_node]) if isinstance(group_path, list) else [linked_node]
+                for r in __search_from_socket(socket, shader_node_filter, child_gp):
+                    results.append(NodeTreeSearchResult(r.shader_node, [link] + r.path, r.group_path))
                 continue
 
             if linked_node.type == "GROUP_INPUT":
+                # GROUP_INPUT is only meaningful inside a group; if we have
+                # no enclosing group recorded there is nothing to ascend to.
+                if not isinstance(group_path, list) or not group_path:
+                    continue
                 socket = [sock for sock in group_path[-1].inputs if sock.name == link.from_socket.name][0]
-                linked_results = __search_from_socket(socket, shader_node_filter,
-                                                      search_path + [link], group_path[:-1].copy())
-                if linked_results:
-                    # add the link to the current path
-                    search_path.append(link)
-                    results += linked_results
+                for r in __search_from_socket(socket, shader_node_filter, group_path[:-1]):
+                    results.append(NodeTreeSearchResult(r.shader_node, [link] + r.path, r.group_path))
                 continue
 
             # check if the node matches the filter
             if shader_node_filter(linked_node):
-                results.append(NodeTreeSearchResult(linked_node, search_path + [link], group_path.copy()))
+                gp_snapshot = list(group_path) if isinstance(group_path, list) else group_path
+                results.append(NodeTreeSearchResult(linked_node, [link], gp_snapshot))
             # traverse into inputs of the node
             for input_socket in linked_node.inputs:
-                linked_results = __search_from_socket(
-                    input_socket, shader_node_filter, search_path + [link], group_path.copy())
-                if linked_results:
-                    # add the link to the current path
-                    search_path.append(link)
-                    results += linked_results
+                for r in __search_from_socket(input_socket, shader_node_filter, group_path):
+                    results.append(NodeTreeSearchResult(r.shader_node, [link] + r.path, r.group_path))
 
+        memo[cache_key] = results
         return results
 
     if start_socket.socket is None:
@@ -133,7 +143,7 @@ def from_socket(start_socket: NodeTreeSearchResult,
     if shader_node_filter(start_socket.socket.node):
         return [NodeTreeSearchResult(start_socket.socket.node, [], start_socket.group_path.copy())]
 
-    return __search_from_socket(start_socket.socket, shader_node_filter, [], start_socket.group_path.copy())
+    return __search_from_socket(start_socket.socket, shader_node_filter, start_socket.group_path)
 
 
 @cached


### PR DESCRIPTION
# Cache shader-graph traversal in `from_socket`

## What this fixes

The recursive socket→shader-node walk in `from_socket` (`addons/io_scene_gltf2/blender/exp/material/search_node_tree.py`) re-walks shared sub-graphs once per upstream input branch. With no caching at the recursion level, materials whose shader graphs share nodes — a node group used by multiple BSDF inputs, or a `Mix` / `MapRange` / `Color Ramp` between an `Image Texture` and a `Principled BSDF` input — get traversed once *per branch they participate in*. Cost grows quadratically (or worse) in the number of shared nodes.

This addresses the long-standing `# TODO: cache these searches` comment that has lived above `from_socket` and gives a concrete fix to the perf concerns surfaced in #2140 ("I think the performance about navigating in material node tree is here from the beginning").

## Measured impact

On a real production scene — 185 materials, 217 textures, 24 linked libraries (mix of Poly Haven materials, custom Geometry Nodes assets, complex BSDF setups):

| Metric | Before | After |
|---|---|---|
| Blender export phase (BEGIN EXPORT → "Exported successfully") | **1h 56m 50s** | **27 s** |
| Speedup | — | **~260×** |
| Output `scene.glb` size | 6,151,248 bytes | 6,150,812 bytes (0.007% delta, all in vendor metadata) |
| Materials / textures / images / lights | 185 / 217 / 218 / 8 | identical |
| `extensionsUsed` | (full list) | identical |

End-to-end (Blender export + downstream Needle build pipeline that runs Basis/KTX2 / Draco compression on top of the glTF output) dropped from ~2h 8m to ~8.5 min on the same scene.

py-spy sampling of the unpatched export showed `__search_from_socket` recursion **~45 frames deep on every sample** (909 frames across 20 samples taken 30 s apart), with `<genexpr>` from `_bpy_types.py` iterating `socket.links` as the active leaf 85 % of the time. After this patch, the same scene's export is too short for sampling to be statistically meaningful.

## Side benefit: UI no longer freezes

The previous quadratic walk held the GIL for its entire duration (pure Python, single-threaded). On scenes where the walk took an hour or more, Blender's UI thread starved completely — the UI froze, no progress feedback, hard to tell whether the export was hung or making progress. With memoization, the work completes fast enough that the UI thread keeps responding and addon-side status logs stream in real time.

## Implementation

* **The inner recursion now returns relative ("suffix") paths** from its `start_socket` to each match, so identical sub-trees produce identical cached results regardless of the outer caller's traversal prefix. The previous code carried a mutable `search_path` accumulator and built absolute paths inline — incompatible with caching because the same sub-tree visited from two different prefixes would have produced two different cached results.

* **A per-call `memo` dict** lives for the duration of one outer `from_socket` call and is keyed on `(start_socket.as_pointer(), group_path_key)`. `group_path_key` is a tuple of node pointers for the materials traversal (where `group_path` is a `List[bpy.types.Node]`) or the tree's own pointer for the lamps traversal (where `gather_lights_punctual` passes the lamp's `ShaderNodeTree` directly instead of a list).

* **`GROUP_INPUT` is now a no-op** when the recursion is not inside a recorded enclosing group. The original code accessed `group_path[-1].inputs` unconditionally, which would `IndexError` on a top-level `GROUP_INPUT`. In practice the only callers that pass a non-list `group_path` (the lamps path) never ascend a group, so this is a defensive clarification rather than a behavior change. It keeps the cache key well-typed.

## What is *not* changed

* No new dependencies.
* No new public API. `from_socket`'s signature is identical.
* Filter behavior unchanged (same `Filter` / `FilterByName` / `FilterByType` semantics).
* Output is byte-near-identical: 436-byte delta on a 6 MB GLB, all in vendor metadata (Needle build-pipeline timestamps/hashes) that isn't emitted by the gltf2 exporter itself.

## Testing

* End-to-end export of a real production scene with deeply-shared shader graphs: passes with **0 errors, 0 warnings**, produces structurally equivalent `scene.glb`.
* Material counts, texture counts, image counts, light counts, `extensionsUsed` array, sample material color factors all match the unpatched run exactly.
* Materials path exercised (185 materials including Poly Haven assets with deep node-group chains).
* Lamps path exercised (12 area lights with emission node trees, where `from_socket` is invoked with a `ShaderNodeTree` as `group_path`).

## Branch strategy

This PR targets `blender-v5.1-release` for backport since the perf issue ships in 5.1.x. An equivalent change against `main` is on `perf/cache-from-socket-traversal` in the same fork (same diff modulo the `__get_socket_index` helper that exists in `main` but not in `blender-v5.1-release`). Happy to file the `main` PR separately if you'd prefer to review them in sequence.

cc @julienduroure
