### PR TITLE
Add cursor style progress reporting to glTF import/export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/export.py
+++ b/addons/io_scene_gltf2/blender/exp/export.py
@@ -38,21 +38,30 @@ def save(context, export_settings):
     if not export_settings['gltf_current_frame']:
         bpy.context.scene.frame_set(0)
 
-    __notify_start(context, export_settings)
-    start_time = time.time()
-    pre_export_callbacks = export_settings["pre_export_callbacks"]
-    for callback in pre_export_callbacks:
-        callback(export_settings)
+    wm = bpy.context.window_manager
+    wm.progress_begin(0, 100)
+    try:
+        __notify_start(context, export_settings)
+        start_time = time.time()
+        pre_export_callbacks = export_settings["pre_export_callbacks"]
+        for callback in pre_export_callbacks:
+            callback(export_settings)
+        wm.progress_update(5)
 
-    json, buffer = __export(export_settings)
+        json, buffer = __export(export_settings, wm)
+        wm.progress_update(80)
 
-    post_export_callbacks = export_settings["post_export_callbacks"]
-    for callback in post_export_callbacks:
-        callback(export_settings)
-    __write_file(json, buffer, export_settings)
+        post_export_callbacks = export_settings["post_export_callbacks"]
+        for callback in post_export_callbacks:
+            callback(export_settings)
+        __write_file(json, buffer, export_settings)
+        wm.progress_update(95)
 
-    end_time = time.time()
-    __notify_end(context, end_time - start_time, export_settings)
+        end_time = time.time()
+        __notify_end(context, end_time - start_time, export_settings)
+        wm.progress_update(100)
+    finally:
+        wm.progress_end()
 
     if not export_settings['gltf_current_frame']:
         bpy.context.scene.frame_set(int(original_frame))
@@ -60,9 +69,10 @@ def save(context, export_settings):
     return {'FINISHED'}
 
 
-def __export(export_settings):
+def __export(export_settings, wm):
     exporter = GlTF2Exporter(export_settings)
     __gather_gltf(exporter, export_settings)
+    wm.progress_update(60)
 
     # If the directory does not exist, create it
     if not os.path.isdir(export_settings['gltf_filedirectory']):
@@ -73,6 +83,7 @@ def __export(export_settings):
 
     buffer = __create_buffer(exporter, export_settings)
     exporter.finalize_images()
+    wm.progress_update(70)
 
     export_user_extensions('gather_gltf_extensions_hook', export_settings, exporter.glTF)
     exporter.traverse_extensions()
@@ -106,6 +117,7 @@ def __export(export_settings):
     # Or extensionsUsed / extensionsRequired that are empty
     # (because we removed some extensions)
     json = __fix_json(json, export_settings, passthrough_extensions)
+    wm.progress_update(78)
 
     # Convert additional data if needed
     if export_settings['gltf_unused_textures'] is True:

--- a/addons/io_scene_gltf2/blender/imp/blender_gltf.py
+++ b/addons/io_scene_gltf2/blender/imp/blender_gltf.py
@@ -53,23 +53,35 @@ class BlenderGlTF():
     @staticmethod
     def _create(gltf):
         """Create glTF main worker method."""
-        BlenderGlTF.set_convert_functions(gltf)
-        BlenderGlTF.pre_compute(gltf)
-        BlenderScene.create(gltf)
+        wm = bpy.context.window_manager
+        wm.progress_begin(0, 100)
+        try:
+            BlenderGlTF.set_convert_functions(gltf)
+            wm.progress_update(5)
 
-        # If needed, create not used materials
-        if gltf.import_settings['import_unused_materials']:
-            for mat_idx in [i for i in range(len(gltf.data.materials)) if len(
-                    gltf.data.materials[i].blender_material) == 0]:
-                BlenderMaterial.create(gltf, mat_idx, None)
-                # Force material users (fake user)
-                bpy.data.materials[gltf.data.materials[mat_idx].blender_material[None]].use_fake_user = True
+            BlenderGlTF.pre_compute(gltf)
+            wm.progress_update(15)
 
-            # If needed, create not used images
-            for img_idx in [i for i in range(len(gltf.data.images)) if gltf.data.images[i].blender_image_name is None]:
-                BlenderImage.create(gltf, img_idx)
-                # Force image users (fake user)
-                bpy.data.images[gltf.data.images[img_idx].blender_image_name].use_fake_user = True
+            BlenderScene.create(gltf, wm)
+            wm.progress_update(90)
+
+            # If needed, create not used materials
+            if gltf.import_settings['import_unused_materials']:
+                for mat_idx in [i for i in range(len(gltf.data.materials)) if len(
+                        gltf.data.materials[i].blender_material) == 0]:
+                    BlenderMaterial.create(gltf, mat_idx, None)
+                    # Force material users (fake user)
+                    bpy.data.materials[gltf.data.materials[mat_idx].blender_material[None]].use_fake_user = True
+
+                # If needed, create not used images
+                for img_idx in [i for i in range(len(gltf.data.images)) if gltf.data.images[i].blender_image_name is None]:
+                    BlenderImage.create(gltf, img_idx)
+                    # Force image users (fake user)
+                    bpy.data.images[gltf.data.images[img_idx].blender_image_name].use_fake_user = True
+
+            wm.progress_update(100)
+        finally:
+            wm.progress_end()
 
     @staticmethod
     def set_convert_functions(gltf):

--- a/addons/io_scene_gltf2/blender/imp/scene.py
+++ b/addons/io_scene_gltf2/blender/imp/scene.py
@@ -27,7 +27,7 @@ class BlenderScene():
         raise RuntimeError("%s should not be instantiated" % cls)
 
     @staticmethod
-    def create(gltf):
+    def create(gltf, wm=None):
         """Scene creation."""
         scene = bpy.context.scene
         gltf.blender_scene = scene.name
@@ -44,9 +44,13 @@ class BlenderScene():
                 set_extras(scene, pyscene.extras)
 
         compute_vnodes(gltf)
+        if wm is not None:
+            wm.progress_update(20)
 
         gltf.display_current_node = 0  # for debugging
         BlenderNode.create_vnode(gltf, 'root')
+        if wm is not None:
+            wm.progress_update(75)
 
         # User extensions before scene creation
         gltf_scene = None
@@ -55,6 +59,8 @@ class BlenderScene():
         import_user_extensions('gather_import_scene_after_nodes_hook', gltf, gltf_scene, scene)
 
         BlenderScene.create_animations(gltf)
+        if wm is not None:
+            wm.progress_update(88)
 
         # User extensions after scene creation
         gltf_scene = None


### PR DESCRIPTION
Show progress during long-running glTF import and export operations using Blender's cursor-based progress indicator (`bpy.context.window_manager.progress_begin/update/end`), which animates the user's cursor to signal activity.

**Exporter** (`export.py`):
- `progress_begin/end` wraps the full `save()` pipeline in a `try/finally`
- Updates at key stages: pre-export callbacks, gather, buffer/image finalize, extension fixup, file write
- `__export()` signature updated to accept `wm` for mid-function updates

**Importer** (`blender_gltf.py`, `scene.py`):
- `progress_begin/end` wraps `_create()` in a `try/finally`
- `BlenderScene.create()` accepts an optional `wm=None` parameter so import flow can update at the three main sub-stages: `compute_vnodes`, `create_vnode` (object/mesh/material creation), and `create_animations`
- Default `wm=None` keeps the signature backward-compatible for any external callers