### PR TITLE
Fix #2492: normalize image path before existence check

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/image.py
+++ b/addons/io_scene_gltf2/blender/exp/material/image.py
@@ -92,7 +92,12 @@ def gather_image(
 
 
 def __gather_original_uri(original_uri, library, export_settings):
-    path_to_image = bpy.path.abspath(original_uri, library=library)
+    # Issue #2492: bpy.path.abspath() can return an absolute path that still
+    # contains relative segments (e.g. '..' through a non-existent directory),
+    # which makes the os.path.exists() check below fail and silently drops the
+    # texture from the export. normpath() collapses those segments without
+    # resolving symlinks, keeping the relpath() against gltf_filedirectory stable.
+    path_to_image = os.path.normpath(bpy.path.abspath(original_uri, library=library))
 
     if not os.path.exists(path_to_image):
         return None


### PR DESCRIPTION
Fixes #2492.

## Bug
With **Keep original textures** enabled, a texture whose resolved path contains relative segments (a `..` passing through a directory that doesn't exist) — or that is long because of such redundant segments — is silently dropped from the export.

## Root cause
In `__gather_original_uri` (`addons/io_scene_gltf2/blender/exp/material/image.py`), `bpy.path.abspath()` can return an absolute path that still contains `..` segments. `os.path.exists()` then fails on that path (an intermediate component can't be traversed), so the function returns `None` and the image is excluded from the export.

## Fix
Normalize the path with `os.path.normpath()` before the existence check:

```python
path_to_image = os.path.normpath(bpy.path.abspath(original_uri, library=library))
```

`normpath()` collapses the redundant `..` / separator segments, which both resolves the failed `exists()` check and shortens the over-long paths described in the thread. I used `normpath` rather than the `os.path.realpath` mentioned in the issue because it fixes the same cases **without** resolving symlinks — that keeps the subsequent `os.path.relpath(..., start=export_settings['gltf_filedirectory'])` predictable for users whose asset folders are symlinked. Happy to switch to `realpath` if you'd prefer.

## Verification
Repro: a texture referenced via `//ghost/../real.png` (where `ghost/` does not exist), exported as glTF-Separate with *Keep original textures* enabled.

- **Before:** export produced `"images": []` — the texture was lost.
- **After:** the texture is exported correctly with `"uri": "../real.png"`.

A standalone repro script (builds the scene, exports, and asserts the image survives) is available — glad to attach it or adapt it into a roundtrip fixture if that's preferred.
