### PR TITLE
Fix #2691: keep image name suffixes like ".001" on export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/image.py
+++ b/addons/io_scene_gltf2/blender/exp/material/image.py
@@ -205,6 +205,11 @@ def __gather_name(export_image, use_tile, export_settings):
         names = []
         for img in imgs:
             name, extension = os.path.splitext(img.name)
+            # img.name is a datablock name, not a filename, so only strip a
+            # genuine image extension. Otherwise names like "Image.001" lose
+            # their suffix and collide with "Image" (#2691).
+            if extension.lower() not in ['.png', '.jpg', '.jpeg', '.webp']:
+                name = img.name
             names.append(name)
         name = '-'.join(names)
         return name or 'Image'


### PR DESCRIPTION
Fixes #2691.

### Problem
On export, image datablock names containing a `.` (Blender's own duplicate suffix, e.g. `Image.001`, `Image.Other.001`) lose everything after the last dot. Distinct images then collapse to the same glTF image `name` (`Image`, `Image`), which is ambiguous and, as reported, scrambles image names on re-import.

### Cause
In `exp/material/image.py`, `__gather_name` runs `os.path.splitext(img.name)` when combining names:

```python
for img in imgs:
    name, extension = os.path.splitext(img.name)   # "Image.001" -> "Image"
    names.append(name)
```

`img.name` is a **datablock** name, not a filename, so `splitext` wrongly treats `.001` / `.Other.001` as a file extension. (The shared-filepath branch a few lines above is already correct — it only strips a whitelisted real image extension.)

### Fix
Apply that same whitelist guard to the datablock-name loop: only strip a genuine image extension (`.png` / `.jpg` / `.jpeg` / `.webp`); otherwise keep the full name. This follows the guidance on the issue — "when possible, we need to do our best to export correctly the name, avoiding ambiguity."

### Verification
Three images named `Image`, `Image.001`, `Image.Other.001`, each on its own plane, exported to GLB (Blender 5.x):

| | `images[].name` in the GLB |
|---|---|
| before | `["Image", "Image", "Image.Other"]` (collision) |
| after  | `["Image", "Image.001", "Image.Other.001"]` |

Genuine file extensions are still stripped (`wood.png` → `wood`), and dotted names that are not extensions are preserved (`v1.5_diffuse` stays intact).
