### PR TITLE
Fix #2592: avoid export recursion when an ancestor is bone-parented to the skinning armature

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/nodes.py
@@ -551,13 +551,17 @@ def gather_skin(vnode, export_settings):
         return None
 
     # Prevent infinite recursive error. A data can't have an Armature modifier
-    # and be bone parented to a bone of this armature
+    # and be bone parented to a bone of this armature, directly or through an
+    # ancestor. Otherwise the skin's joint becomes an ancestor of this node in
+    # the exported hierarchy, forming a cycle (skin -> joint -> ... -> node).
     # In that case, ignore the armature modifier, keep only the bone parenting
-    if blender_object.parent is not None \
-            and blender_object.parent_type == 'BONE' \
-            and blender_object.parent.name == modifiers["ARMATURE"].object.name:
-
-        return None
+    ancestor = blender_object
+    while ancestor is not None:
+        if ancestor.parent is not None \
+                and ancestor.parent_type == 'BONE' \
+                and ancestor.parent.name == modifiers["ARMATURE"].object.name:
+            return None
+        ancestor = ancestor.parent
 
     # glTF Skins and mesh must be in the same glTF node, which is different from how blender handles armatures
     return gltf2_blender_gather_skins.gather_skin(export_settings['vtree'].nodes[vnode].armature, export_settings)


### PR DESCRIPTION
Fixes #2592.

### Problem
Exporting a scene where a **skinned** mesh has an **ancestor** that is bone-parented to the same armature raises `RecursionError`, and the export fails.

Minimal repro: `Armature` (bone `Bone`) → `Empty` bone-parented to `Bone` → `Cube` object-parented to the `Empty`, with a vertex group `Bone` + an Armature modifier targeting `Armature`. Exporting to glTF raises `RecursionError: maximum recursion depth exceeded`.

### Cause
`gather_skin` (`exp/nodes.py`) already guards the *direct* case: a mesh bone-parented to a bone of its own skinning armature would make the skin's joint an ancestor of the mesh node, forming a cycle, so the skin is dropped. But the guard only checked `blender_object.parent`. When the bone-parented node is an **ancestor** (the `Empty`) rather than the mesh itself, the guard misses it, the skin is created, and the exported node graph contains a cycle:

```
Cube.skin -> joint (Bone) -> Bone.children = [Empty] -> Empty.children = [Cube] -> Cube.skin -> ...
```

The exporter's node traversal follows `.skin` and `.children`, so it recurses until `RecursionError`.

### Fix
Walk the whole ancestor chain instead of only the direct parent; if any ancestor is bone-parented to the skinning armature, drop the skin (and keep the bone parenting) — identical behavior to the existing guard, just generalized past the direct parent.

### Verification
Headless Blender 5.1.1 (the reported version), `export_format='GLTF_SEPARATE'`:

| scene | before | after |
|---|---|---|
| repro (skinned mesh, bone-parented **ancestor**) | `RecursionError`, no file written | `FINISHED` · `skins: []` · Cube node has `mesh`, no `skin` |
| control (normal skinning, mesh parented to the armature) | `skins` length 1, Cube skinned | `skins` length 1, Cube skinned (unchanged) |

So the cycle is broken (skin dropped, mesh + bone parenting preserved) and normal skinning is unaffected.

Two points for your call: I kept the existing name-based armature comparison for a minimal diff — happy to switch it to identity (`ancestor.parent == modifiers["ARMATURE"].object`) to harden against same-named linked/duplicated armatures if you'd prefer. I can also add a `tests/` fixture for this topology if that's useful.
