### PR TITLE
fix: preserve custom properties when boolean modifier is applied during export

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/nodes.py
+++ b/addons/io_scene_gltf2/blender/exp/nodes.py
@@ -323,18 +323,23 @@ def __gather_mesh(vnode, blender_object, export_settings):
                 depsgraph = bpy.context.evaluated_depsgraph_get()
                 blender_data_owner = blender_object.evaluated_get(depsgraph)
                 blender_data = blender_data_owner.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
-                # Seems now (from 4.2) the custom properties are Statically Typed
-                # so no need to copy them in that case, because overwriting them will crash
-                if len(blender_data.keys()) == 0:
-                    # Copy custom properties
-                    for prop in [p for p in blender_object.data.keys() if (
-                            (p not in BLACK_LIST) or p.startswith("gltf"))]:
+                # Copy non-blacklisted custom properties from original to evaluated mesh.
+                # From 4.2 some properties are Statically Typed and overwriting them
+                # would crash, so we use try/except to skip those gracefully.
+                for prop in [p for p in blender_object.data.keys() if (
+                        (p not in BLACK_LIST) or p.startswith("gltf"))]:
+                    try:
                         blender_data[prop] = blender_object.data[prop]
-                else:
-                    # But we need to remove some properties that are not needed
-                    for prop in [p for p in blender_object.data.keys() if (
-                            p in BLACK_LIST and not p.startswith("gltf"))]:
+                    except Exception:
+                        pass
+                # Remove blacklisted properties that may have been carried over
+                # by the modifier evaluation pipeline
+                for prop in [p for p in blender_data.keys() if (
+                        p in BLACK_LIST and not p.startswith("gltf"))]:
+                    try:
                         del blender_data[prop]
+                    except Exception:
+                        pass
                 # Store the fact that this evaluated data has been created by the
                 # exporter, and is not a GN instance data
                 blender_data['gltf2_mesh_applied'] = True


### PR DESCRIPTION
When "Apply Modifiers" is enabled and a Boolean modifier is active on an object, the `to_mesh()` call creates a new evaluated mesh datablock. If that evaluated mesh has any auto-generated properties (e.g. from the modifier evaluation pipeline), `blender_data.keys()` becomes non-empty, and the old code would skip copying custom properties from the original mesh — only removing blacklisted ones. This silently drops Python-registered custom properties on Mesh datablocks.

**Root cause:** The `if len(blender_data.keys()) == 0` condition guarded the custom property copy. Any property present on the evaluated mesh (even irrelevant ones) flipped the behavior to delete-only.

**Fix:** Unconditionally copy non-blacklisted custom properties from the original mesh data to the evaluated mesh, using try/except to gracefully skip Blender 4.2+ statically-typed properties that cannot be overwritten. Blacklisted properties introduced by the modifier evaluation are still cleaned up.

**How to test:**
1. Open Blender, create a Cube
2. Run a script that registers a BoolProperty on `bpy.types.Mesh` (e.g. `bpy.types.Mesh.testProp = bpy.props.BoolProperty(name="Test")`)
3. Set the property to True
4. Add a Boolean modifier to the Cube and enable it in viewport
5. Export to glTF with "Apply Modifiers" and "Include Custom Properties" both checked
6. Verify the custom property appears in the glTF `extras`
7. Toggle the modifier off and re-export — property should still be present

Fixes #2700