### PR TITLE
Fix #2579: keep blender_idxs in sync with dots_edges dedup

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/primitive_extract.py
+++ b/addons/io_scene_gltf2/blender/exp/primitive_extract.py
@@ -1005,9 +1005,17 @@ class PrimitiveCreator:
 
             if self.blender_idxs_edges.shape[0] > 0:
                 # Export one glTF vert per unique Blender vert in a loose edge
-                self.blender_idxs = self.blender_idxs_edges
-                dots_edges, indices = fast_structured_np_unique(self.dots_edges, return_inverse=True)
-                self.blender_idxs = np.unique(self.blender_idxs_edges)
+                # Issue #2579: self.blender_idxs must come from the SAME dedup as
+                # self.dots_edges, matching primitive_creation_shared/_not_shared below.
+                # It previously came from an independent np.unique(blender_idxs_edges),
+                # which sorts by raw vertex index rather than by the structured dots_edges
+                # bytes, so its row order didn't match dots_edges/indices. POSITION is
+                # built from self.locs[self.blender_idxs] while other attributes are read
+                # straight off dots_edges, so the mismatch paired each vertex's position
+                # with another vertex's attribute value (e.g. a custom float attribute).
+                self.dots_edges, indices = fast_structured_np_unique(self.dots_edges, return_inverse=True)
+                dots_edges = self.dots_edges
+                self.blender_idxs = self.dots_edges['vertex_index']
 
                 self.attributes_edges_points = {}
 


### PR DESCRIPTION
## Problem

Exporting a custom float attribute on loose edges could produce mangled geometry: each exported vertex's position and its attribute value could end up belonging to two different original Blender vertices.

@julienduroure traced the first-order cause to `fast_structured_np_unique` vs `np.unique` behaving differently. @Mysteryem dug further and found the actual mismatch: in `primitive_creation_edges_and_points`, `self.blender_idxs` was computed via a standalone `np.unique(self.blender_idxs_edges)` call, independent of the `fast_structured_np_unique(self.dots_edges, ...)` dedup used for the attribute data itself, unlike the matching pattern in `primitive_creation_shared`/`primitive_creation_not_shared`.

Since `__set_positions_attribute` builds `POSITION` from `self.locs[self.blender_idxs]`, while other attributes are read straight off `dots_edges`, the two independently-sorted arrays don't share row order, so position and attribute data get paired up incorrectly.

## Solution

Derive `self.blender_idxs` from the same deduplicated `self.dots_edges` used for the attribute data, matching the existing pattern in the two sibling functions, per @Mysteryem's proposed fix in the issue thread.

## Verification

- Isolated test against the real `fast_structured_np_unique`: 11/12 row mismatches with the old logic, 0/12 after the fix.
- Full export against the reporter's attached repro file on Blender 5.1.1: exports cleanly, exact expected vertex count (835/835), both `POSITION` and the custom attribute present and correctly paired.

Closes #2579