### PR TITLE
Fix #2732 - pass the original material to hook

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/material/materials.py
+++ b/addons/io_scene_gltf2/blender/exp/material/materials.py
@@ -796,6 +796,8 @@ def __export_unlit(bmat, export_settings):
     if export_settings['gltf_extras'] and export_settings['gltf_export_anim_pointer']:
         export_settings['KHR_animation_pointer']['extras']['materials'][bmat.id]['glTF_extras'] = material
 
+    # Make sure to expose bmat.material (the original material), so users can retrieve additional proporties
+    # (These properties are not available on the inline material)
     export_user_extensions('gather_material_unlit_hook', export_settings, material, bmat.material)
 
     # Now we have exported the material itself, we need to store some additional data

--- a/addons/io_scene_gltf2/blender/exp/material/materials.py
+++ b/addons/io_scene_gltf2/blender/exp/material/materials.py
@@ -331,7 +331,9 @@ def gather_material(bmat, export_settings):
 
     mat_unlit, uvmap_info, vc_info, udim_info = __export_unlit(bmat, export_settings)
     if mat_unlit is not None:
-        export_user_extensions('gather_material_hook', export_settings, mat_unlit, bmat)
+        # Make sure to expose bmat.material (the original material), so users can retrieve additional proporties
+        # (These properties are not available on the inline material)
+        export_user_extensions('gather_material_hook', export_settings, mat_unlit, bmat.material)
         return mat_unlit, {"uv_info": uvmap_info, "vc_info": vc_info, "udim_info": udim_info}
 
     orm_texture = __gather_orm_texture(bmat, export_settings)
@@ -420,7 +422,9 @@ def gather_material(bmat, export_settings):
     if material.emissive_factor is not None and bmat.get_socket("Base Color").socket is None:
         material.pbr_metallic_roughness = gltf2_pbr_metallic_roughness.get_default_pbr_for_emissive_node()
 
-    export_user_extensions('gather_material_hook', export_settings, material, bmat.get_used_material())
+    # Make sure to expose bmat.material (the original material), so users can retrieve additional proporties
+    # (These properties are not available on the inline material)
+    export_user_extensions('gather_material_hook', export_settings, material, bmat.material)
 
     # Now we have exported the material itself, we need to store some additional data
     # This will be used when trying to export some KHR_animation_pointer

--- a/addons/io_scene_gltf2/blender/exp/material/materials.py
+++ b/addons/io_scene_gltf2/blender/exp/material/materials.py
@@ -796,7 +796,7 @@ def __export_unlit(bmat, export_settings):
     if export_settings['gltf_extras'] and export_settings['gltf_export_anim_pointer']:
         export_settings['KHR_animation_pointer']['extras']['materials'][bmat.id]['glTF_extras'] = material
 
-    export_user_extensions('gather_material_unlit_hook', export_settings, material, bmat.get_used_material())
+    export_user_extensions('gather_material_unlit_hook', export_settings, material, bmat.material)
 
     # Now we have exported the material itself, we need to store some additional data
     # This will be used when trying to export some KHR_animation_pointer


### PR DESCRIPTION
Make sure to not expose the inline material, as material properties are not exposed